### PR TITLE
feat(trpc): tRPC v11 foundation + ping endpoint

### DIFF
--- a/src/app/api/trpc/[trpc]/route.ts
+++ b/src/app/api/trpc/[trpc]/route.ts
@@ -1,0 +1,19 @@
+import { fetchRequestHandler } from "@trpc/server/adapters/fetch";
+
+import { createTrpcContext } from "@/server/trpc/init";
+import { appRouter } from "@/server/trpc/routers";
+
+const handler = (req: Request) =>
+  fetchRequestHandler({
+    endpoint: "/api/trpc",
+    req,
+    router: appRouter,
+    createContext: () => createTrpcContext(),
+    onError({ error, path }) {
+      if (process.env.NODE_ENV !== "production") {
+        console.error(`[tRPC] ${path ?? "<no-path>"}: ${error.message}`);
+      }
+    },
+  });
+
+export { handler as GET, handler as POST };

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,8 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
+
+import { TrpcProvider } from "@/lib/trpc/react";
+
 import "./globals.css";
 
 const geistSans = Geist({
@@ -24,7 +27,9 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="ja" className={`${geistSans.variable} ${geistMono.variable} h-full antialiased`}>
-      <body className="flex min-h-full flex-col">{children}</body>
+      <body className="flex min-h-full flex-col">
+        <TrpcProvider>{children}</TrpcProvider>
+      </body>
     </html>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,5 @@
+import { PingCard } from "@/features/ping/ping-card";
+
 export default function Home() {
   return (
     <main className="flex min-h-screen flex-col items-center justify-center gap-6 bg-zinc-50 p-8 font-sans dark:bg-black">
@@ -7,6 +9,7 @@ export default function Home() {
       <p className="max-w-md text-center text-zinc-600 dark:text-zinc-400">
         エンジニアのための AI 家庭教師。Phase 0 bootstrap。
       </p>
+      <PingCard />
     </main>
   );
 }

--- a/src/features/ping/ping-card.tsx
+++ b/src/features/ping/ping-card.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import { trpc } from "@/lib/trpc/react";
+
+/** tRPC 疎通確認用の最小 UI。Phase 0 でのみ使い、認証導入後に差し替える想定 */
+export function PingCard() {
+  const ping = trpc.ping.useQuery(undefined, { staleTime: Infinity });
+
+  return (
+    <div className="w-full max-w-md rounded-lg border border-zinc-200 bg-white p-4 text-sm text-zinc-700 shadow-sm dark:border-zinc-800 dark:bg-zinc-900 dark:text-zinc-300">
+      <div className="font-medium">tRPC ping</div>
+      <div className="mt-1 font-mono text-xs">
+        {ping.isLoading && "…"}
+        {ping.isError && `error: ${ping.error.message}`}
+        {ping.data?.message}
+      </div>
+    </div>
+  );
+}

--- a/src/lib/trpc/react.tsx
+++ b/src/lib/trpc/react.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { httpBatchLink } from "@trpc/client";
+import { createTRPCReact } from "@trpc/react-query";
+import { useState, type ReactNode } from "react";
+
+import type { AppRouter } from "@/server/trpc/routers";
+
+import { getTrpcUrl } from "./shared";
+
+export const trpc = createTRPCReact<AppRouter>();
+
+function makeQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        staleTime: 30_000,
+        refetchOnWindowFocus: false,
+      },
+    },
+  });
+}
+
+export function TrpcProvider({ children }: { children: ReactNode }) {
+  const [queryClient] = useState(() => makeQueryClient());
+  const [trpcClient] = useState(() =>
+    trpc.createClient({
+      links: [
+        httpBatchLink({
+          url: getTrpcUrl(),
+          fetch(url, options) {
+            return fetch(url, { ...options, credentials: "same-origin" });
+          },
+        }),
+      ],
+    }),
+  );
+
+  return (
+    <trpc.Provider client={trpcClient} queryClient={queryClient}>
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    </trpc.Provider>
+  );
+}

--- a/src/lib/trpc/shared.test.ts
+++ b/src/lib/trpc/shared.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+
+import { getTrpcUrl } from "./shared";
+
+describe("getTrpcUrl", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("サーバー (window 未定義) では絶対 URL を返す", () => {
+    // vitest のデフォルトでは window が定義されていないので、そのまま確認できる
+    expect(typeof window).toBe("undefined");
+    expect(getTrpcUrl()).toMatch(/^https?:\/\/.+\/api\/trpc$/);
+  });
+
+  it("ブラウザ (window 定義) では相対パスを返す", () => {
+    vi.stubGlobal("window", {});
+    expect(getTrpcUrl()).toBe("/api/trpc");
+  });
+});

--- a/src/lib/trpc/shared.ts
+++ b/src/lib/trpc/shared.ts
@@ -1,0 +1,5 @@
+import { appUrl } from "@/lib/env";
+
+export function getTrpcUrl(): string {
+  return `${appUrl}/api/trpc`;
+}

--- a/src/lib/trpc/shared.ts
+++ b/src/lib/trpc/shared.ts
@@ -1,5 +1,13 @@
 import { appUrl } from "@/lib/env";
 
+/**
+ * tRPC エンドポイント URL を返す。
+ * - ブラウザ: 同一オリジンなので相対パスで十分 (NEXT_PUBLIC_ でない VERCEL_URL は client bundle に乗らないため fallback が効かない)
+ * - サーバー (SSR / Server Component / Route Handler): 絶対 URL が必要なため appUrl ベースで組み立てる
+ */
 export function getTrpcUrl(): string {
+  if (typeof window !== "undefined") {
+    return "/api/trpc";
+  }
   return `${appUrl}/api/trpc`;
 }

