### PR TITLE
feat(auth): Passkey (WebAuthn) 最小認証

### DIFF
--- a/src/app/api/auth/authenticate/options/route.ts
+++ b/src/app/api/auth/authenticate/options/route.ts
@@ -1,0 +1,12 @@
+import { NextResponse } from "next/server";
+
+import { buildAuthenticationOptions, isPasskeyEnabled } from "@/server/auth/webauthn";
+
+export async function POST() {
+  if (!isPasskeyEnabled()) {
+    return NextResponse.json({ error: "Passkey is disabled" }, { status: 503 });
+  }
+
+  const { options, challengeId } = await buildAuthenticationOptions();
+  return NextResponse.json({ options, challengeId });
+}

--- a/src/app/api/auth/authenticate/verify/route.ts
+++ b/src/app/api/auth/authenticate/verify/route.ts
@@ -1,0 +1,39 @@
+import { cookies } from "next/headers";
+import { NextResponse } from "next/server";
+import { z } from "zod";
+
+import { SESSION_COOKIE_NAME } from "@/server/auth/constants";
+import { createSession } from "@/server/auth/session";
+import { isPasskeyEnabled, verifyAuthentication } from "@/server/auth/webauthn";
+
+const BodySchema = z.object({
+  challengeId: z.string().min(1),
+  response: z.unknown(),
+});
+
+export async function POST(req: Request) {
+  if (!isPasskeyEnabled()) {
+    return NextResponse.json({ error: "Passkey is disabled" }, { status: 503 });
+  }
+
+  const parsed = BodySchema.safeParse(await req.json());
+  if (!parsed.success) {
+    return NextResponse.json({ error: "Invalid body" }, { status: 400 });
+  }
+
+  try {
+    const { user } = await verifyAuthentication({
+      challengeId: parsed.data.challengeId,
+      response: parsed.data.response as Parameters<typeof verifyAuthentication>[0]["response"],
+    });
+    const { sessionId, cookie } = await createSession(user.id);
+    const store = await cookies();
+    store.set({ name: SESSION_COOKIE_NAME, value: sessionId, ...cookie });
+    return NextResponse.json({ ok: true, user: { id: user.id, email: user.email } });
+  } catch (error) {
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "verification failed" },
+      { status: 401 },
+    );
+  }
+}

--- a/src/app/api/auth/dev-login/route.ts
+++ b/src/app/api/auth/dev-login/route.ts
@@ -9,8 +9,14 @@ import { isPasskeyEnabled } from "@/server/auth/webauthn";
 /**
  * Passkey 無効環境 (Preview の一部 / 作者ローカルで WebAuthn を切った場合) の
  * ワンショット自動ログイン。Users テーブルにちょうど 1 名しかいない個人用プロダクトのみで許可。
+ *
+ * 本番 (Vercel production) では WEBAUTHN_* の設定漏れが「誰でも owner としてログイン可」に
+ * 化けないよう、404 (エンドポイント自体を隠蔽) を返す。Preview / dev だけで利用可能。
  */
 export async function POST() {
+  if (process.env.VERCEL_ENV === "production" || process.env.NODE_ENV === "production") {
+    return new NextResponse("Not Found", { status: 404 });
+  }
   if (isPasskeyEnabled()) {
     return NextResponse.json(
       { error: "Passkey is enabled; use /api/auth/authenticate" },
@@ -35,8 +41,8 @@ export async function POST() {
     sameSite: cookie.sameSite,
     path: cookie.path,
     expires: cookie.expires,
-    // __Host- prefix は使わないので Secure は本番のみ
-    secure: process.env.NODE_ENV === "production",
+    // __Host- prefix は使わないので Secure は HTTPS のみ必要。本番では上で 404 を返す
+    secure: false,
   });
   return NextResponse.json({ ok: true, user: { id: user.id, email: user.email } });
 }

--- a/src/app/api/auth/dev-login/route.ts
+++ b/src/app/api/auth/dev-login/route.ts
@@ -1,0 +1,42 @@
+import { cookies } from "next/headers";
+import { NextResponse } from "next/server";
+
+import { DEV_SESSION_COOKIE_NAME } from "@/server/auth/constants";
+import { tryDevAutoLoginUser } from "@/server/auth/dev-login";
+import { createSession } from "@/server/auth/session";
+import { isPasskeyEnabled } from "@/server/auth/webauthn";
+
+/**
+ * Passkey 無効環境 (Preview の一部 / 作者ローカルで WebAuthn を切った場合) の
+ * ワンショット自動ログイン。Users テーブルにちょうど 1 名しかいない個人用プロダクトのみで許可。
+ */
+export async function POST() {
+  if (isPasskeyEnabled()) {
+    return NextResponse.json(
+      { error: "Passkey is enabled; use /api/auth/authenticate" },
+      { status: 400 },
+    );
+  }
+
+  const user = await tryDevAutoLoginUser();
+  if (!user) {
+    return NextResponse.json(
+      { error: "dev auto-login refused (no user, or multiple users exist)" },
+      { status: 403 },
+    );
+  }
+
+  const { sessionId, cookie } = await createSession(user.id);
+  const store = await cookies();
+  store.set({
+    name: DEV_SESSION_COOKIE_NAME,
+    value: sessionId,
+    httpOnly: cookie.httpOnly,
+    sameSite: cookie.sameSite,
+    path: cookie.path,
+    expires: cookie.expires,
+    // __Host- prefix は使わないので Secure は本番のみ
+    secure: process.env.NODE_ENV === "production",
+  });
+  return NextResponse.json({ ok: true, user: { id: user.id, email: user.email } });
+}

--- a/src/app/api/auth/logout/route.ts
+++ b/src/app/api/auth/logout/route.ts
@@ -1,0 +1,16 @@
+import { cookies } from "next/headers";
+import { NextResponse } from "next/server";
+
+import { DEV_SESSION_COOKIE_NAME, SESSION_COOKIE_NAME } from "@/server/auth/constants";
+import { destroySession, resolveSession } from "@/server/auth/session";
+
+export async function POST() {
+  const store = await cookies();
+  const resolved = await resolveSession(store);
+  if (resolved) {
+    await destroySession(resolved.sessionId);
+  }
+  store.delete(SESSION_COOKIE_NAME);
+  store.delete(DEV_SESSION_COOKIE_NAME);
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/auth/register/options/route.ts
+++ b/src/app/api/auth/register/options/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from "next/server";
+
+import { getCurrentUser } from "@/server/auth/session";
+import { buildRegistrationOptions, isPasskeyEnabled } from "@/server/auth/webauthn";
+
+export async function POST() {
+  if (!isPasskeyEnabled()) {
+    return NextResponse.json({ error: "Passkey is disabled in this environment" }, { status: 503 });
+  }
+
+  const user = await getCurrentUser();
+  if (!user) {
+    return NextResponse.json({ error: "Must be logged in to add a passkey" }, { status: 401 });
+  }
+
+  const { options, challengeId } = await buildRegistrationOptions({
+    userId: user.id,
+    userName: user.email,
+  });
+
+  return NextResponse.json({ options, challengeId });
+}

--- a/src/app/api/auth/register/verify/route.ts
+++ b/src/app/api/auth/register/verify/route.ts
@@ -1,0 +1,44 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+
+import { getCurrentUser } from "@/server/auth/session";
+import { isPasskeyEnabled, verifyRegistration } from "@/server/auth/webauthn";
+
+const BodySchema = z.object({
+  challengeId: z.string().min(1),
+  // @simplewebauthn/browser が返す JSON をそのまま受け取る。内容は SimpleWebAuthn 側で厳密検証するためここは緩く
+  response: z.unknown(),
+  nickname: z.string().min(1).max(50).optional(),
+});
+
+export async function POST(req: Request) {
+  if (!isPasskeyEnabled()) {
+    return NextResponse.json({ error: "Passkey is disabled" }, { status: 503 });
+  }
+
+  const user = await getCurrentUser();
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const parsed = BodySchema.safeParse(await req.json());
+  if (!parsed.success) {
+    return NextResponse.json({ error: "Invalid body" }, { status: 400 });
+  }
+
+  try {
+    const result = await verifyRegistration({
+      userId: user.id,
+      challengeId: parsed.data.challengeId,
+      // SimpleWebAuthn 側で形を強く検証するので unknown を渡す
+      response: parsed.data.response as Parameters<typeof verifyRegistration>[0]["response"],
+      nickname: parsed.data.nickname,
+    });
+    return NextResponse.json({ ok: true, credentialId: result.credentialId });
+  } catch (error) {
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "verification failed" },
+      { status: 400 },
+    );
+  }
+}

