### PR TITLE
feat(db): initial Drizzle schema + Neon client + first migration

### DIFF
--- a/drizzle/0000_initial_schema.sql
+++ b/drizzle/0000_initial_schema.sql
@@ -1,0 +1,186 @@
+-- 必須拡張。gen_random_uuid() と gin_trgm_ops のために先頭で一度だけ有効化する
+CREATE EXTENSION IF NOT EXISTS pgcrypto;--> statement-breakpoint
+CREATE EXTENSION IF NOT EXISTS pg_trgm;--> statement-breakpoint
+CREATE TABLE "attempts" (
+	"id" text PRIMARY KEY DEFAULT gen_random_uuid()::text NOT NULL,
+	"user_id" text NOT NULL,
+	"session_id" text NOT NULL,
+	"question_id" text NOT NULL,
+	"concept_id" text NOT NULL,
+	"user_answer" text,
+	"correct" boolean,
+	"score" real,
+	"self_rating" smallint,
+	"elapsed_ms" integer,
+	"feedback" text,
+	"rubric_checks" jsonb,
+	"misconception_tags" jsonb,
+	"reason_given" text,
+	"copied_for_external" integer DEFAULT 0 NOT NULL,
+	"search_tsv" "tsvector" GENERATED ALWAYS AS (to_tsvector('simple', coalesce(user_answer, '') || ' ' || coalesce(reason_given, '') || ' ' || coalesce(feedback, ''))) STORED,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "concepts" (
+	"id" text PRIMARY KEY NOT NULL,
+	"domain_id" text NOT NULL,
+	"subdomain_id" text,
+	"name" text NOT NULL,
+	"description" text,
+	"prereqs" jsonb DEFAULT '[]'::jsonb,
+	"tags" jsonb DEFAULT '[]'::jsonb,
+	"difficulty_levels" jsonb DEFAULT '[]'::jsonb,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "credentials" (
+	"id" text PRIMARY KEY NOT NULL,
+	"user_id" text NOT NULL,
+	"public_key" "bytea" NOT NULL,
+	"counter" bigint DEFAULT 0 NOT NULL,
+	"device_type" text,
+	"backed_up" boolean DEFAULT false NOT NULL,
+	"transports" jsonb DEFAULT '[]'::jsonb,
+	"nickname" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"last_used_at" timestamp with time zone
+);
+--> statement-breakpoint
+CREATE TABLE "daily_stats" (
+	"user_id" text NOT NULL,
+	"date" date NOT NULL,
+	"attempts_count" integer DEFAULT 0 NOT NULL,
+	"correct_count" integer DEFAULT 0 NOT NULL,
+	"concepts_touched" integer DEFAULT 0 NOT NULL,
+	"study_time_sec" integer DEFAULT 0 NOT NULL,
+	"domains_touched" jsonb DEFAULT '[]'::jsonb,
+	CONSTRAINT "daily_stats_user_id_date_pk" PRIMARY KEY("user_id","date")
+);
+--> statement-breakpoint
+CREATE TABLE "users" (
+	"id" text PRIMARY KEY DEFAULT gen_random_uuid()::text NOT NULL,
+	"email" text NOT NULL,
+	"display_name" text,
+	"timezone" text DEFAULT 'Asia/Tokyo',
+	"daily_goal" integer DEFAULT 15 NOT NULL,
+	"notification_time" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "users_email_unique" UNIQUE("email")
+);
+--> statement-breakpoint
+CREATE TABLE "sessions_auth" (
+	"id" text PRIMARY KEY NOT NULL,
+	"user_id" text NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"expires_at" timestamp with time zone NOT NULL,
+	"last_active_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "webauthn_challenges" (
+	"id" text PRIMARY KEY NOT NULL,
+	"user_id" text,
+	"challenge" text NOT NULL,
+	"purpose" text NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"expires_at" timestamp with time zone NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "questions" (
+	"id" text PRIMARY KEY DEFAULT gen_random_uuid()::text NOT NULL,
+	"concept_id" text NOT NULL,
+	"type" text NOT NULL,
+	"thinking_style" text,
+	"difficulty" text NOT NULL,
+	"prompt" text NOT NULL,
+	"answer" text NOT NULL,
+	"rubric" jsonb,
+	"distractors" jsonb,
+	"hint" text,
+	"explanation" text,
+	"tags" jsonb DEFAULT '[]'::jsonb,
+	"generated_by" text,
+	"prompt_version" text,
+	"retired" boolean DEFAULT false NOT NULL,
+	"retired_reason" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"last_served_at" timestamp with time zone,
+	"serve_count" integer DEFAULT 0 NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "session_templates" (
+	"id" text PRIMARY KEY DEFAULT gen_random_uuid()::text NOT NULL,
+	"user_id" text NOT NULL,
+	"name" text NOT NULL,
+	"raw_request" text,
+	"spec" jsonb NOT NULL,
+	"use_count" integer DEFAULT 0 NOT NULL,
+	"last_used_at" timestamp with time zone,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "sessions" (
+	"id" text PRIMARY KEY DEFAULT gen_random_uuid()::text NOT NULL,
+	"user_id" text NOT NULL,
+	"kind" text NOT NULL,
+	"spec" jsonb,
+	"template_id" text,
+	"started_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"finished_at" timestamp with time zone,
+	"question_count" integer DEFAULT 0 NOT NULL,
+	"correct_count" integer DEFAULT 0 NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "mastery" (
+	"user_id" text NOT NULL,
+	"concept_id" text NOT NULL,
+	"stability" real,
+	"difficulty" real,
+	"last_review" timestamp with time zone,
+	"next_review" timestamp with time zone,
+	"review_count" integer DEFAULT 0 NOT NULL,
+	"lapse_count" integer DEFAULT 0 NOT NULL,
+	"mastered" boolean DEFAULT false NOT NULL,
+	"mastery_pct" real DEFAULT 0 NOT NULL,
+	CONSTRAINT "mastery_user_id_concept_id_pk" PRIMARY KEY("user_id","concept_id")
+);
+--> statement-breakpoint
+CREATE TABLE "misconceptions" (
+	"id" text PRIMARY KEY DEFAULT gen_random_uuid()::text NOT NULL,
+	"user_id" text NOT NULL,
+	"concept_id" text NOT NULL,
+	"description" text NOT NULL,
+	"first_seen" timestamp with time zone DEFAULT now() NOT NULL,
+	"last_seen" timestamp with time zone DEFAULT now() NOT NULL,
+	"count" integer DEFAULT 1 NOT NULL,
+	"resolved" boolean DEFAULT false NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "attempts" ADD CONSTRAINT "attempts_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "attempts" ADD CONSTRAINT "attempts_session_id_sessions_id_fk" FOREIGN KEY ("session_id") REFERENCES "public"."sessions"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "attempts" ADD CONSTRAINT "attempts_question_id_questions_id_fk" FOREIGN KEY ("question_id") REFERENCES "public"."questions"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "attempts" ADD CONSTRAINT "attempts_concept_id_concepts_id_fk" FOREIGN KEY ("concept_id") REFERENCES "public"."concepts"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "credentials" ADD CONSTRAINT "credentials_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "daily_stats" ADD CONSTRAINT "daily_stats_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "sessions_auth" ADD CONSTRAINT "sessions_auth_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "webauthn_challenges" ADD CONSTRAINT "webauthn_challenges_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "questions" ADD CONSTRAINT "questions_concept_id_concepts_id_fk" FOREIGN KEY ("concept_id") REFERENCES "public"."concepts"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "session_templates" ADD CONSTRAINT "session_templates_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "sessions" ADD CONSTRAINT "sessions_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "sessions" ADD CONSTRAINT "sessions_template_id_session_templates_id_fk" FOREIGN KEY ("template_id") REFERENCES "public"."session_templates"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "mastery" ADD CONSTRAINT "mastery_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "mastery" ADD CONSTRAINT "mastery_concept_id_concepts_id_fk" FOREIGN KEY ("concept_id") REFERENCES "public"."concepts"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "misconceptions" ADD CONSTRAINT "misconceptions_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "misconceptions" ADD CONSTRAINT "misconceptions_concept_id_concepts_id_fk" FOREIGN KEY ("concept_id") REFERENCES "public"."concepts"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "idx_attempts_user_concept" ON "attempts" USING btree ("user_id","concept_id");--> statement-breakpoint
+CREATE INDEX "idx_attempts_user_created" ON "attempts" USING btree ("user_id","created_at" DESC NULLS LAST);--> statement-breakpoint
+CREATE INDEX "idx_attempts_search" ON "attempts" USING gin ("search_tsv");--> statement-breakpoint
+CREATE INDEX "idx_attempts_trgm" ON "attempts" USING gin ("user_answer" gin_trgm_ops);--> statement-breakpoint
+CREATE INDEX "idx_concepts_domain" ON "concepts" USING btree ("domain_id");--> statement-breakpoint
+CREATE INDEX "idx_concepts_tags" ON "concepts" USING gin ("tags");--> statement-breakpoint
+CREATE INDEX "idx_credentials_user" ON "credentials" USING btree ("user_id");--> statement-breakpoint
+CREATE INDEX "idx_sessions_auth_user" ON "sessions_auth" USING btree ("user_id");--> statement-breakpoint
+CREATE INDEX "idx_sessions_auth_expires" ON "sessions_auth" USING btree ("expires_at");--> statement-breakpoint
+CREATE INDEX "idx_questions_concept_type_style" ON "questions" USING btree ("concept_id","type","thinking_style","difficulty") WHERE "questions"."retired" = FALSE;--> statement-breakpoint
+CREATE INDEX "idx_sessions_user_started" ON "sessions" USING btree ("user_id","started_at" DESC NULLS LAST);--> statement-breakpoint
+CREATE INDEX "idx_mastery_next_review" ON "mastery" USING btree ("user_id","next_review");

--- a/src/db/client.ts
+++ b/src/db/client.ts
@@ -1,0 +1,26 @@
+import { neon, neonConfig } from "@neondatabase/serverless";
+import { drizzle } from "drizzle-orm/neon-http";
+
+import { env } from "@/lib/env";
+
+import * as schema from "./schema";
+
+neonConfig.fetchConnectionCache = true;
+
+let cached: ReturnType<typeof createDb> | undefined;
+
+function createDb() {
+  const sql = neon(env.databaseUrl());
+  return drizzle(sql, { schema, casing: "snake_case", logger: false });
+}
+
+/**
+ * Drizzle クライアント。シングルトン (serverless で最適化).
+ */
+export function getDb() {
+  cached ??= createDb();
+  return cached;
+}
+
+export type Db = ReturnType<typeof createDb>;
+export { schema };

--- a/src/db/schema.test.ts
+++ b/src/db/schema.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expectTypeOf } from "vitest";
+
+import {
+  type Attempt,
+  type Concept,
+  type Credential,
+  type DailyStat,
+  type Mastery,
+  type Misconception,
+  type NewUser,
+  type Question,
+  type Session,
+  type SessionAuth,
+  type SessionTemplate,
+  type User,
+  type WebauthnChallenge,
+  DIFFICULTY_LEVELS,
+  DOMAIN_IDS,
+  QUESTION_TYPES,
+  SESSION_KINDS,
+  THINKING_STYLES,
+  WEBAUTHN_CHALLENGE_PURPOSES,
+  concepts,
+  credentials,
+  sessions,
+  users,
+} from "./schema";
+
+describe("db/schema", () => {
+  it("users 型は id/email/displayName を持ち、createdAt は Date", () => {
+    expectTypeOf<User["id"]>().toEqualTypeOf<string>();
+    expectTypeOf<User["email"]>().toEqualTypeOf<string>();
+    expectTypeOf<User["displayName"]>().toEqualTypeOf<string | null>();
+    expectTypeOf<User["createdAt"]>().toEqualTypeOf<Date>();
+  });
+
+  it("NewUser では id/createdAt など default 付きカラムは optional", () => {
+    expectTypeOf<NewUser>().toMatchTypeOf<{ email: string }>();
+    // デフォルト値があるので insert 時に省略可能
+    expectTypeOf<NewUser["id"]>().toEqualTypeOf<string | undefined>();
+    expectTypeOf<NewUser["createdAt"]>().toEqualTypeOf<Date | undefined>();
+  });
+
+  it("concepts は DomainId でドメインを限定", () => {
+    expectTypeOf<Concept["domainId"]>().toEqualTypeOf<(typeof DOMAIN_IDS)[number]>();
+    expectTypeOf<Concept["difficultyLevels"]>().toEqualTypeOf<
+      (typeof DIFFICULTY_LEVELS)[number][] | null
+    >();
+    expectTypeOf<Concept["prereqs"]>().toEqualTypeOf<string[] | null>();
+  });
+
+  it("questions は type/difficulty/thinkingStyle の列挙が効いている", () => {
+    expectTypeOf<Question["type"]>().toEqualTypeOf<(typeof QUESTION_TYPES)[number]>();
+    expectTypeOf<Question["difficulty"]>().toEqualTypeOf<(typeof DIFFICULTY_LEVELS)[number]>();
+    expectTypeOf<Question["thinkingStyle"]>().toEqualTypeOf<
+      (typeof THINKING_STYLES)[number] | null
+    >();
+  });
+
+  it("sessions.kind は SESSION_KINDS に制限される", () => {
+    expectTypeOf<Session["kind"]>().toEqualTypeOf<(typeof SESSION_KINDS)[number]>();
+  });
+
+  it("attempts は score(real) / selfRating(smallint) / elapsedMs(int) を持つ", () => {
+    expectTypeOf<Attempt["score"]>().toEqualTypeOf<number | null>();
+    expectTypeOf<Attempt["selfRating"]>().toEqualTypeOf<number | null>();
+    expectTypeOf<Attempt["elapsedMs"]>().toEqualTypeOf<number | null>();
+    expectTypeOf<Attempt["correct"]>().toEqualTypeOf<boolean | null>();
+  });
+
+  it("mastery は複合 PK を持つ (userId + conceptId)", () => {
+    expectTypeOf<Mastery["userId"]>().toEqualTypeOf<string>();
+    expectTypeOf<Mastery["conceptId"]>().toEqualTypeOf<string>();
+    expectTypeOf<Mastery["masteryPct"]>().toEqualTypeOf<number>();
+    expectTypeOf<Mastery["mastered"]>().toEqualTypeOf<boolean>();
+  });
+
+  it("credentials の counter は bigint", () => {
+    expectTypeOf<Credential["counter"]>().toEqualTypeOf<bigint>();
+    expectTypeOf<Credential["publicKey"]>().toEqualTypeOf<Uint8Array>();
+  });
+
+  it("sessionsAuth/webauthnChallenges/dailyStats/misconceptions/sessionTemplates の基本型", () => {
+    expectTypeOf<SessionAuth["expiresAt"]>().toEqualTypeOf<Date>();
+    expectTypeOf<WebauthnChallenge["purpose"]>().toEqualTypeOf<
+      (typeof WEBAUTHN_CHALLENGE_PURPOSES)[number]
+    >();
+    expectTypeOf<DailyStat["attemptsCount"]>().toEqualTypeOf<number>();
+    expectTypeOf<Misconception["resolved"]>().toEqualTypeOf<boolean>();
+    expectTypeOf<SessionTemplate["useCount"]>().toEqualTypeOf<number>();
+  });
+
+  it("外部キーが PgTable として認識できる (関係の土台)", () => {
+    // これらが export されていれば「テーブルとして存在する」のテストになる
+    expectTypeOf(users).not.toBeAny();
+    expectTypeOf(concepts).not.toBeAny();
+    expectTypeOf(sessions).not.toBeAny();
+    expectTypeOf(credentials).not.toBeAny();
+  });
+});

--- a/src/db/schema/_constants.ts
+++ b/src/db/schema/_constants.ts
@@ -1,0 +1,54 @@
+/**
+ * 13 ドメインのマスタは YAML (`src/db/seed/concepts.yaml`) が正。
+ * ここでは TypeScript 側で型を締めるための列挙だけを定義する。
+ * docs/06-architecture.md §6.2.2 に準拠。
+ */
+export const DOMAIN_IDS = [
+  "programming",
+  "typesystem",
+  "algorithm",
+  "data_structure",
+  "database",
+  "network",
+  "os_runtime",
+  "distributed",
+  "security",
+  "web",
+  "architecture",
+  "testing",
+  "devops",
+] as const;
+export type DomainId = (typeof DOMAIN_IDS)[number];
+
+/** ADR-0001 で統一された 6 段階 */
+export const DIFFICULTY_LEVELS = [
+  "beginner",
+  "junior",
+  "mid",
+  "senior",
+  "staff",
+  "principal",
+] as const;
+export type DifficultyLevel = (typeof DIFFICULTY_LEVELS)[number];
+
+export const SESSION_KINDS = ["daily", "deep", "custom", "review"] as const;
+export type SessionKind = (typeof SESSION_KINDS)[number];
+
+export const QUESTION_TYPES = ["mcq", "short", "written", "cloze", "code_read", "design"] as const;
+export type QuestionType = (typeof QUESTION_TYPES)[number];
+
+export const THINKING_STYLES = [
+  "why",
+  "how",
+  "trade_off",
+  "edge_case",
+  "compare",
+  "apply",
+] as const;
+export type ThinkingStyle = (typeof THINKING_STYLES)[number];
+
+export const WEBAUTHN_CHALLENGE_PURPOSES = ["register", "authenticate"] as const;
+export type WebauthnChallengePurpose = (typeof WEBAUTHN_CHALLENGE_PURPOSES)[number];
+
+export const CREDENTIAL_DEVICE_TYPES = ["singleDevice", "multiDevice"] as const;
+export type CredentialDeviceType = (typeof CREDENTIAL_DEVICE_TYPES)[number];

--- a/src/db/schema/attempts.ts
+++ b/src/db/schema/attempts.ts
@@ -1,0 +1,90 @@
+import { sql } from "drizzle-orm";
+import {
+  boolean,
+  customType,
+  index,
+  integer,
+  jsonb,
+  pgTable,
+  real,
+  smallint,
+  text,
+  timestamp,
+} from "drizzle-orm/pg-core";
+
+import { concepts } from "./concepts";
+import { questions, type RubricCheck } from "./questions";
+import { sessions } from "./sessions";
+import { users } from "./users";
+
+/** tsvector 型は drizzle に組み込みがないので customType で定義 */
+const tsvector = customType<{ data: string }>({
+  dataType() {
+    return "tsvector";
+  },
+});
+
+export type RubricCheckResult = {
+  id: string;
+  passed: boolean;
+  comment?: string;
+};
+
+export type MisconceptionTag = {
+  conceptId: string;
+  description: string;
+};
+
+export const attempts = pgTable(
+  "attempts",
+  {
+    id: text("id")
+      .primaryKey()
+      .default(sql`gen_random_uuid()::text`),
+    userId: text("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    sessionId: text("session_id")
+      .notNull()
+      .references(() => sessions.id, { onDelete: "cascade" }),
+    questionId: text("question_id")
+      .notNull()
+      .references(() => questions.id),
+    conceptId: text("concept_id")
+      .notNull()
+      .references(() => concepts.id),
+    userAnswer: text("user_answer"),
+    correct: boolean("correct"),
+    /** 0.0 - 1.0 */
+    score: real("score"),
+    /** 自己評価 1-5 */
+    selfRating: smallint("self_rating"),
+    elapsedMs: integer("elapsed_ms"),
+    feedback: text("feedback"),
+    rubricChecks: jsonb("rubric_checks").$type<RubricCheckResult[]>(),
+    misconceptionTags: jsonb("misconception_tags").$type<MisconceptionTag[]>(),
+    reasonGiven: text("reason_given"),
+    copiedForExternal: integer("copied_for_external").notNull().default(0),
+    /**
+     * 全文検索用 tsvector (ADR-0003 / §6.2.2)。
+     * user_answer / reason_given / feedback の連結を 'simple' analyzer で index 化する。
+     * 日本語は語境界が曖昧なため pg_trgm による trigram index (idx_attempts_trgm) を併用。
+     */
+    searchTsv: tsvector("search_tsv").generatedAlwaysAs(
+      sql`to_tsvector('simple', coalesce(user_answer, '') || ' ' || coalesce(reason_given, '') || ' ' || coalesce(feedback, ''))`,
+    ),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    index("idx_attempts_user_concept").on(table.userId, table.conceptId),
+    index("idx_attempts_user_created").on(table.userId, table.createdAt.desc()),
+    index("idx_attempts_search").using("gin", table.searchTsv),
+    index("idx_attempts_trgm").using("gin", sql`${table.userAnswer} gin_trgm_ops`),
+  ],
+);
+
+export type Attempt = typeof attempts.$inferSelect;
+export type NewAttempt = typeof attempts.$inferInsert;
+
+/** rubric と rubric_checks を上位層で使いまわせるよう re-export */
+export type { RubricCheck };

--- a/src/db/schema/concepts.ts
+++ b/src/db/schema/concepts.ts
@@ -1,0 +1,34 @@
+import { sql } from "drizzle-orm";
+import { index, jsonb, pgTable, text, timestamp } from "drizzle-orm/pg-core";
+
+import type { DifficultyLevel, DomainId } from "./_constants";
+
+export const concepts = pgTable(
+  "concepts",
+  {
+    /** 'network.tcp.congestion' のような snake_case ドット区切り */
+    id: text("id").primaryKey(),
+    domainId: text("domain_id").$type<DomainId>().notNull(),
+    subdomainId: text("subdomain_id"),
+    name: text("name").notNull(),
+    description: text("description"),
+    prereqs: jsonb("prereqs")
+      .$type<string[]>()
+      .default(sql`'[]'::jsonb`),
+    tags: jsonb("tags")
+      .$type<string[]>()
+      .default(sql`'[]'::jsonb`),
+    difficultyLevels: jsonb("difficulty_levels")
+      .$type<DifficultyLevel[]>()
+      .default(sql`'[]'::jsonb`),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    index("idx_concepts_domain").on(table.domainId),
+    index("idx_concepts_tags").using("gin", table.tags),
+  ],
+);
+
+export type Concept = typeof concepts.$inferSelect;
+export type NewConcept = typeof concepts.$inferInsert;

--- a/src/db/schema/credentials.ts
+++ b/src/db/schema/credentials.ts
@@ -1,0 +1,55 @@
+import type { AuthenticatorTransportFuture } from "@simplewebauthn/server";
+import { sql } from "drizzle-orm";
+import {
+  bigint,
+  boolean,
+  customType,
+  index,
+  jsonb,
+  pgTable,
+  text,
+  timestamp,
+} from "drizzle-orm/pg-core";
+
+import type { CredentialDeviceType } from "./_constants";
+import { users } from "./users";
+
+const bytea = customType<{ data: Uint8Array; driverData: Buffer }>({
+  dataType() {
+    return "bytea";
+  },
+  toDriver(value: Uint8Array): Buffer {
+    return Buffer.from(value);
+  },
+  fromDriver(value: Buffer): Uint8Array {
+    return new Uint8Array(value);
+  },
+});
+
+export const credentials = pgTable(
+  "credentials",
+  {
+    /** base64url エンコード済み credentialId */
+    id: text("id").primaryKey(),
+    userId: text("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    publicKey: bytea("public_key").notNull(),
+    /** WebAuthn signCount。十分な桁を確保するため bigint */
+    counter: bigint("counter", { mode: "bigint" })
+      .notNull()
+      .default(sql`0`),
+    deviceType: text("device_type").$type<CredentialDeviceType>(),
+    backedUp: boolean("backed_up").notNull().default(false),
+    transports: jsonb("transports")
+      .$type<AuthenticatorTransportFuture[]>()
+      .default(sql`'[]'::jsonb`),
+    nickname: text("nickname"),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    lastUsedAt: timestamp("last_used_at", { withTimezone: true }),
+  },
+  (table) => [index("idx_credentials_user").on(table.userId)],
+);
+
+export type Credential = typeof credentials.$inferSelect;
+export type NewCredential = typeof credentials.$inferInsert;

--- a/src/db/schema/daily-stats.ts
+++ b/src/db/schema/daily-stats.ts
@@ -1,0 +1,26 @@
+import { sql } from "drizzle-orm";
+import { date, integer, jsonb, pgTable, primaryKey, text } from "drizzle-orm/pg-core";
+
+import type { DomainId } from "./_constants";
+import { users } from "./users";
+
+export const dailyStats = pgTable(
+  "daily_stats",
+  {
+    userId: text("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    date: date("date").notNull(),
+    attemptsCount: integer("attempts_count").notNull().default(0),
+    correctCount: integer("correct_count").notNull().default(0),
+    conceptsTouched: integer("concepts_touched").notNull().default(0),
+    studyTimeSec: integer("study_time_sec").notNull().default(0),
+    domainsTouched: jsonb("domains_touched")
+      .$type<DomainId[]>()
+      .default(sql`'[]'::jsonb`),
+  },
+  (table) => [primaryKey({ columns: [table.userId, table.date] })],
+);
+
+export type DailyStat = typeof dailyStats.$inferSelect;
+export type NewDailyStat = typeof dailyStats.$inferInsert;

--- a/src/db/schema/index.ts
+++ b/src/db/schema/index.ts
@@ -1,0 +1,14 @@
+export * from "./_constants";
+
+export * from "./users";
+export * from "./credentials";
+export * from "./sessions-auth";
+export * from "./webauthn-challenges";
+export * from "./concepts";
+export * from "./questions";
+export * from "./session-templates";
+export * from "./sessions";
+export * from "./attempts";
+export * from "./mastery";
+export * from "./misconceptions";
+export * from "./daily-stats";

--- a/src/db/schema/mastery.ts
+++ b/src/db/schema/mastery.ts
@@ -1,0 +1,41 @@
+import {
+  boolean,
+  index,
+  integer,
+  pgTable,
+  primaryKey,
+  real,
+  text,
+  timestamp,
+} from "drizzle-orm/pg-core";
+
+import { concepts } from "./concepts";
+import { users } from "./users";
+
+/** FSRS 状態。PK は (user_id, concept_id) の複合 */
+export const mastery = pgTable(
+  "mastery",
+  {
+    userId: text("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    conceptId: text("concept_id")
+      .notNull()
+      .references(() => concepts.id),
+    stability: real("stability"),
+    difficulty: real("difficulty"),
+    lastReview: timestamp("last_review", { withTimezone: true }),
+    nextReview: timestamp("next_review", { withTimezone: true }),
+    reviewCount: integer("review_count").notNull().default(0),
+    lapseCount: integer("lapse_count").notNull().default(0),
+    mastered: boolean("mastered").notNull().default(false),
+    masteryPct: real("mastery_pct").notNull().default(0),
+  },
+  (table) => [
+    primaryKey({ columns: [table.userId, table.conceptId] }),
+    index("idx_mastery_next_review").on(table.userId, table.nextReview),
+  ],
+);
+
+export type Mastery = typeof mastery.$inferSelect;
+export type NewMastery = typeof mastery.$inferInsert;

--- a/src/db/schema/misconceptions.ts
+++ b/src/db/schema/misconceptions.ts
@@ -1,0 +1,25 @@
+import { sql } from "drizzle-orm";
+import { boolean, integer, pgTable, text, timestamp } from "drizzle-orm/pg-core";
+
+import { concepts } from "./concepts";
+import { users } from "./users";
+
+export const misconceptions = pgTable("misconceptions", {
+  id: text("id")
+    .primaryKey()
+    .default(sql`gen_random_uuid()::text`),
+  userId: text("user_id")
+    .notNull()
+    .references(() => users.id, { onDelete: "cascade" }),
+  conceptId: text("concept_id")
+    .notNull()
+    .references(() => concepts.id),
+  description: text("description").notNull(),
+  firstSeen: timestamp("first_seen", { withTimezone: true }).notNull().defaultNow(),
+  lastSeen: timestamp("last_seen", { withTimezone: true }).notNull().defaultNow(),
+  count: integer("count").notNull().default(1),
+  resolved: boolean("resolved").notNull().default(false),
+});
+
+export type Misconception = typeof misconceptions.$inferSelect;
+export type NewMisconception = typeof misconceptions.$inferInsert;

--- a/src/db/schema/questions.ts
+++ b/src/db/schema/questions.ts
@@ -1,0 +1,52 @@
+import { sql } from "drizzle-orm";
+import { boolean, index, integer, jsonb, pgTable, text, timestamp } from "drizzle-orm/pg-core";
+
+import type { DifficultyLevel, QuestionType, ThinkingStyle } from "./_constants";
+import { concepts } from "./concepts";
+
+export type RubricCheck = {
+  id: string;
+  description: string;
+  weight?: number;
+};
+
+export const questions = pgTable(
+  "questions",
+  {
+    id: text("id")
+      .primaryKey()
+      .default(sql`gen_random_uuid()::text`),
+    conceptId: text("concept_id")
+      .notNull()
+      .references(() => concepts.id),
+    type: text("type").$type<QuestionType>().notNull(),
+    thinkingStyle: text("thinking_style").$type<ThinkingStyle>(),
+    difficulty: text("difficulty").$type<DifficultyLevel>().notNull(),
+    prompt: text("prompt").notNull(),
+    answer: text("answer").notNull(),
+    rubric: jsonb("rubric").$type<RubricCheck[]>(),
+    /** mcq のときだけ埋まる。選択肢テキスト配列 */
+    distractors: jsonb("distractors").$type<string[]>(),
+    hint: text("hint"),
+    explanation: text("explanation"),
+    tags: jsonb("tags")
+      .$type<string[]>()
+      .default(sql`'[]'::jsonb`),
+    /** 'gpt-5' / 'gpt-5-mini' など */
+    generatedBy: text("generated_by"),
+    promptVersion: text("prompt_version"),
+    retired: boolean("retired").notNull().default(false),
+    retiredReason: text("retired_reason"),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    lastServedAt: timestamp("last_served_at", { withTimezone: true }),
+    serveCount: integer("serve_count").notNull().default(0),
+  },
+  (table) => [
+    index("idx_questions_concept_type_style")
+      .on(table.conceptId, table.type, table.thinkingStyle, table.difficulty)
+      .where(sql`${table.retired} = FALSE`),
+  ],
+);
+
+export type Question = typeof questions.$inferSelect;
+export type NewQuestion = typeof questions.$inferInsert;

--- a/src/db/schema/session-templates.ts
+++ b/src/db/schema/session-templates.ts
@@ -1,0 +1,23 @@
+import { sql } from "drizzle-orm";
+import { integer, jsonb, pgTable, text, timestamp } from "drizzle-orm/pg-core";
+
+import { users } from "./users";
+
+/** Custom Session の spec は JSON 構造を Zod で別途パース (04-custom-sessions.md) */
+export const sessionTemplates = pgTable("session_templates", {
+  id: text("id")
+    .primaryKey()
+    .default(sql`gen_random_uuid()::text`),
+  userId: text("user_id")
+    .notNull()
+    .references(() => users.id, { onDelete: "cascade" }),
+  name: text("name").notNull(),
+  rawRequest: text("raw_request"),
+  spec: jsonb("spec").notNull(),
+  useCount: integer("use_count").notNull().default(0),
+  lastUsedAt: timestamp("last_used_at", { withTimezone: true }),
+  createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+});
+
+export type SessionTemplate = typeof sessionTemplates.$inferSelect;
+export type NewSessionTemplate = typeof sessionTemplates.$inferInsert;

--- a/src/db/schema/sessions-auth.ts
+++ b/src/db/schema/sessions-auth.ts
@@ -1,0 +1,25 @@
+import { index, pgTable, text, timestamp } from "drizzle-orm/pg-core";
+
+import { users } from "./users";
+
+/** 認証セッション (cookie)。学習の sessions テーブルとは別物 */
+export const sessionsAuth = pgTable(
+  "sessions_auth",
+  {
+    /** `crypto.randomUUID()` 由来の cookie 値 */
+    id: text("id").primaryKey(),
+    userId: text("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    expiresAt: timestamp("expires_at", { withTimezone: true }).notNull(),
+    lastActiveAt: timestamp("last_active_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    index("idx_sessions_auth_user").on(table.userId),
+    index("idx_sessions_auth_expires").on(table.expiresAt),
+  ],
+);
+
+export type SessionAuth = typeof sessionsAuth.$inferSelect;
+export type NewSessionAuth = typeof sessionsAuth.$inferInsert;

--- a/src/db/schema/sessions.ts
+++ b/src/db/schema/sessions.ts
@@ -1,0 +1,33 @@
+import { sql } from "drizzle-orm";
+import { index, integer, jsonb, pgTable, text, timestamp } from "drizzle-orm/pg-core";
+
+import type { SessionKind } from "./_constants";
+import { sessionTemplates } from "./session-templates";
+import { users } from "./users";
+
+/** 学習セッション (認証 sessions_auth とは別物) */
+export const sessions = pgTable(
+  "sessions",
+  {
+    id: text("id")
+      .primaryKey()
+      .default(sql`gen_random_uuid()::text`),
+    userId: text("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    kind: text("kind").$type<SessionKind>().notNull(),
+    /** Custom Session のときだけ CustomSessionSpec が入る */
+    spec: jsonb("spec"),
+    templateId: text("template_id").references(() => sessionTemplates.id, {
+      onDelete: "set null",
+    }),
+    startedAt: timestamp("started_at", { withTimezone: true }).notNull().defaultNow(),
+    finishedAt: timestamp("finished_at", { withTimezone: true }),
+    questionCount: integer("question_count").notNull().default(0),
+    correctCount: integer("correct_count").notNull().default(0),
+  },
+  (table) => [index("idx_sessions_user_started").on(table.userId, table.startedAt.desc())],
+);
+
+export type Session = typeof sessions.$inferSelect;
+export type NewSession = typeof sessions.$inferInsert;

--- a/src/db/schema/users.ts
+++ b/src/db/schema/users.ts
@@ -1,0 +1,18 @@
+import { sql } from "drizzle-orm";
+import { integer, pgTable, text, timestamp } from "drizzle-orm/pg-core";
+
+export const users = pgTable("users", {
+  id: text("id")
+    .primaryKey()
+    .default(sql`gen_random_uuid()::text`),
+  email: text("email").notNull().unique(),
+  displayName: text("display_name"),
+  timezone: text("timezone").default("Asia/Tokyo"),
+  dailyGoal: integer("daily_goal").notNull().default(15),
+  /** 'HH:mm' 形式 */
+  notificationTime: text("notification_time"),
+  createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+});
+
+export type User = typeof users.$inferSelect;
+export type NewUser = typeof users.$inferInsert;

--- a/src/db/schema/webauthn-challenges.ts
+++ b/src/db/schema/webauthn-challenges.ts
@@ -1,0 +1,16 @@
+import { pgTable, text, timestamp } from "drizzle-orm/pg-core";
+
+import type { WebauthnChallengePurpose } from "./_constants";
+import { users } from "./users";
+
+export const webauthnChallenges = pgTable("webauthn_challenges", {
+  id: text("id").primaryKey(),
+  userId: text("user_id").references(() => users.id, { onDelete: "cascade" }),
+  challenge: text("challenge").notNull(),
+  purpose: text("purpose").$type<WebauthnChallengePurpose>().notNull(),
+  createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  expiresAt: timestamp("expires_at", { withTimezone: true }).notNull(),
+});
+
+export type WebauthnChallenge = typeof webauthnChallenges.$inferSelect;
+export type NewWebauthnChallenge = typeof webauthnChallenges.$inferInsert;


### PR DESCRIPTION
## Summary
- Issue #4 を解決。`docs/06-architecture.md` §6.2.2 に定義された 12 テーブル分の Drizzle スキーマを `src/db/schema/` に実装
- `src/db/client.ts` で `@neondatabase/serverless` + Drizzle の singleton クライアントを公開
- 初回マイグレーション `drizzle/0000_initial_schema.sql` を生成し Neon dev branch に適用済み
- `CREATE EXTENSION pgcrypto / pg_trgm` を先頭で実行
- `attempts.search_tsv` は `GENERATED ALWAYS AS ... STORED` の tsvector 生成列

## 受け入れ基準 (issue #4)
- [x] `src/db/client.ts` で `@neondatabase/serverless` + Drizzle クライアントを公開
- [x] `src/db/schema/{users,credentials,sessions_auth,webauthn_challenges,concepts,questions,sessions,attempts,mastery,misconceptions,session_templates,daily_stats}.ts` を作成
- [x] `src/db/schema/index.ts` で全部まとめてエクスポート
- [x] `pnpm db:generate` で `drizzle/` にマイグレーション SQL が生成される
- [x] `pnpm db:migrate` で Neon dev branch に適用成功
- [x] `pg_trgm` / `pgcrypto` 拡張を有効化する migration を含む
- [x] スキーマの unit test: 主要テーブルの型/関係を `expectTypeOf` で確認
- [x] CI 緑 (`pnpm typecheck` / `pnpm test` / `pnpm build`)

Closes #4

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm test -- --run` (15 pass)
- [x] `pnpm build`
- [x] `pnpm db:generate` + `pnpm db:migrate` (Neon development branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)