--- a/src/server/trpc/init.ts
+++ b/src/server/trpc/init.ts
@@ -1,0 +1,36 @@
+import { initTRPC, TRPCError } from "@trpc/server";
+
+import type { User } from "@/db/schema";
+
+/**
+ * tRPC 用のリクエストコンテキスト。
+ * 認証は issue #6 で実装するため、ここでは `user` 欄のみ定義して
+ * 中身は空 (anonymous) で埋める。
+ */
+export type TrpcContext = {
+  user: User | null;
+};
+
+export async function createTrpcContext(): Promise<TrpcContext> {
+  return { user: null };
+}
+
+const t = initTRPC.context<TrpcContext>().create();
+
+export const router = t.router;
+export const publicProcedure = t.procedure;
+
+/**
+ * protected procedure のスタブ。
+ * Passkey 認証 (issue #6) が入るまでは常に UNAUTHORIZED を返し、
+ * ダウンストリームが「ここで cookie → user が注入される」前提で書ける。
+ */
+export const protectedProcedure = publicProcedure.use(({ ctx, next }) => {
+  if (!ctx.user) {
+    throw new TRPCError({
+      code: "UNAUTHORIZED",
+      message: "Passkey auth is not yet wired (issue #6)",
+    });
+  }
+  return next({ ctx: { ...ctx, user: ctx.user } });
+});

--- a/src/server/trpc/routers/index.test.ts
+++ b/src/server/trpc/routers/index.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from "vitest";
+
+import { appRouter } from "./index";
+
+describe("appRouter.ping", () => {
+  it("引数なしで呼ぶと pong を返す", async () => {
+    const caller = appRouter.createCaller({ user: null });
+    await expect(caller.ping()).resolves.toEqual({ message: "pong" });
+  });
+
+  it("name を渡すと pong: <name> を返す", async () => {
+    const caller = appRouter.createCaller({ user: null });
+    await expect(caller.ping({ name: "tanren" })).resolves.toEqual({
+      message: "pong: tanren",
+    });
+  });
+
+  it("name が空文字なら Zod バリデーションで弾かれる", async () => {
+    const caller = appRouter.createCaller({ user: null });
+    await expect(caller.ping({ name: "" })).rejects.toThrow();
+  });
+
+  it("name が 50 文字超なら Zod バリデーションで弾かれる", async () => {
+    const caller = appRouter.createCaller({ user: null });
+    await expect(caller.ping({ name: "x".repeat(51) })).rejects.toThrow();
+  });
+});

--- a/src/server/trpc/routers/index.ts
+++ b/src/server/trpc/routers/index.ts
@@ -1,0 +1,8 @@
+import { router } from "../init";
+import { pingRouter } from "./ping";
+
+export const appRouter = router({
+  ping: pingRouter.ping,
+});
+
+export type AppRouter = typeof appRouter;

--- a/src/server/trpc/routers/ping.ts
+++ b/src/server/trpc/routers/ping.ts
@@ -1,0 +1,23 @@
+import { z } from "zod";
+
+import { publicProcedure, router } from "../init";
+
+/**
+ * 疎通確認用。引数 `name` を受けて「pong: <name>」を返すため Zod バリデーションの動作例になる。
+ */
+export const pingRouter = router({
+  ping: publicProcedure
+    .input(
+      z
+        .object({
+          name: z.string().min(1).max(50).optional(),
+        })
+        .optional(),
+    )
+    .query(({ input }) => {
+      if (input?.name) {
+        return { message: `pong: ${input.name}` as const };
+      }
+      return { message: "pong" as const };
+    }),
+});


### PR DESCRIPTION
## Summary
- Issue #5 を解決。`docs/06-architecture.md` §6.3 の tRPC 構成の土台を置く
- `src/server/trpc/init.ts` で `publicProcedure` / `protectedProcedure` (auth 未実装のため UNAUTHORIZED スタブ) を定義
- `src/server/trpc/routers/ping.ts` の `ping` で Zod バリデーション動作を含む疎通 endpoint
- `src/app/api/trpc/[trpc]/route.ts` に fetchRequestHandler ベースの Route Handler
- `src/lib/trpc/react.tsx` で React Query + tRPC client の Provider を公開、`layout.tsx` から全体をラップ
- `PingCard` (home) が実際に `/api/trpc/ping` を叩いて `pong` を表示

## 受け入れ基準 (issue #5)
- [x] `src/server/trpc/init.ts` で `initTRPC` / `publicProcedure` / `protectedProcedure` (スタブ) を定義
- [x] `src/server/trpc/routers/index.ts` で `appRouter` をエクスポート
- [x] `src/app/api/trpc/[trpc]/route.ts` で Route Handler
- [x] `src/lib/trpc/react.tsx` に React Query + tRPC client の provider
- [x] `appRouter.ping` が `"pong"` を返す、ホームから呼べる
- [x] Zod 入力バリデーションの動作例 (`name` 1〜50 文字)
- [x] unit test で caller 経由で `ping` を呼ぶ

Closes #5

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm test -- --run` (19 pass)
- [x] `pnpm build` (Route `/api/trpc/[trpc]` が動的 route として生成)

🤖 Generated with [Claude Code](https://claude.com/claude-code)