--- a/src/server/auth/bootstrap.ts
+++ b/src/server/auth/bootstrap.ts
@@ -1,0 +1,40 @@
+#!/usr/bin/env tsx
+/**
+ * 初回ユーザー作成用 CLI (ADR-0004)。
+ *   pnpm auth:bootstrap <email> [displayName]
+ *
+ * 既に同 email のユーザーがいれば何もしない (idempotent)。
+ * Passkey 登録自体はブラウザ UI から /api/auth/register/* を叩く想定。
+ */
+import { eq } from "drizzle-orm";
+
+import { getDb } from "@/db/client";
+import { users } from "@/db/schema";
+
+async function main() {
+  const [email, displayName] = process.argv.slice(2);
+  if (!email) {
+    console.error("usage: pnpm auth:bootstrap <email> [displayName]");
+    process.exit(1);
+  }
+
+  const db = getDb();
+  const existing = await db.select().from(users).where(eq(users.email, email)).limit(1);
+  if (existing[0]) {
+    console.log(`✓ user already exists: ${existing[0].id} (${email})`);
+    return;
+  }
+
+  const inserted = await db
+    .insert(users)
+    .values({ email, displayName: displayName ?? null })
+    .returning();
+
+  console.log(`✓ created user: ${inserted[0]?.id} (${email})`);
+  console.log("  次に http://localhost:3000/login で Passkey を登録してください");
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/server/auth/constants.ts
+++ b/src/server/auth/constants.ts
@@ -1,0 +1,11 @@
+/** WebAuthn / セッション運用の定数 (ADR-0004 §6.8.1) */
+
+export const SESSION_COOKIE_NAME = "__Host-tanren_session";
+/** dev ショートカット用の cookie。passkey 無効 Preview などで使用 */
+export const DEV_SESSION_COOKIE_NAME = "tanren_dev_session";
+
+/** 30 日 sliding expiry */
+export const SESSION_MAX_AGE_MS = 30 * 24 * 60 * 60 * 1000;
+
+/** WebAuthn チャレンジ有効期間 (登録・認証とも短め) */
+export const WEBAUTHN_CHALLENGE_TTL_MS = 5 * 60 * 1000;

--- a/src/server/auth/dev-login.ts
+++ b/src/server/auth/dev-login.ts
@@ -1,0 +1,24 @@
+import { eq } from "drizzle-orm";
+
+import { getDb } from "@/db/client";
+import { users } from "@/db/schema";
+
+import { isPasskeyEnabled } from "./webauthn";
+
+/**
+ * Passkey を使えない環境 (Preview で RP_ID 未設定など) で「作者 1 名」の個人プロダクトとして動かすための fallback。
+ * 既に users テーブルにユーザーが 1 名だけ存在する場合にそれを返す。
+ * 複数ユーザー時や passkey が有効な場合は必ず false を返して、通常の auth フローに委ねる。
+ */
+export async function tryDevAutoLoginUser() {
+  if (isPasskeyEnabled()) return null;
+  const rows = await getDb().select().from(users).limit(2);
+  if (rows.length !== 1) return null;
+  return rows[0];
+}
+
+/** dev モードで特定 email の user を取得するヘルパ。存在しなければ null */
+export async function findUserByEmail(email: string) {
+  const rows = await getDb().select().from(users).where(eq(users.email, email)).limit(1);
+  return rows[0] ?? null;
+}

--- a/src/server/auth/session.test.ts
+++ b/src/server/auth/session.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("next/headers", () => ({
+  cookies: vi.fn(),
+}));
+
+type Builders = {
+  select: ReturnType<typeof vi.fn>;
+  update: ReturnType<typeof vi.fn>;
+  insert: ReturnType<typeof vi.fn>;
+  delete: ReturnType<typeof vi.fn>;
+};
+
+const builders: Builders = {
+  select: vi.fn(),
+  update: vi.fn(),
+  insert: vi.fn(),
+  delete: vi.fn(),
+};
+
+vi.mock("@/db/client", () => ({
+  getDb: () => builders,
+}));
+
+import { SESSION_COOKIE_NAME } from "./constants";
+import { resolveSession } from "./session";
+
+function mockCookieStore(values: Record<string, string>) {
+  return {
+    get: (name: string) => (values[name] ? { value: values[name] } : undefined),
+    set: vi.fn(),
+    delete: vi.fn(),
+  } as unknown as Parameters<typeof resolveSession>[0];
+}
+
+function fluentSelect(rows: unknown[]) {
+  const api = {
+    from: () => api,
+    innerJoin: () => api,
+    where: () => api,
+    limit: () => rows,
+  };
+  return api;
+}
+
+function fluentUpdate() {
+  const api = {
+    set: () => api,
+    where: async () => {},
+  };
+  return api;
+}
+
+describe("resolveSession", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("cookie がない場合は null", async () => {
+    const result = await resolveSession(mockCookieStore({}));
+    expect(result).toBeNull();
+  });
+
+  it("cookie はあるが sessions_auth に見つからない/期限切れ → null", async () => {
+    builders.select.mockReturnValue(fluentSelect([]));
+    const result = await resolveSession(
+      mockCookieStore({ [SESSION_COOKIE_NAME]: "expired-session" }),
+    );
+    expect(result).toBeNull();
+  });
+
+  it("有効なセッションなら user を返し last_active_at を更新する", async () => {
+    const fakeUser = { id: "u1", email: "x@example.com" };
+    builders.select.mockReturnValue(
+      fluentSelect([{ session: { id: "s1", userId: "u1" }, user: fakeUser }]),
+    );
+    builders.update.mockReturnValue(fluentUpdate());
+
+    const result = await resolveSession(mockCookieStore({ [SESSION_COOKIE_NAME]: "s1" }));
+    expect(result?.user).toEqual(fakeUser);
+    expect(result?.sessionId).toBe("s1");
+    expect(builders.update).toHaveBeenCalled();
+  });
+});

--- a/src/server/auth/session.test.ts
+++ b/src/server/auth/session.test.ts
@@ -22,7 +22,7 @@ vi.mock("@/db/client", () => ({
   getDb: () => builders,
 }));
 
-import { SESSION_COOKIE_NAME } from "./constants";
+import { SESSION_COOKIE_NAME, SESSION_MAX_AGE_MS } from "./constants";
 import { resolveSession } from "./session";
 
 function mockCookieStore(values: Record<string, string>) {
@@ -43,9 +43,12 @@ function fluentSelect(rows: unknown[]) {
   return api;
 }
 
-function fluentUpdate() {
+function fluentUpdateCapture(capture: { set?: unknown }) {
   const api = {
-    set: () => api,
+    set: (v: unknown) => {
+      capture.set = v;
+      return api;
+    },
     where: async () => {},
   };
   return api;
@@ -63,22 +66,32 @@ describe("resolveSession", () => {
 
   it("cookie はあるが sessions_auth に見つからない/期限切れ → null", async () => {
     builders.select.mockReturnValue(fluentSelect([]));
-    const result = await resolveSession(
-      mockCookieStore({ [SESSION_COOKIE_NAME]: "expired-session" }),
-    );
+    const result = await resolveSession(mockCookieStore({ [SESSION_COOKIE_NAME]: "expired" }));
     expect(result).toBeNull();
   });
 
-  it("有効なセッションなら user を返し last_active_at を更新する", async () => {
+  it("有効なセッションなら user と sessionId を返す (passkey kind)", async () => {
     const fakeUser = { id: "u1", email: "x@example.com" };
     builders.select.mockReturnValue(
       fluentSelect([{ session: { id: "s1", userId: "u1" }, user: fakeUser }]),
     );
-    builders.update.mockReturnValue(fluentUpdate());
+    const capture: { set?: { expiresAt?: Date; lastActiveAt?: Date } } = {};
+    builders.update.mockReturnValue(fluentUpdateCapture(capture));
 
+    const before = Date.now();
     const result = await resolveSession(mockCookieStore({ [SESSION_COOKIE_NAME]: "s1" }));
+    const after = Date.now();
+
     expect(result?.user).toEqual(fakeUser);
     expect(result?.sessionId).toBe("s1");
-    expect(builders.update).toHaveBeenCalled();
+    expect(result?.kind).toBe("passkey");
+
+    // sliding expiry の更新: set() に expiresAt と lastActiveAt 両方が乗っている
+    expect(capture.set?.expiresAt).toBeInstanceOf(Date);
+    expect(capture.set?.lastActiveAt).toBeInstanceOf(Date);
+    const expiresTs = capture.set!.expiresAt!.getTime();
+    expect(expiresTs).toBeGreaterThanOrEqual(before + SESSION_MAX_AGE_MS - 1);
+    expect(expiresTs).toBeLessThanOrEqual(after + SESSION_MAX_AGE_MS + 1);
+    expect(result?.expiresAt.getTime()).toBe(expiresTs);
   });
 });

--- a/src/server/auth/session.ts
+++ b/src/server/auth/session.ts
@@ -10,7 +10,7 @@ import { sessionsAuth, users, type User } from "@/db/schema";
 
 import { DEV_SESSION_COOKIE_NAME, SESSION_COOKIE_NAME, SESSION_MAX_AGE_MS } from "./constants";
 
-type CookieStore = ReadonlyRequestCookies | Awaited<ReturnType<typeof cookies>>;
+export type CookieStore = ReadonlyRequestCookies | Awaited<ReturnType<typeof cookies>>;
 
 type SessionResolution = {
   user: User;
@@ -88,9 +88,48 @@ export async function destroySession(sessionId: string): Promise<void> {
   await getDb().delete(sessionsAuth).where(eq(sessionsAuth.id, sessionId));
 }
 
-/** Route Handler 内で使うヘルパ */
+/**
+ * 既存セッションの cookie を延長された expiresAt で再発行する共通ヘルパ。
+ * tRPC context / Route Handler どちらからも呼べるよう、`store.set` が不可な文脈では
+ * 例外を握りつぶす (DB 側は既に延長済みなので整合は保たれる)。
+ */
+export function refreshSessionCookie(
+  store: CookieStore,
+  resolution: Pick<SessionResolution, "sessionId" | "expiresAt" | "kind">,
+): void {
+  try {
+    if (resolution.kind === "passkey") {
+      store.set({
+        name: SESSION_COOKIE_NAME,
+        value: resolution.sessionId,
+        httpOnly: true,
+        secure: true,
+        sameSite: "lax",
+        path: "/",
+        expires: resolution.expiresAt,
+      });
+    } else {
+      store.set({
+        name: DEV_SESSION_COOKIE_NAME,
+        value: resolution.sessionId,
+        httpOnly: true,
+        sameSite: "lax",
+        path: "/",
+        expires: resolution.expiresAt,
+        secure: process.env.NODE_ENV === "production",
+      });
+    }
+  } catch {
+    // Server Component など store.set が呼べない文脈では DB 側の延長で十分 (cookie は
+    // 次回ミドルウェア / Route Handler 経由で再発行される)
+  }
+}
+
+/** Route Handler 内で使うヘルパ。sliding expiry の cookie 再発行も同時に行う */
 export async function getCurrentUser(): Promise<User | null> {
   const store = await cookies();
   const resolved = await resolveSession(store);
-  return resolved?.user ?? null;
+  if (!resolved) return null;
+  refreshSessionCookie(store, resolved);
+  return resolved.user;
 }

--- a/src/server/auth/session.ts
+++ b/src/server/auth/session.ts
@@ -15,11 +15,16 @@ type CookieStore = ReadonlyRequestCookies | Awaited<ReturnType<typeof cookies>>;
 type SessionResolution = {
   user: User;
   sessionId: string;
+  /** resolve 時に延長された expiresAt。cookie の再発行に使う */
+  expiresAt: Date;
+  /** dev (non __Host-) セッションか、Passkey (__Host-) セッションか */
+  kind: "passkey" | "dev";
 };
 
 /** `sessions_auth` に新しい行を作り、cookie attribute を返す */
 export async function createSession(userId: string): Promise<{
   sessionId: string;
+  expiresAt: Date;
   cookie: Omit<ResponseCookie, "value" | "name">;
 }> {
   const sessionId = randomUUID();
@@ -33,6 +38,7 @@ export async function createSession(userId: string): Promise<{
 
   return {
     sessionId,
+    expiresAt,
     cookie: {
       httpOnly: true,
       secure: true,
@@ -44,21 +50,20 @@ export async function createSession(userId: string): Promise<{
 }
 
 /**
- * cookie 経由で session を取得。sliding expiry 更新も担当。
- * Passkey (__Host-) と dev ショートカット両方をチェックする。
+ * cookie 経由で session を取得。30 日 sliding expiry の更新も担当。
+ * Passkey (__Host-) と dev ショートカット両方をチェック。
+ * 呼び出し元は返却された `expiresAt` を使って cookie を再発行すること。
  */
 export async function resolveSession(store: CookieStore): Promise<SessionResolution | null> {
-  const sessionId =
-    store.get(SESSION_COOKIE_NAME)?.value ?? store.get(DEV_SESSION_COOKIE_NAME)?.value ?? null;
-
+  const passkeyId = store.get(SESSION_COOKIE_NAME)?.value ?? null;
+  const devId = store.get(DEV_SESSION_COOKIE_NAME)?.value ?? null;
+  const sessionId = passkeyId ?? devId;
   if (!sessionId) return null;
+  const kind: "passkey" | "dev" = passkeyId ? "passkey" : "dev";
 
   const db = getDb();
   const rows = await db
-    .select({
-      session: sessionsAuth,
-      user: users,
-    })
+    .select({ session: sessionsAuth, user: users })
     .from(sessionsAuth)
     .innerJoin(users, eq(users.id, sessionsAuth.userId))
     .where(and(eq(sessionsAuth.id, sessionId), gt(sessionsAuth.expiresAt, new Date())))
@@ -67,13 +72,15 @@ export async function resolveSession(store: CookieStore): Promise<SessionResolut
   const row = rows[0];
   if (!row) return null;
 
-  // Sliding expiry: last_active_at を更新 (expires_at は既に先にしか進めない設計)
+  // 30 日 sliding: アクセス毎に expiresAt を押し出し、cookie も後続で同期延長する
+  const now = new Date();
+  const newExpiresAt = new Date(now.getTime() + SESSION_MAX_AGE_MS);
   await db
     .update(sessionsAuth)
-    .set({ lastActiveAt: new Date() })
+    .set({ lastActiveAt: now, expiresAt: newExpiresAt })
     .where(eq(sessionsAuth.id, sessionId));
 
-  return { user: row.user, sessionId };
+  return { user: row.user, sessionId, expiresAt: newExpiresAt, kind };
 }
 
 /** cookie の破棄とテーブル削除 */

--- a/src/server/auth/session.ts
+++ b/src/server/auth/session.ts
@@ -1,0 +1,89 @@
+import { randomUUID } from "node:crypto";
+
+import { and, eq, gt } from "drizzle-orm";
+import type { ResponseCookie } from "next/dist/compiled/@edge-runtime/cookies";
+import type { ReadonlyRequestCookies } from "next/dist/server/web/spec-extension/adapters/request-cookies";
+import { cookies } from "next/headers";
+
+import { getDb } from "@/db/client";
+import { sessionsAuth, users, type User } from "@/db/schema";
+
+import { DEV_SESSION_COOKIE_NAME, SESSION_COOKIE_NAME, SESSION_MAX_AGE_MS } from "./constants";
+
+type CookieStore = ReadonlyRequestCookies | Awaited<ReturnType<typeof cookies>>;
+
+type SessionResolution = {
+  user: User;
+  sessionId: string;
+};
+
+/** `sessions_auth` に新しい行を作り、cookie attribute を返す */
+export async function createSession(userId: string): Promise<{
+  sessionId: string;
+  cookie: Omit<ResponseCookie, "value" | "name">;
+}> {
+  const sessionId = randomUUID();
+  const expiresAt = new Date(Date.now() + SESSION_MAX_AGE_MS);
+
+  await getDb().insert(sessionsAuth).values({
+    id: sessionId,
+    userId,
+    expiresAt,
+  });
+
+  return {
+    sessionId,
+    cookie: {
+      httpOnly: true,
+      secure: true,
+      sameSite: "lax",
+      path: "/",
+      expires: expiresAt,
+    },
+  };
+}
+
+/**
+ * cookie 経由で session を取得。sliding expiry 更新も担当。
+ * Passkey (__Host-) と dev ショートカット両方をチェックする。
+ */
+export async function resolveSession(store: CookieStore): Promise<SessionResolution | null> {
+  const sessionId =
+    store.get(SESSION_COOKIE_NAME)?.value ?? store.get(DEV_SESSION_COOKIE_NAME)?.value ?? null;
+
+  if (!sessionId) return null;
+
+  const db = getDb();
+  const rows = await db
+    .select({
+      session: sessionsAuth,
+      user: users,
+    })
+    .from(sessionsAuth)
+    .innerJoin(users, eq(users.id, sessionsAuth.userId))
+    .where(and(eq(sessionsAuth.id, sessionId), gt(sessionsAuth.expiresAt, new Date())))
+    .limit(1);
+
+  const row = rows[0];
+  if (!row) return null;
+
+  // Sliding expiry: last_active_at を更新 (expires_at は既に先にしか進めない設計)
+  await db
+    .update(sessionsAuth)
+    .set({ lastActiveAt: new Date() })
+    .where(eq(sessionsAuth.id, sessionId));
+
+  return { user: row.user, sessionId };
+}
+
+/** cookie の破棄とテーブル削除 */
+export async function destroySession(sessionId: string): Promise<void> {
+  await getDb().delete(sessionsAuth).where(eq(sessionsAuth.id, sessionId));
+}
+
+/** Route Handler 内で使うヘルパ */
+export async function getCurrentUser(): Promise<User | null> {
+  const store = await cookies();
+  const resolved = await resolveSession(store);
+  return resolved?.user ?? null;
+}

--- a/src/server/auth/webauthn.test.ts
+++ b/src/server/auth/webauthn.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+type Builders = {
+  select: ReturnType<typeof vi.fn>;
+  insert: ReturnType<typeof vi.fn>;
+  delete: ReturnType<typeof vi.fn>;
+  update: ReturnType<typeof vi.fn>;
+};
+
+const builders: Builders = {
+  select: vi.fn(),
+  insert: vi.fn(),
+  delete: vi.fn(),
+  update: vi.fn(),
+};
+
+vi.mock("@/db/client", () => ({
+  getDb: () => builders,
+}));
+
+// SimpleWebAuthn はネットワーク不要だが、ここでは consumeChallenge の挙動のみに興味があるので verify 側はモック化
+vi.mock("@simplewebauthn/server", () => ({
+  generateAuthenticationOptions: vi.fn(),
+  generateRegistrationOptions: vi.fn(),
+  verifyAuthenticationResponse: vi.fn(),
+  verifyRegistrationResponse: vi.fn(),
+}));
+
+import { verifyRegistration } from "./webauthn";
+
+function fluentDeleteReturning(rows: { challenge: string }[]) {
+  const api = {
+    where: () => api,
+    returning: () => rows,
+  };
+  return api;
+}
+
+describe("verifyRegistration のチャレンジ消費", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.WEBAUTHN_RP_ID = "localhost";
+    process.env.WEBAUTHN_RP_NAME = "Tanren";
+    process.env.WEBAUTHN_ORIGIN = "http://localhost:3000";
+  });
+
+  it("challenge が見つからない (or userId 不一致) と Error を投げる", async () => {
+    builders.delete.mockReturnValue(fluentDeleteReturning([]));
+    await expect(
+      verifyRegistration({
+        userId: "u-different",
+        challengeId: "c-1",
+        response: {} as Parameters<typeof verifyRegistration>[0]["response"],
+      }),
+    ).rejects.toThrow(/Challenge not found/);
+
+    // DELETE ... RETURNING 1 ステートメントで消費している (SELECT→DELETE の 2 段階でない)
+    expect(builders.delete).toHaveBeenCalledTimes(1);
+    expect(builders.select).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/auth/webauthn.ts
+++ b/src/server/auth/webauthn.ts
@@ -1,0 +1,236 @@
+import { randomUUID } from "node:crypto";
+
+import {
+  generateAuthenticationOptions,
+  generateRegistrationOptions,
+  verifyAuthenticationResponse,
+  verifyRegistrationResponse,
+} from "@simplewebauthn/server";
+import type {
+  AuthenticationResponseJSON,
+  AuthenticatorTransportFuture,
+  RegistrationResponseJSON,
+} from "@simplewebauthn/server";
+import { and, eq, gt } from "drizzle-orm";
+
+import { getDb } from "@/db/client";
+import {
+  credentials as credentialsTable,
+  users as usersTable,
+  webauthnChallenges as challengesTable,
+  type CredentialDeviceType,
+} from "@/db/schema";
+
+import { WEBAUTHN_CHALLENGE_TTL_MS } from "./constants";
+
+/** Passkey 利用時の rp 設定。Preview など RP_ID 未設定では使わない想定 */
+function rpConfig() {
+  const rpID = process.env.WEBAUTHN_RP_ID;
+  const rpName = process.env.WEBAUTHN_RP_NAME ?? "Tanren";
+  const origin = process.env.WEBAUTHN_ORIGIN;
+  if (!rpID || !origin) {
+    throw new Error("WEBAUTHN_RP_ID / WEBAUTHN_ORIGIN is not set");
+  }
+  return { rpID, rpName, origin };
+}
+
+export function isPasskeyEnabled(): boolean {
+  return Boolean(process.env.WEBAUTHN_RP_ID && process.env.WEBAUTHN_ORIGIN);
+}
+
+async function saveChallenge(params: {
+  userId: string | null;
+  challenge: string;
+  purpose: "register" | "authenticate";
+}) {
+  const id = randomUUID();
+  await getDb()
+    .insert(challengesTable)
+    .values({
+      id,
+      userId: params.userId,
+      challenge: params.challenge,
+      purpose: params.purpose,
+      expiresAt: new Date(Date.now() + WEBAUTHN_CHALLENGE_TTL_MS),
+    });
+  return id;
+}
+
+async function consumeChallenge(params: {
+  id: string;
+  purpose: "register" | "authenticate";
+}): Promise<string | null> {
+  const db = getDb();
+  const rows = await db
+    .select()
+    .from(challengesTable)
+    .where(
+      and(
+        eq(challengesTable.id, params.id),
+        eq(challengesTable.purpose, params.purpose),
+        gt(challengesTable.expiresAt, new Date()),
+      ),
+    )
+    .limit(1);
+
+  const row = rows[0];
+  if (!row) return null;
+
+  await db.delete(challengesTable).where(eq(challengesTable.id, params.id));
+  return row.challenge;
+}
+
+// ───────────────────────────────── Registration ─────────────────────────────────
+
+export async function buildRegistrationOptions(params: { userId: string; userName: string }) {
+  const { rpID, rpName } = rpConfig();
+  const existing = await getDb()
+    .select({ id: credentialsTable.id, transports: credentialsTable.transports })
+    .from(credentialsTable)
+    .where(eq(credentialsTable.userId, params.userId));
+
+  const options = await generateRegistrationOptions({
+    rpName,
+    rpID,
+    userName: params.userName,
+    userID: Buffer.from(params.userId),
+    attestationType: "none",
+    authenticatorSelection: {
+      residentKey: "preferred",
+      userVerification: "preferred",
+    },
+    excludeCredentials: existing.map((c) => ({
+      id: c.id,
+      transports: (c.transports ?? undefined) as AuthenticatorTransportFuture[] | undefined,
+    })),
+  });
+
+  const challengeId = await saveChallenge({
+    userId: params.userId,
+    challenge: options.challenge,
+    purpose: "register",
+  });
+
+  return { options, challengeId };
+}
+
+export async function verifyRegistration(params: {
+  userId: string;
+  challengeId: string;
+  response: RegistrationResponseJSON;
+  nickname?: string;
+}) {
+  const { rpID, origin } = rpConfig();
+  const expectedChallenge = await consumeChallenge({
+    id: params.challengeId,
+    purpose: "register",
+  });
+  if (!expectedChallenge) {
+    throw new Error("Challenge not found or expired");
+  }
+
+  const verification = await verifyRegistrationResponse({
+    response: params.response,
+    expectedChallenge,
+    expectedOrigin: origin,
+    expectedRPID: rpID,
+    requireUserVerification: false,
+  });
+
+  if (!verification.verified || !verification.registrationInfo) {
+    throw new Error("Registration verification failed");
+  }
+
+  const { credential, credentialDeviceType, credentialBackedUp } = verification.registrationInfo;
+
+  await getDb()
+    .insert(credentialsTable)
+    .values({
+      id: credential.id,
+      userId: params.userId,
+      publicKey: credential.publicKey,
+      counter: BigInt(credential.counter),
+      deviceType: credentialDeviceType as CredentialDeviceType,
+      backedUp: credentialBackedUp,
+      transports: (credential.transports as AuthenticatorTransportFuture[] | undefined) ?? [],
+      nickname: params.nickname,
+    });
+
+  return { credentialId: credential.id };
+}
+
+// ─────────────────────────────── Authentication ────────────────────────────────
+
+export async function buildAuthenticationOptions() {
+  const { rpID } = rpConfig();
+  const options = await generateAuthenticationOptions({
+    rpID,
+    userVerification: "preferred",
+  });
+
+  const challengeId = await saveChallenge({
+    userId: null,
+    challenge: options.challenge,
+    purpose: "authenticate",
+  });
+
+  return { options, challengeId };
+}
+
+export async function verifyAuthentication(params: {
+  challengeId: string;
+  response: AuthenticationResponseJSON;
+}) {
+  const { rpID, origin } = rpConfig();
+  const expectedChallenge = await consumeChallenge({
+    id: params.challengeId,
+    purpose: "authenticate",
+  });
+  if (!expectedChallenge) {
+    throw new Error("Challenge not found or expired");
+  }
+
+  const db = getDb();
+  const credentialId = params.response.id;
+  const rows = await db
+    .select()
+    .from(credentialsTable)
+    .innerJoin(usersTable, eq(usersTable.id, credentialsTable.userId))
+    .where(eq(credentialsTable.id, credentialId))
+    .limit(1);
+
+  const found = rows[0];
+  if (!found) {
+    throw new Error("Unknown credential");
+  }
+
+  const verification = await verifyAuthenticationResponse({
+    response: params.response,
+    expectedChallenge,
+    expectedOrigin: origin,
+    expectedRPID: rpID,
+    credential: {
+      id: found.credentials.id,
+      // ArrayBufferLike → ArrayBuffer (bytea 由来の Buffer view が SharedArrayBuffer を含まない前提で安全に narrow)
+      publicKey: new Uint8Array(found.credentials.publicKey),
+      counter: Number(found.credentials.counter),
+      transports:
+        (found.credentials.transports as AuthenticatorTransportFuture[] | null) ?? undefined,
+    },
+    requireUserVerification: false,
+  });
+
+  if (!verification.verified) {
+    throw new Error("Authentication verification failed");
+  }
+
+  await db
+    .update(credentialsTable)
+    .set({
+      counter: BigInt(verification.authenticationInfo.newCounter),
+      lastUsedAt: new Date(),
+    })
+    .where(eq(credentialsTable.id, credentialId));
+
+  return { user: found.users, credentialId };
+}

--- a/src/server/auth/webauthn.ts
+++ b/src/server/auth/webauthn.ts
@@ -11,7 +11,7 @@ import type {
   AuthenticatorTransportFuture,
   RegistrationResponseJSON,
 } from "@simplewebauthn/server";
-import { and, eq, gt } from "drizzle-orm";
+import { and, eq, gt, isNull } from "drizzle-orm";
 
 import { getDb } from "@/db/client";
 import {
@@ -56,28 +56,33 @@ async function saveChallenge(params: {
   return id;
 }
 
+/**
+ * challenge を原子的に消費する。DELETE ... RETURNING 1 ステートメントで実装。
+ * `expectedUserId` を渡すと、challenge 発行時に束縛した userId と一致しない場合に失敗する。
+ */
 async function consumeChallenge(params: {
   id: string;
   purpose: "register" | "authenticate";
+  expectedUserId?: string | null;
 }): Promise<string | null> {
   const db = getDb();
-  const rows = await db
-    .select()
-    .from(challengesTable)
-    .where(
-      and(
-        eq(challengesTable.id, params.id),
-        eq(challengesTable.purpose, params.purpose),
-        gt(challengesTable.expiresAt, new Date()),
-      ),
-    )
-    .limit(1);
+  const predicates = [
+    eq(challengesTable.id, params.id),
+    eq(challengesTable.purpose, params.purpose),
+    gt(challengesTable.expiresAt, new Date()),
+  ];
+  if (params.expectedUserId === null) {
+    predicates.push(isNull(challengesTable.userId));
+  } else if (params.expectedUserId !== undefined) {
+    predicates.push(eq(challengesTable.userId, params.expectedUserId));
+  }
 
-  const row = rows[0];
-  if (!row) return null;
+  const deleted = await db
+    .delete(challengesTable)
+    .where(and(...predicates))
+    .returning({ challenge: challengesTable.challenge });
 
-  await db.delete(challengesTable).where(eq(challengesTable.id, params.id));
-  return row.challenge;
+  return deleted[0]?.challenge ?? null;
 }
 
 // ───────────────────────────────── Registration ─────────────────────────────────
@@ -121,9 +126,11 @@ export async function verifyRegistration(params: {
   nickname?: string;
 }) {
   const { rpID, origin } = rpConfig();
+  // userId も一致条件に含めて、challenge の取り違えによる別ユーザーへの credential 紐付けを防ぐ
   const expectedChallenge = await consumeChallenge({
     id: params.challengeId,
     purpose: "register",
+    expectedUserId: params.userId,
   });
   if (!expectedChallenge) {
     throw new Error("Challenge not found or expired");
@@ -182,6 +189,7 @@ export async function verifyAuthentication(params: {
   response: AuthenticationResponseJSON;
 }) {
   const { rpID, origin } = rpConfig();
+  // authenticate は発行時 userId=null で束縛対象がないため、expectedUserId は渡さない
   const expectedChallenge = await consumeChallenge({
     id: params.challengeId,
     purpose: "authenticate",

--- a/src/server/trpc/init.ts
+++ b/src/server/trpc/init.ts
@@ -1,18 +1,26 @@
 import { initTRPC, TRPCError } from "@trpc/server";
+import { cookies } from "next/headers";
 
 import type { User } from "@/db/schema";
+import { resolveSession } from "@/server/auth/session";
 
 /**
- * tRPC 用のリクエストコンテキスト。
- * 認証は issue #6 で実装するため、ここでは `user` 欄のみ定義して
- * 中身は空 (anonymous) で埋める。
+ * tRPC 用のリクエストコンテキスト。cookie → sessions_auth → users の解決結果を `user` に入れる。
  */
 export type TrpcContext = {
   user: User | null;
 };
 
 export async function createTrpcContext(): Promise<TrpcContext> {
-  return { user: null };
+  try {
+    const store = await cookies();
+    const resolved = await resolveSession(store);
+    return { user: resolved?.user ?? null };
+  } catch {
+    // cookies() は Server Action や一部 edge ランタイムで使えないケースがある。
+    // その場合は未ログイン扱いにフォールバックして呼び出し元に委ねる。
+    return { user: null };
+  }
 }
 
 const t = initTRPC.context<TrpcContext>().create();
@@ -21,16 +29,12 @@ export const router = t.router;
 export const publicProcedure = t.procedure;
 
 /**
- * protected procedure のスタブ。
- * Passkey 認証 (issue #6) が入るまでは常に UNAUTHORIZED を返し、
- * ダウンストリームが「ここで cookie → user が注入される」前提で書ける。
+ * 認証必須の procedure。
+ * `createTrpcContext` で cookie 由来の user が ctx に入る前提で、未ログインなら UNAUTHORIZED。
  */
 export const protectedProcedure = publicProcedure.use(({ ctx, next }) => {
   if (!ctx.user) {
-    throw new TRPCError({
-      code: "UNAUTHORIZED",
-      message: "Passkey auth is not yet wired (issue #6)",
-    });
+    throw new TRPCError({ code: "UNAUTHORIZED", message: "Not signed in" });
   }
   return next({ ctx: { ...ctx, user: ctx.user } });
 });

--- a/src/server/trpc/init.ts
+++ b/src/server/trpc/init.ts
@@ -2,6 +2,7 @@ import { initTRPC, TRPCError } from "@trpc/server";
 import { cookies } from "next/headers";
 
 import type { User } from "@/db/schema";
+import { DEV_SESSION_COOKIE_NAME, SESSION_COOKIE_NAME } from "@/server/auth/constants";
 import { resolveSession } from "@/server/auth/session";
 
 /**
@@ -15,10 +16,37 @@ export async function createTrpcContext(): Promise<TrpcContext> {
   try {
     const store = await cookies();
     const resolved = await resolveSession(store);
-    return { user: resolved?.user ?? null };
+    if (!resolved) return { user: null };
+
+    // 30 日 sliding: 延長された expiresAt で cookie を再発行 (失敗は握りつぶす)
+    try {
+      if (resolved.kind === "passkey") {
+        store.set({
+          name: SESSION_COOKIE_NAME,
+          value: resolved.sessionId,
+          httpOnly: true,
+          secure: true,
+          sameSite: "lax",
+          path: "/",
+          expires: resolved.expiresAt,
+        });
+      } else {
+        store.set({
+          name: DEV_SESSION_COOKIE_NAME,
+          value: resolved.sessionId,
+          httpOnly: true,
+          sameSite: "lax",
+          path: "/",
+          expires: resolved.expiresAt,
+          secure: process.env.NODE_ENV === "production",
+        });
+      }
+    } catch {
+      // Server Component から呼ばれた場合など store.set が不可のケース。DB 側は既に延長済み
+    }
+
+    return { user: resolved.user };
   } catch {
-    // cookies() は Server Action や一部 edge ランタイムで使えないケースがある。
-    // その場合は未ログイン扱いにフォールバックして呼び出し元に委ねる。
     return { user: null };
   }
 }
@@ -29,8 +57,8 @@ export const router = t.router;
 export const publicProcedure = t.procedure;
 
 /**
- * 認証必須の procedure。
- * `createTrpcContext` で cookie 由来の user が ctx に入る前提で、未ログインなら UNAUTHORIZED。
+ * 認証必須の procedure。`createTrpcContext` で cookie 由来の user が入る前提で
+ * 未ログインなら UNAUTHORIZED。
  */
 export const protectedProcedure = publicProcedure.use(({ ctx, next }) => {
   if (!ctx.user) {

--- a/src/server/trpc/init.ts
+++ b/src/server/trpc/init.ts
@@ -2,8 +2,7 @@ import { initTRPC, TRPCError } from "@trpc/server";
 import { cookies } from "next/headers";
 
 import type { User } from "@/db/schema";
-import { DEV_SESSION_COOKIE_NAME, SESSION_COOKIE_NAME } from "@/server/auth/constants";
-import { resolveSession } from "@/server/auth/session";
+import { refreshSessionCookie, resolveSession } from "@/server/auth/session";
 
 /**
  * tRPC 用のリクエストコンテキスト。cookie → sessions_auth → users の解決結果を `user` に入れる。
@@ -17,34 +16,8 @@ export async function createTrpcContext(): Promise<TrpcContext> {
     const store = await cookies();
     const resolved = await resolveSession(store);
     if (!resolved) return { user: null };
-
-    // 30 日 sliding: 延長された expiresAt で cookie を再発行 (失敗は握りつぶす)
-    try {
-      if (resolved.kind === "passkey") {
-        store.set({
-          name: SESSION_COOKIE_NAME,
-          value: resolved.sessionId,
-          httpOnly: true,
-          secure: true,
-          sameSite: "lax",
-          path: "/",
-          expires: resolved.expiresAt,
-        });
-      } else {
-        store.set({
-          name: DEV_SESSION_COOKIE_NAME,
-          value: resolved.sessionId,
-          httpOnly: true,
-          sameSite: "lax",
-          path: "/",
-          expires: resolved.expiresAt,
-          secure: process.env.NODE_ENV === "production",
-        });
-      }
-    } catch {
-      // Server Component から呼ばれた場合など store.set が不可のケース。DB 側は既に延長済み
-    }
-
+    // 30 日 sliding: 延長された expiresAt で cookie を再発行
+    refreshSessionCookie(store, resolved);
     return { user: resolved.user };
   } catch {
     return { user: null };


### PR DESCRIPTION
## Summary
Issue #6 を解決。ADR-0004 に沿って Passkey (WebAuthn) + 自前セッション cookie を実装。

### サーバー
- `src/server/auth/`
  - `constants.ts` — `__Host-tanren_session`, `SESSION_MAX_AGE_MS`, チャレンジ TTL
  - `session.ts` — createSession / resolveSession (sliding expiry) / destroySession / getCurrentUser
  - `webauthn.ts` — SimpleWebAuthn ラッパ (`buildRegistrationOptions`, `verifyRegistration`, `buildAuthenticationOptions`, `verifyAuthentication`)
  - `dev-login.ts` — Preview などで RP_ID 未設定の単一ユーザ自動ログイン
  - `bootstrap.ts` — `pnpm auth:bootstrap <email>` CLI (idempotent)

### Route Handlers
- `/api/auth/register/options` `/api/auth/register/verify`
- `/api/auth/authenticate/options` `/api/auth/authenticate/verify` (cookie 発行)
- `/api/auth/logout` / `/api/auth/dev-login`

### tRPC
- `createTrpcContext` が cookie → `resolveSession` で `ctx.user` を注入
- `protectedProcedure` のスタブを外して実稼働

## 受け入れ基準 (issue #6)
- [x] `src/server/auth/` に SimpleWebAuthn ラッパ (register/authenticate の options + verify)
- [x] `/api/auth/*` Route Handlers
- [x] cookie `__Host-tanren_session` (HttpOnly/Secure/SameSite=Lax) の発行と検証
- [x] `sessions_auth` の CRUD + 30 日 sliding 有効期限
- [x] `protectedProcedure` が cookie 検証 → `ctx.user` 注入
- [x] `pnpm run auth:bootstrap` で初期 user 登録 CLI
- [x] Preview (WEBAUTHN_RP_ID 未設定) での dev 自動ログイン
- [x] 基本 unit test (cookie 無し / 期限切れ / 有効)

Closes #6

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm test -- --run` (24 pass)
- [x] `pnpm build` (全 Route Handler が動的 route として生成)

🤖 Generated with [Claude Code](https://claude.com/claude-code)