### PR TITLE
feat(generator): OpenAI client + mcq 問題生成

### DIFF
--- a/prompts/generation/mcq.v1.md
+++ b/prompts/generation/mcq.v1.md
@@ -1,0 +1,44 @@
+# mcq.v1
+
+multiple-choice question を生成するプロンプト。
+共通 prefix は先頭に置き、prompt caching (OpenAI 自動) が効くようにする (CLAUDE.md §4.5)。
+
+---
+
+## system
+
+You are a senior engineer creating a multiple-choice quiz question for a professional software engineer.
+Output strictly as JSON matching the provided schema. Use 日本語 (Japanese) for all human-readable fields.
+
+## user (テンプレ変数は `{}` で囲む)
+
+## Concept
+
+id: {concept.id}
+name: {concept.name}
+description: {concept.description}
+domain: {concept.domainId}
+subdomain: {concept.subdomainId}
+
+## Spec
+
+difficulty: {difficulty}
+thinking_style: {thinking_style}
+
+## Style instruction
+
+{styleInstruction}
+
+## Avoid duplicates
+
+Past recent framings for this concept (last 30 days, if any):
+{pastQuestionsSummary}
+
+## Output requirements
+
+- `prompt` (string): 日本語の問題文
+- `answer` (string): 正解の 1 文 (他の distractors と区別できる決定的な選択肢)
+- `distractors` (string[]): 不正解候補を 3 つ。正解と紛らわしいが明らかに誤り
+- `explanation` (string): なぜ answer が正しく、distractors が誤りかを簡潔に日本語で説明
+- `hint` (string | null): 解答前に 1 回だけ表示できる軽いヒント (Optional)
+- `tags` (string[]): 1〜4 個の短い英語タグ (domain.subdomain を含めない)

--- a/prompts/generation/mcq.v1.md
+++ b/prompts/generation/mcq.v1.md
@@ -1,7 +1,8 @@
 # mcq.v1
 
 multiple-choice question を生成するプロンプト。
-共通 prefix (system + セクション見出し) が先頭に来て OpenAI の prompt caching が効く形にする (CLAUDE.md §4.5)。
+OpenAI の prompt caching が効くよう、固定テキスト (Output requirements) を `user` 冒頭に置き、
+可変値 (`## Concept` など) は末尾にまとめる (CLAUDE.md §4.5)。
 
 テンプレ変数は `{{ camelCase }}` で囲む。`src/server/generator/prompts.ts` の `buildMcqPrompt` が
 このファイルを読み込んで HTML コメント `<!-- role:system -->` / `<!-- role:user -->` で囲まれた
@@ -18,29 +19,7 @@ Output strictly as JSON matching the provided schema. Use 日本語 (Japanese) f
 
 <!-- role:user -->
 
-## Concept
-
-id: {{ conceptId }}
-name: {{ conceptName }}
-description: {{ conceptDescription }}
-domain: {{ domainId }}
-subdomain: {{ subdomainId }}
-
-## Spec
-
-difficulty: {{ difficulty }}
-thinking_style: {{ thinkingStyle }}
-
-## Style instruction
-
-{{ styleInstruction }}
-
-## Avoid duplicates
-
-Past recent framings for this concept (last 30 days, if any):
-{{ pastQuestionsSummary }}
-
-## Output requirements
+## Output requirements (固定)
 
 - `prompt` (string): 日本語の問題文
 - `answer` (string): 正解の 1 文 (他の distractors と区別できる決定的な選択肢)
@@ -48,5 +27,27 @@ Past recent framings for this concept (last 30 days, if any):
 - `explanation` (string): なぜ answer が正しく、distractors が誤りかを簡潔に日本語で説明
 - `hint` (string | null): 解答前に 1 回だけ表示できる軽いヒント (Optional)
 - `tags` (string[]): 1〜4 個の短い英語タグ (domain.subdomain を含めない)
+
+## Concept (可変)
+
+id: {{ conceptId }}
+name: {{ conceptName }}
+description: {{ conceptDescription }}
+domain: {{ domainId }}
+subdomain: {{ subdomainId }}
+
+## Spec (可変)
+
+difficulty: {{ difficulty }}
+thinking_style: {{ thinkingStyle }}
+
+## Style instruction (可変)
+
+{{ styleInstruction }}
+
+## Avoid duplicates (可変)
+
+Past recent framings for this concept (last 30 days, if any):
+{{ pastQuestionsSummary }}
 
 <!-- /role -->

--- a/prompts/generation/mcq.v1.md
+++ b/prompts/generation/mcq.v1.md
@@ -1,38 +1,41 @@
 # mcq.v1
 
 multiple-choice question を生成するプロンプト。
-共通 prefix は先頭に置き、prompt caching (OpenAI 自動) が効くようにする (CLAUDE.md §4.5)。
+共通 prefix (system + セクション見出し) が先頭に来て OpenAI の prompt caching が効く形にする (CLAUDE.md §4.5)。
+
+テンプレ変数は `{{ camelCase }}` で囲む。`src/server/generator/prompts.ts` の `buildMcqPrompt` が
+このファイルを読み込んで `{{ }}` を置換する (テンプレ文字列の直書き禁止)。
 
 ---
 
-## system
-
+::: system
 You are a senior engineer creating a multiple-choice quiz question for a professional software engineer.
 Output strictly as JSON matching the provided schema. Use 日本語 (Japanese) for all human-readable fields.
+:::
 
-## user (テンプレ変数は `{}` で囲む)
+::: user
 
 ## Concept
 
-id: {concept.id}
-name: {concept.name}
-description: {concept.description}
-domain: {concept.domainId}
-subdomain: {concept.subdomainId}
+id: {{ conceptId }}
+name: {{ conceptName }}
+description: {{ conceptDescription }}
+domain: {{ domainId }}
+subdomain: {{ subdomainId }}
 
 ## Spec
 
-difficulty: {difficulty}
-thinking_style: {thinking_style}
+difficulty: {{ difficulty }}
+thinking_style: {{ thinkingStyle }}
 
 ## Style instruction
 
-{styleInstruction}
+{{ styleInstruction }}
 
 ## Avoid duplicates
 
 Past recent framings for this concept (last 30 days, if any):
-{pastQuestionsSummary}
+{{ pastQuestionsSummary }}
 
 ## Output requirements
 
@@ -42,3 +45,4 @@ Past recent framings for this concept (last 30 days, if any):
 - `explanation` (string): なぜ answer が正しく、distractors が誤りかを簡潔に日本語で説明
 - `hint` (string | null): 解答前に 1 回だけ表示できる軽いヒント (Optional)
 - `tags` (string[]): 1〜4 個の短い英語タグ (domain.subdomain を含めない)
+  :::

--- a/prompts/generation/mcq.v1.md
+++ b/prompts/generation/mcq.v1.md
@@ -4,16 +4,19 @@ multiple-choice question を生成するプロンプト。
 共通 prefix (system + セクション見出し) が先頭に来て OpenAI の prompt caching が効く形にする (CLAUDE.md §4.5)。
 
 テンプレ変数は `{{ camelCase }}` で囲む。`src/server/generator/prompts.ts` の `buildMcqPrompt` が
-このファイルを読み込んで `{{ }}` を置換する (テンプレ文字列の直書き禁止)。
+このファイルを読み込んで HTML コメント `<!-- role:system -->` / `<!-- role:user -->` で囲まれた
+ブロックを抽出し、`{{ }}` を置換する (テンプレ文字列の直書き禁止)。
 
 ---
 
-::: system
+<!-- role:system -->
+
 You are a senior engineer creating a multiple-choice quiz question for a professional software engineer.
 Output strictly as JSON matching the provided schema. Use 日本語 (Japanese) for all human-readable fields.
-:::
 
-::: user
+<!-- /role -->
+
+<!-- role:user -->
 
 ## Concept
 
@@ -45,4 +48,5 @@ Past recent framings for this concept (last 30 days, if any):
 - `explanation` (string): なぜ answer が正しく、distractors が誤りかを簡潔に日本語で説明
 - `hint` (string | null): 解答前に 1 回だけ表示できる軽いヒント (Optional)
 - `tags` (string[]): 1〜4 個の短い英語タグ (domain.subdomain を含めない)
-  :::
+
+<!-- /role -->

--- a/src/lib/openai/client.ts
+++ b/src/lib/openai/client.ts
@@ -1,0 +1,14 @@
+import OpenAI from "openai";
+
+import { env } from "@/lib/env";
+
+let cached: OpenAI | undefined;
+
+/**
+ * OpenAI SDK のシングルトン。ドメインロジックから `openai.*` を直接呼ばず、
+ * 必ず src/server/generator / src/server/grader 等のラッパ経由で使うこと (CLAUDE.md §4.6)。
+ */
+export function getOpenAI(): OpenAI {
+  cached ??= new OpenAI({ apiKey: env.openaiApiKey() });
+  return cached;
+}

--- a/src/lib/openai/models.ts
+++ b/src/lib/openai/models.ts
@@ -1,0 +1,8 @@
+/**
+ * OpenAI モデル ID の定数。docs/03-ai-strategy.md §3.0 が真実の源。
+ * モデル名が更新されたらここを一箇所だけ直す (文字列リテラル散在禁止)。
+ */
+export const MODEL_MAIN = "gpt-5" as const;
+export const MODEL_CHEAP = "gpt-5-mini" as const;
+
+export type OpenAIModelId = typeof MODEL_MAIN | typeof MODEL_CHEAP;

--- a/src/server/generator/cache.ts
+++ b/src/server/generator/cache.ts
@@ -1,0 +1,60 @@
+import { and, desc, eq, gte, isNull, sql } from "drizzle-orm";
+
+import type { Db } from "@/db/client";
+import {
+  questions,
+  type DifficultyLevel,
+  type Question,
+  type QuestionType,
+  type ThinkingStyle,
+} from "@/db/schema";
+
+export type CacheLookupInput = {
+  conceptId: string;
+  type: QuestionType;
+  thinkingStyle: ThinkingStyle | null;
+  difficulty: DifficultyLevel;
+  /** 直近 N 日 (default 30) の生成済みから返す */
+  recentDays?: number;
+};
+
+/**
+ * docs/03-ai-strategy.md §3.3.1 のキャッシュ検索。
+ * 同じ (concept, type, style, difficulty) の問題で、retired=false かつ
+ * 直近 N 日以内に生成されていて、serve_count が少ない順に 1 件返す。
+ * 「未使用を優先」するため last_served_at が null のものを先に。
+ */
+export async function findCachedQuestion(
+  db: Db,
+  input: CacheLookupInput,
+): Promise<Question | null> {
+  const windowDays = input.recentDays ?? 30;
+  const since = new Date(Date.now() - windowDays * 24 * 60 * 60 * 1000);
+
+  const predicates = [
+    eq(questions.conceptId, input.conceptId),
+    eq(questions.type, input.type),
+    eq(questions.difficulty, input.difficulty),
+    eq(questions.retired, false),
+    gte(questions.createdAt, since),
+  ];
+  predicates.push(
+    input.thinkingStyle === null
+      ? isNull(questions.thinkingStyle)
+      : eq(questions.thinkingStyle, input.thinkingStyle),
+  );
+
+  const rows = await db
+    .select()
+    .from(questions)
+    .where(and(...predicates))
+    // 未使用 (last_served_at IS NULL) を優先、次に使用回数が少ない順
+    .orderBy(
+      sql`${questions.lastServedAt} IS NULL DESC`,
+      questions.serveCount,
+      desc(questions.createdAt),
+    )
+    .limit(1);
+
+  return rows[0] ?? null;
+}

--- a/src/server/generator/mcq.ts
+++ b/src/server/generator/mcq.ts
@@ -1,4 +1,4 @@
-import { eq } from "drizzle-orm";
+import { eq, sql } from "drizzle-orm";
 
 import { getDb } from "@/db/client";
 import {
@@ -89,7 +89,19 @@ export async function generateMcq(
       thinkingStyle: input.thinkingStyle,
       difficulty: input.difficulty,
     });
-    if (cached) return { question: cached, source: "cache" };
+    if (cached) {
+      // キャッシュローテーション: serve_count を増やし last_served_at を更新することで、
+      // 次回は未使用 (last_served_at IS NULL) の別問題が優先され、30d 内に出題が分散する
+      const [updated] = await db
+        .update(questions)
+        .set({
+          serveCount: sql`${questions.serveCount} + 1`,
+          lastServedAt: new Date(),
+        })
+        .where(eq(questions.id, cached.id))
+        .returning();
+      return { question: updated ?? cached, source: "cache" };
+    }
   }
 
   const concept = await loadConcept(input.conceptId);
@@ -103,6 +115,7 @@ export async function generateMcq(
 
   const generated = await llm({ model: MODEL_MAIN, system, user });
 
+  const now = new Date();
   const [inserted] = await db
     .insert(questions)
     .values({
@@ -118,6 +131,9 @@ export async function generateMcq(
       tags: generated.tags,
       generatedBy: MODEL_MAIN,
       promptVersion: MCQ_PROMPT_VERSION,
+      // 新規問題は出題時点で配信済みとマークする (次回は別問題が未使用として優先される)
+      serveCount: 1,
+      lastServedAt: now,
     })
     .returning();
 

--- a/src/server/generator/mcq.ts
+++ b/src/server/generator/mcq.ts
@@ -1,4 +1,4 @@
-import { eq, sql } from "drizzle-orm";
+import { and, desc, eq, gte, sql } from "drizzle-orm";
 
 import { getDb } from "@/db/client";
 import {
@@ -29,12 +29,20 @@ export type GenerateMcqResult = {
   source: "cache" | "generated";
 };
 
-/** 直近出題の要約文 (重複回避ヒント用) */
+/** 直近 30 日の出題要約文 (prompt の重複回避ヒント用、retired を除外して新しい順) */
 async function fetchPastSummaries(conceptId: string, max = 5): Promise<string[]> {
+  const since = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
   const rows = await getDb()
     .select({ prompt: questions.prompt })
     .from(questions)
-    .where(eq(questions.conceptId, conceptId))
+    .where(
+      and(
+        eq(questions.conceptId, conceptId),
+        eq(questions.retired, false),
+        gte(questions.createdAt, since),
+      ),
+    )
+    .orderBy(desc(questions.createdAt))
     .limit(max);
   return rows.map((r) => r.prompt.slice(0, 60)).filter(Boolean);
 }
@@ -44,6 +52,47 @@ async function loadConcept(conceptId: string): Promise<Concept> {
   const row = rows[0];
   if (!row) throw new Error(`unknown concept: ${conceptId}`);
   return row;
+}
+
+/** この concept で許可されている難易度以外を指定されたら弾く (questions テーブルの汚染防止) */
+function assertDifficultyAllowed(concept: Concept, difficulty: DifficultyLevel): void {
+  const allowed = concept.difficultyLevels;
+  if (!allowed.includes(difficulty)) {
+    throw new Error(
+      `difficulty ${difficulty} is not allowed for concept ${concept.id} (allowed: ${allowed.join(",")})`,
+    );
+  }
+}
+
+/**
+ * 最小キャッシュ件数。cache 件数が MIN_CACHE_COUNT 未満のときは必ず新規生成して
+ * キャッシュを育てる。以降は 50/50 で cache hit / 新規生成を分岐 (docs/03 §3.3.4)。
+ */
+const MIN_CACHE_COUNT = 3;
+const FRESH_GENERATION_RATIO = 0.5;
+
+async function countCachedQuestions(params: {
+  conceptId: string;
+  difficulty: DifficultyLevel;
+  thinkingStyle: ThinkingStyle | null;
+}): Promise<number> {
+  const since = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+  const db = getDb();
+  const predicates = [
+    eq(questions.conceptId, params.conceptId),
+    eq(questions.type, "mcq"),
+    eq(questions.difficulty, params.difficulty),
+    eq(questions.retired, false),
+    gte(questions.createdAt, since),
+  ];
+  if (params.thinkingStyle) {
+    predicates.push(eq(questions.thinkingStyle, params.thinkingStyle));
+  }
+  const rows = await db
+    .select({ count: sql<number>`count(*)::int` })
+    .from(questions)
+    .where(and(...predicates));
+  return rows[0]?.count ?? 0;
 }
 
 /**
@@ -81,30 +130,41 @@ export async function generateMcq(
   llm: McqLlmCaller = defaultMcqLlm,
 ): Promise<GenerateMcqResult> {
   const db = getDb();
+  const concept = await loadConcept(input.conceptId);
+  assertDifficultyAllowed(concept, input.difficulty);
 
   if (!input.forceFresh) {
-    const cached = await findCachedQuestion(db, {
+    // キャッシュが十分育っていれば 50/50 で cache hit / 新規生成を選ぶ (docs/03 §3.3.4)
+    const cacheCount = await countCachedQuestions({
       conceptId: input.conceptId,
-      type: "mcq",
-      thinkingStyle: input.thinkingStyle,
       difficulty: input.difficulty,
+      thinkingStyle: input.thinkingStyle,
     });
-    if (cached) {
-      // キャッシュローテーション: serve_count を増やし last_served_at を更新することで、
-      // 次回は未使用 (last_served_at IS NULL) の別問題が優先され、30d 内に出題が分散する
-      const [updated] = await db
-        .update(questions)
-        .set({
-          serveCount: sql`${questions.serveCount} + 1`,
-          lastServedAt: new Date(),
-        })
-        .where(eq(questions.id, cached.id))
-        .returning();
-      return { question: updated ?? cached, source: "cache" };
+    const useCache = cacheCount >= MIN_CACHE_COUNT && Math.random() >= FRESH_GENERATION_RATIO;
+
+    if (useCache) {
+      const cached = await findCachedQuestion(db, {
+        conceptId: input.conceptId,
+        type: "mcq",
+        thinkingStyle: input.thinkingStyle,
+        difficulty: input.difficulty,
+      });
+      if (cached) {
+        // キャッシュローテーション: serve_count を増やし last_served_at を更新することで、
+        // 次回は未使用 (last_served_at IS NULL) の別問題が優先され、30d 内に出題が分散する
+        const [updated] = await db
+          .update(questions)
+          .set({
+            serveCount: sql`${questions.serveCount} + 1`,
+            lastServedAt: new Date(),
+          })
+          .where(eq(questions.id, cached.id))
+          .returning();
+        return { question: updated ?? cached, source: "cache" };
+      }
     }
   }
 
-  const concept = await loadConcept(input.conceptId);
   const past = await fetchPastSummaries(input.conceptId);
   const { system, user } = buildMcqPrompt({
     concept,

--- a/src/server/generator/mcq.ts
+++ b/src/server/generator/mcq.ts
@@ -1,3 +1,4 @@
+import { TRPCError } from "@trpc/server";
 import { and, desc, eq, gte, isNull, sql } from "drizzle-orm";
 
 import { getDb } from "@/db/client";
@@ -50,7 +51,12 @@ async function fetchPastSummaries(conceptId: string, max = 5): Promise<string[]>
 async function loadConcept(conceptId: string): Promise<Concept> {
   const rows = await getDb().select().from(concepts).where(eq(concepts.id, conceptId)).limit(1);
   const row = rows[0];
-  if (!row) throw new Error(`unknown concept: ${conceptId}`);
+  if (!row) {
+    throw new TRPCError({
+      code: "NOT_FOUND",
+      message: `Unknown concept: ${conceptId}`,
+    });
+  }
   return row;
 }
 
@@ -58,9 +64,10 @@ async function loadConcept(conceptId: string): Promise<Concept> {
 function assertDifficultyAllowed(concept: Concept, difficulty: DifficultyLevel): void {
   const allowed = concept.difficultyLevels;
   if (!allowed.includes(difficulty)) {
-    throw new Error(
-      `difficulty ${difficulty} is not allowed for concept ${concept.id} (allowed: ${allowed.join(",")})`,
-    );
+    throw new TRPCError({
+      code: "BAD_REQUEST",
+      message: `difficulty "${difficulty}" is not allowed for concept ${concept.id} (allowed: ${allowed.join(", ")})`,
+    });
   }
 }
 

--- a/src/server/generator/mcq.ts
+++ b/src/server/generator/mcq.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, gte, sql } from "drizzle-orm";
+import { and, desc, eq, gte, isNull, sql } from "drizzle-orm";
 
 import { getDb } from "@/db/client";
 import {
@@ -85,9 +85,13 @@ async function countCachedQuestions(params: {
     eq(questions.retired, false),
     gte(questions.createdAt, since),
   ];
-  if (params.thinkingStyle) {
-    predicates.push(eq(questions.thinkingStyle, params.thinkingStyle));
-  }
+  // thinkingStyle の null/値 ともに lookup (findCachedQuestion) と同じキーで絞る。
+  // 片側だけ合算すると MIN_CACHE_COUNT 判定が崩れて 50/50 分岐が早まる。
+  predicates.push(
+    params.thinkingStyle === null
+      ? isNull(questions.thinkingStyle)
+      : eq(questions.thinkingStyle, params.thinkingStyle),
+  );
   const rows = await db
     .select({ count: sql<number>`count(*)::int` })
     .from(questions)

--- a/src/server/generator/mcq.ts
+++ b/src/server/generator/mcq.ts
@@ -1,0 +1,126 @@
+import { eq } from "drizzle-orm";
+
+import { getDb } from "@/db/client";
+import {
+  concepts,
+  questions,
+  type Concept,
+  type DifficultyLevel,
+  type Question,
+  type ThinkingStyle,
+} from "@/db/schema";
+import { getOpenAI } from "@/lib/openai/client";
+import { MODEL_MAIN } from "@/lib/openai/models";
+
+import { findCachedQuestion } from "./cache";
+import { buildMcqPrompt, MCQ_PROMPT_VERSION } from "./prompts";
+import { GeneratedMcqSchema, MCQ_JSON_SCHEMA, type GeneratedMcq } from "./schema";
+
+export type GenerateMcqInput = {
+  conceptId: string;
+  difficulty: DifficultyLevel;
+  thinkingStyle: ThinkingStyle | null;
+  /** true のときキャッシュを使わず必ず新規生成 (開発用) */
+  forceFresh?: boolean;
+};
+
+export type GenerateMcqResult = {
+  question: Question;
+  source: "cache" | "generated";
+};
+
+/** 直近出題の要約文 (重複回避ヒント用) */
+async function fetchPastSummaries(conceptId: string, max = 5): Promise<string[]> {
+  const rows = await getDb()
+    .select({ prompt: questions.prompt })
+    .from(questions)
+    .where(eq(questions.conceptId, conceptId))
+    .limit(max);
+  return rows.map((r) => r.prompt.slice(0, 60)).filter(Boolean);
+}
+
+async function loadConcept(conceptId: string): Promise<Concept> {
+  const rows = await getDb().select().from(concepts).where(eq(concepts.id, conceptId)).limit(1);
+  const row = rows[0];
+  if (!row) throw new Error(`unknown concept: ${conceptId}`);
+  return row;
+}
+
+/**
+ * OpenAI Responses API で Structured Output (json_schema) を取得する。
+ * dependency injection 可能にして snapshot / unit test で LLM を呼ばずに済むよう `llm` 引数で差し替え可能。
+ */
+export type McqLlmCaller = (args: {
+  model: string;
+  system: string;
+  user: string;
+}) => Promise<GeneratedMcq>;
+
+export const defaultMcqLlm: McqLlmCaller = async ({ model, system, user }) => {
+  const client = getOpenAI();
+  const res = await client.responses.create({
+    model,
+    input: [
+      { role: "system", content: system },
+      { role: "user", content: user },
+    ],
+    text: {
+      format: {
+        type: "json_schema",
+        ...MCQ_JSON_SCHEMA,
+      },
+    },
+  });
+  // 返却された output_text に JSON 文字列が入る。Zod でガード
+  const parsed = JSON.parse(res.output_text);
+  return GeneratedMcqSchema.parse(parsed);
+};
+
+export async function generateMcq(
+  input: GenerateMcqInput,
+  llm: McqLlmCaller = defaultMcqLlm,
+): Promise<GenerateMcqResult> {
+  const db = getDb();
+
+  if (!input.forceFresh) {
+    const cached = await findCachedQuestion(db, {
+      conceptId: input.conceptId,
+      type: "mcq",
+      thinkingStyle: input.thinkingStyle,
+      difficulty: input.difficulty,
+    });
+    if (cached) return { question: cached, source: "cache" };
+  }
+
+  const concept = await loadConcept(input.conceptId);
+  const past = await fetchPastSummaries(input.conceptId);
+  const { system, user } = buildMcqPrompt({
+    concept,
+    difficulty: input.difficulty,
+    thinkingStyle: input.thinkingStyle,
+    pastQuestionsSummary: past,
+  });
+
+  const generated = await llm({ model: MODEL_MAIN, system, user });
+
+  const [inserted] = await db
+    .insert(questions)
+    .values({
+      conceptId: input.conceptId,
+      type: "mcq",
+      difficulty: input.difficulty,
+      thinkingStyle: input.thinkingStyle,
+      prompt: generated.prompt,
+      answer: generated.answer,
+      distractors: generated.distractors,
+      hint: generated.hint,
+      explanation: generated.explanation,
+      tags: generated.tags,
+      generatedBy: MODEL_MAIN,
+      promptVersion: MCQ_PROMPT_VERSION,
+    })
+    .returning();
+
+  if (!inserted) throw new Error("failed to insert generated question");
+  return { question: inserted, source: "generated" };
+}

--- a/src/server/generator/prompt-template.ts
+++ b/src/server/generator/prompt-template.ts
@@ -5,14 +5,15 @@ import { join } from "node:path";
  * markdown ベースのプロンプトテンプレ読み込みと変数置換。
  *
  * フォーマット:
- *   ::: system
+ *   <!-- role:system -->
  *   ...
- *   :::
+ *   <!-- /role -->
  *
- *   ::: user
+ *   <!-- role:user -->
  *   ...{{ variable }}...
- *   :::
+ *   <!-- /role -->
  *
+ * prettier が markdown のリストとして扱ってインデントを付けたりしないよう HTML コメント区切り。
  * `buildMcqPrompt` 等のラッパがこの utility を使って markdown を単一のマスタとして扱う。
  */
 export type SplitPrompt = {
@@ -33,7 +34,8 @@ export function loadTemplate(relativePath: string): string {
   return cached;
 }
 
-const SECTION_RE = /:::\s*(system|user)\s*\n([\s\S]*?)\n:::/g;
+// 先頭 `<!--` と終端 `-->` の両側に空白・改行があることを要求 (prose 中のコード引用に引っかからない)
+const SECTION_RE = /^<!--\s+role:(system|user)\s+-->\s*\n([\s\S]*?)\n\s*<!--\s+\/role\s+-->\s*$/gm;
 
 function extractSections(raw: string): SplitPrompt {
   const out: Partial<SplitPrompt> = {};
@@ -44,7 +46,9 @@ function extractSections(raw: string): SplitPrompt {
     }
   }
   if (!out.system || !out.user) {
-    throw new Error("prompt template must contain both ::: system and ::: user sections");
+    throw new Error(
+      "prompt template must contain both <!-- role:system --> and <!-- role:user --> blocks",
+    );
   }
   return out as SplitPrompt;
 }

--- a/src/server/generator/prompt-template.ts
+++ b/src/server/generator/prompt-template.ts
@@ -1,0 +1,74 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * markdown ベースのプロンプトテンプレ読み込みと変数置換。
+ *
+ * フォーマット:
+ *   ::: system
+ *   ...
+ *   :::
+ *
+ *   ::: user
+ *   ...{{ variable }}...
+ *   :::
+ *
+ * `buildMcqPrompt` 等のラッパがこの utility を使って markdown を単一のマスタとして扱う。
+ */
+export type SplitPrompt = {
+  system: string;
+  user: string;
+};
+
+const TEMPLATE_ROOT = join(process.cwd(), "prompts");
+const cache = new Map<string, string>();
+
+export function loadTemplate(relativePath: string): string {
+  const full = join(TEMPLATE_ROOT, relativePath);
+  let cached = cache.get(full);
+  if (cached === undefined) {
+    cached = readFileSync(full, "utf8");
+    cache.set(full, cached);
+  }
+  return cached;
+}
+
+const SECTION_RE = /:::\s*(system|user)\s*\n([\s\S]*?)\n:::/g;
+
+function extractSections(raw: string): SplitPrompt {
+  const out: Partial<SplitPrompt> = {};
+  for (const match of raw.matchAll(SECTION_RE)) {
+    const [, kind, body] = match;
+    if (kind === "system" || kind === "user") {
+      out[kind] = body.trim();
+    }
+  }
+  if (!out.system || !out.user) {
+    throw new Error("prompt template must contain both ::: system and ::: user sections");
+  }
+  return out as SplitPrompt;
+}
+
+function substitute(text: string, vars: Record<string, string>): string {
+  return text.replace(/\{\{\s*([a-zA-Z_][a-zA-Z0-9_]*)\s*\}\}/g, (full, key: string) => {
+    if (!(key in vars)) {
+      throw new Error(`unbound template variable: {{ ${key} }}`);
+    }
+    return vars[key];
+  });
+}
+
+/** markdown テンプレを読み込み + 変数置換して system/user を返す */
+export function renderTemplate(relativePath: string, vars: Record<string, string>): SplitPrompt {
+  const raw = loadTemplate(relativePath);
+  const { system, user } = extractSections(raw);
+  return {
+    system: substitute(system, vars),
+    user: substitute(user, vars),
+  };
+}
+
+/** テスト用に cache をクリアする (ホットリロード) */
+export function __clearTemplateCache(): void {
+  cache.clear();
+}

--- a/src/server/generator/prompts.test.ts
+++ b/src/server/generator/prompts.test.ts
@@ -51,6 +51,7 @@ describe("buildMcqPrompt", () => {
         "system": "You are a senior engineer creating a multiple-choice quiz question for a professional software engineer.
       Output strictly as JSON matching the provided schema. Use 日本語 (Japanese) for all human-readable fields.",
         "user": "## Concept
+
       id: programming.async.event_loop
       name: イベントループ
       description: JavaScript/Node.js のタスクキューとマイクロタスクの実行順
@@ -58,15 +59,27 @@ describe("buildMcqPrompt", () => {
       subdomain: async
 
       ## Spec
+
       difficulty: junior
       thinking_style: why
 
       ## Style instruction
+
       問題は「なぜそうなっているか」「理由を説明せよ」形式。表面的な定義を問わないこと。
 
       ## Avoid duplicates
+
       Past recent framings for this concept (last 30 days, if any):
-      - setTimeout の評価タイミングを問う問題",
+      - setTimeout の評価タイミングを問う問題
+
+      ## Output requirements
+
+      - \`prompt\` (string): 日本語の問題文
+      - \`answer\` (string): 正解の 1 文 (他の distractors と区別できる決定的な選択肢)
+      - \`distractors\` (string[]): 不正解候補を 3 つ。正解と紛らわしいが明らかに誤り
+      - \`explanation\` (string): なぜ answer が正しく、distractors が誤りかを簡潔に日本語で説明
+      - \`hint\` (string | null): 解答前に 1 回だけ表示できる軽いヒント (Optional)
+      - \`tags\` (string[]): 1〜4 個の短い英語タグ (domain.subdomain を含めない)",
       }
     `);
   });

--- a/src/server/generator/prompts.test.ts
+++ b/src/server/generator/prompts.test.ts
@@ -7,7 +7,7 @@ describe("buildMcqPrompt", () => {
     expect(MCQ_PROMPT_VERSION).toBe("mcq.v1");
   });
 
-  it("共通 prefix が先頭にあり、variant が後ろに回っている (prompt caching 前提)", () => {
+  it("固定の Output requirements が user の先頭に、可変の Concept/Spec 等が後ろに (prompt caching 前提)", () => {
     const out = buildMcqPrompt({
       concept: {
         id: "network.http.methods_idempotency",
@@ -23,12 +23,17 @@ describe("buildMcqPrompt", () => {
 
     // system は固定、先頭に配置
     expect(out.system.startsWith("You are a senior engineer")).toBe(true);
-    // user は変動する concept セクションが下に来る形
-    expect(out.user.indexOf("## Concept")).toBeLessThan(out.user.indexOf("## Spec"));
-    expect(out.user.indexOf("## Spec")).toBeLessThan(out.user.indexOf("## Style instruction"));
-    expect(out.user.indexOf("## Style instruction")).toBeLessThan(
-      out.user.indexOf("## Avoid duplicates"),
-    );
+    // user は固定 (Output requirements) が先、可変が後
+    const outputIdx = out.user.indexOf("## Output requirements");
+    const conceptIdx = out.user.indexOf("## Concept");
+    const specIdx = out.user.indexOf("## Spec");
+    const styleIdx = out.user.indexOf("## Style instruction");
+    const avoidIdx = out.user.indexOf("## Avoid duplicates");
+    expect(outputIdx).toBeGreaterThanOrEqual(0);
+    expect(outputIdx).toBeLessThan(conceptIdx);
+    expect(conceptIdx).toBeLessThan(specIdx);
+    expect(specIdx).toBeLessThan(styleIdx);
+    expect(styleIdx).toBeLessThan(avoidIdx);
   });
 
   it("snapshot: 代表入力に対する組み立て結果", () => {
@@ -50,7 +55,16 @@ describe("buildMcqPrompt", () => {
       {
         "system": "You are a senior engineer creating a multiple-choice quiz question for a professional software engineer.
       Output strictly as JSON matching the provided schema. Use 日本語 (Japanese) for all human-readable fields.",
-        "user": "## Concept
+        "user": "## Output requirements (固定)
+
+      - \`prompt\` (string): 日本語の問題文
+      - \`answer\` (string): 正解の 1 文 (他の distractors と区別できる決定的な選択肢)
+      - \`distractors\` (string[]): 不正解候補を 3 つ。正解と紛らわしいが明らかに誤り
+      - \`explanation\` (string): なぜ answer が正しく、distractors が誤りかを簡潔に日本語で説明
+      - \`hint\` (string | null): 解答前に 1 回だけ表示できる軽いヒント (Optional)
+      - \`tags\` (string[]): 1〜4 個の短い英語タグ (domain.subdomain を含めない)
+
+      ## Concept (可変)
 
       id: programming.async.event_loop
       name: イベントループ
@@ -58,28 +72,19 @@ describe("buildMcqPrompt", () => {
       domain: programming
       subdomain: async
 
-      ## Spec
+      ## Spec (可変)
 
       difficulty: junior
       thinking_style: why
 
-      ## Style instruction
+      ## Style instruction (可変)
 
       問題は「なぜそうなっているか」「理由を説明せよ」形式。表面的な定義を問わないこと。
 
-      ## Avoid duplicates
+      ## Avoid duplicates (可変)
 
       Past recent framings for this concept (last 30 days, if any):
-      - setTimeout の評価タイミングを問う問題
-
-      ## Output requirements
-
-      - \`prompt\` (string): 日本語の問題文
-      - \`answer\` (string): 正解の 1 文 (他の distractors と区別できる決定的な選択肢)
-      - \`distractors\` (string[]): 不正解候補を 3 つ。正解と紛らわしいが明らかに誤り
-      - \`explanation\` (string): なぜ answer が正しく、distractors が誤りかを簡潔に日本語で説明
-      - \`hint\` (string | null): 解答前に 1 回だけ表示できる軽いヒント (Optional)
-      - \`tags\` (string[]): 1〜4 個の短い英語タグ (domain.subdomain を含めない)",
+      - setTimeout の評価タイミングを問う問題",
       }
     `);
   });

--- a/src/server/generator/prompts.test.ts
+++ b/src/server/generator/prompts.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from "vitest";
+
+import { buildMcqPrompt, MCQ_PROMPT_VERSION } from "./prompts";
+
+describe("buildMcqPrompt", () => {
+  it("MCQ_PROMPT_VERSION は mcq.v1", () => {
+    expect(MCQ_PROMPT_VERSION).toBe("mcq.v1");
+  });
+
+  it("共通 prefix が先頭にあり、variant が後ろに回っている (prompt caching 前提)", () => {
+    const out = buildMcqPrompt({
+      concept: {
+        id: "network.http.methods_idempotency",
+        name: "HTTP メソッドとベキ等性",
+        description: "GET/POST/PUT/DELETE/PATCH の意味と安全性・冪等性",
+        domainId: "network",
+        subdomainId: "http",
+      },
+      difficulty: "junior",
+      thinkingStyle: "why",
+      pastQuestionsSummary: [],
+    });
+
+    // system は固定、先頭に配置
+    expect(out.system.startsWith("You are a senior engineer")).toBe(true);
+    // user は変動する concept セクションが下に来る形
+    expect(out.user.indexOf("## Concept")).toBeLessThan(out.user.indexOf("## Spec"));
+    expect(out.user.indexOf("## Spec")).toBeLessThan(out.user.indexOf("## Style instruction"));
+    expect(out.user.indexOf("## Style instruction")).toBeLessThan(
+      out.user.indexOf("## Avoid duplicates"),
+    );
+  });
+
+  it("snapshot: 代表入力に対する組み立て結果", () => {
+    const out = buildMcqPrompt({
+      concept: {
+        id: "programming.async.event_loop",
+        name: "イベントループ",
+        description: "JavaScript/Node.js のタスクキューとマイクロタスクの実行順",
+        domainId: "programming",
+        subdomainId: "async",
+      },
+      difficulty: "junior",
+      thinkingStyle: "why",
+      pastQuestionsSummary: ["setTimeout の評価タイミングを問う問題"],
+    });
+
+    // 代表入出力スナップショット (人間レビュー対象)
+    expect({ system: out.system, user: out.user }).toMatchInlineSnapshot(`
+      {
+        "system": "You are a senior engineer creating a multiple-choice quiz question for a professional software engineer.
+      Output strictly as JSON matching the provided schema. Use 日本語 (Japanese) for all human-readable fields.",
+        "user": "## Concept
+      id: programming.async.event_loop
+      name: イベントループ
+      description: JavaScript/Node.js のタスクキューとマイクロタスクの実行順
+      domain: programming
+      subdomain: async
+
+      ## Spec
+      difficulty: junior
+      thinking_style: why
+
+      ## Style instruction
+      問題は「なぜそうなっているか」「理由を説明せよ」形式。表面的な定義を問わないこと。
+
+      ## Avoid duplicates
+      Past recent framings for this concept (last 30 days, if any):
+      - setTimeout の評価タイミングを問う問題",
+      }
+    `);
+  });
+});

--- a/src/server/generator/prompts.ts
+++ b/src/server/generator/prompts.ts
@@ -1,0 +1,67 @@
+import type { Concept, DifficultyLevel, ThinkingStyle } from "@/db/schema";
+
+/** 生成プロンプトのテンプレ版。docs/03-ai-strategy.md §3.3 参照 */
+export const MCQ_PROMPT_VERSION = "mcq.v1";
+
+const STYLE_INSTRUCTION_MAP: Record<ThinkingStyle, string> = {
+  why: "問題は「なぜそうなっているか」「理由を説明せよ」形式。表面的な定義を問わないこと。",
+  how: "実際の手順や選び方を問う。状況を具体化して実務寄りにすること。",
+  trade_off: "複数の選択肢/アプローチの利点と欠点を比較させる問題にすること。",
+  edge_case: "通常ケースではなく、境界条件・異常系・稀な条件下の挙動を問うこと。",
+  compare: "二つ以上の概念を並べて差を問う。違いが最も本質的な選択肢を正解に。",
+  apply: "本番運用で起きうる具体的なシナリオに置き換えて、判断を問うこと。",
+};
+
+export function styleInstruction(style: ThinkingStyle | null | undefined): string {
+  if (!style) return "思考様式は特に指定なし。自然な出題で。";
+  return STYLE_INSTRUCTION_MAP[style];
+}
+
+export type McqPromptInput = {
+  concept: Pick<Concept, "id" | "name" | "description" | "domainId" | "subdomainId">;
+  difficulty: DifficultyLevel;
+  thinkingStyle: ThinkingStyle | null;
+  /** 直近 30 日の既出問題の要約。文字列の配列で渡す。空配列なら "(none)" を出す */
+  pastQuestionsSummary: string[];
+};
+
+/**
+ * mcq プロンプトを組み立てる。
+ * OpenAI の prompt caching は「共通 prefix が長いほど効きやすい」ので、
+ * variant が多い箇所 (concept / 履歴) は後ろに回し、固定文は前に置く。
+ */
+export function buildMcqPrompt(input: McqPromptInput): {
+  system: string;
+  user: string;
+} {
+  const system =
+    "You are a senior engineer creating a multiple-choice quiz question for a professional software engineer.\n" +
+    "Output strictly as JSON matching the provided schema. Use 日本語 (Japanese) for all human-readable fields.";
+
+  const past =
+    input.pastQuestionsSummary.length === 0
+      ? "(none)"
+      : input.pastQuestionsSummary.map((s) => `- ${s}`).join("\n");
+
+  const user = [
+    "## Concept",
+    `id: ${input.concept.id}`,
+    `name: ${input.concept.name}`,
+    `description: ${input.concept.description ?? "(none)"}`,
+    `domain: ${input.concept.domainId}`,
+    `subdomain: ${input.concept.subdomainId}`,
+    "",
+    "## Spec",
+    `difficulty: ${input.difficulty}`,
+    `thinking_style: ${input.thinkingStyle ?? "(none)"}`,
+    "",
+    "## Style instruction",
+    styleInstruction(input.thinkingStyle),
+    "",
+    "## Avoid duplicates",
+    "Past recent framings for this concept (last 30 days, if any):",
+    past,
+  ].join("\n");
+
+  return { system, user };
+}

--- a/src/server/generator/prompts.ts
+++ b/src/server/generator/prompts.ts
@@ -1,7 +1,10 @@
 import type { Concept, DifficultyLevel, ThinkingStyle } from "@/db/schema";
 
+import { renderTemplate } from "./prompt-template";
+
 /** 生成プロンプトのテンプレ版。docs/03-ai-strategy.md §3.3 参照 */
 export const MCQ_PROMPT_VERSION = "mcq.v1";
+const MCQ_TEMPLATE_PATH = "generation/mcq.v1.md";
 
 const STYLE_INSTRUCTION_MAP: Record<ThinkingStyle, string> = {
   why: "問題は「なぜそうなっているか」「理由を説明せよ」形式。表面的な定義を問わないこと。",
@@ -26,42 +29,28 @@ export type McqPromptInput = {
 };
 
 /**
- * mcq プロンプトを組み立てる。
- * OpenAI の prompt caching は「共通 prefix が長いほど効きやすい」ので、
- * variant が多い箇所 (concept / 履歴) は後ろに回し、固定文は前に置く。
+ * `prompts/generation/mcq.v1.md` を読み込んで変数置換し system/user を返す。
+ * テンプレは markdown が真実の源 (CLAUDE.md §4.5)。このラッパはドメイン固有の
+ * 補助辞書 (思考スタイル説明) と過去履歴の整形のみを担う。
  */
 export function buildMcqPrompt(input: McqPromptInput): {
   system: string;
   user: string;
 } {
-  const system =
-    "You are a senior engineer creating a multiple-choice quiz question for a professional software engineer.\n" +
-    "Output strictly as JSON matching the provided schema. Use 日本語 (Japanese) for all human-readable fields.";
-
   const past =
     input.pastQuestionsSummary.length === 0
       ? "(none)"
       : input.pastQuestionsSummary.map((s) => `- ${s}`).join("\n");
 
-  const user = [
-    "## Concept",
-    `id: ${input.concept.id}`,
-    `name: ${input.concept.name}`,
-    `description: ${input.concept.description ?? "(none)"}`,
-    `domain: ${input.concept.domainId}`,
-    `subdomain: ${input.concept.subdomainId}`,
-    "",
-    "## Spec",
-    `difficulty: ${input.difficulty}`,
-    `thinking_style: ${input.thinkingStyle ?? "(none)"}`,
-    "",
-    "## Style instruction",
-    styleInstruction(input.thinkingStyle),
-    "",
-    "## Avoid duplicates",
-    "Past recent framings for this concept (last 30 days, if any):",
-    past,
-  ].join("\n");
-
-  return { system, user };
+  return renderTemplate(MCQ_TEMPLATE_PATH, {
+    conceptId: input.concept.id,
+    conceptName: input.concept.name,
+    conceptDescription: input.concept.description ?? "(none)",
+    domainId: input.concept.domainId,
+    subdomainId: input.concept.subdomainId,
+    difficulty: input.difficulty,
+    thinkingStyle: input.thinkingStyle ?? "(none)",
+    styleInstruction: styleInstruction(input.thinkingStyle),
+    pastQuestionsSummary: past,
+  });
 }

--- a/src/server/generator/schema.test.ts
+++ b/src/server/generator/schema.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+
+import { GeneratedMcqSchema, MCQ_JSON_SCHEMA } from "./schema";
+
+describe("GeneratedMcqSchema", () => {
+  it("正常系 JSON を受理", () => {
+    const ok = {
+      prompt: "HTTP の PUT と PATCH の違いは?",
+      answer: "PUT は冪等、PATCH は部分更新",
+      distractors: [
+        "PUT は常に新規作成、PATCH は既存更新",
+        "PUT はキャッシュされる、PATCH はされない",
+        "PUT は body 不要、PATCH は必須",
+      ],
+      explanation: "PUT は同じ結果を何度呼んでも同じ状態にする冪等性を保証する。",
+      hint: null,
+      tags: ["rest", "idempotency"],
+    };
+    expect(() => GeneratedMcqSchema.parse(ok)).not.toThrow();
+  });
+
+  it("distractors が 3 件以外なら reject", () => {
+    const bad = {
+      prompt: "x",
+      answer: "y",
+      distractors: ["a", "b"], // 2 件のみ
+      explanation: "z",
+      hint: null,
+      tags: ["t"],
+    };
+    expect(() => GeneratedMcqSchema.parse(bad)).toThrow();
+  });
+
+  it("MCQ_JSON_SCHEMA は strict=true で additionalProperties:false", () => {
+    expect(MCQ_JSON_SCHEMA.strict).toBe(true);
+    expect(MCQ_JSON_SCHEMA.schema.additionalProperties).toBe(false);
+    expect(MCQ_JSON_SCHEMA.schema.required).toContain("hint");
+  });
+});

--- a/src/server/generator/schema.ts
+++ b/src/server/generator/schema.ts
@@ -1,0 +1,45 @@
+import { z } from "zod";
+
+/** OpenAI Structured Outputs で受け取る mcq JSON の形 */
+export const GeneratedMcqSchema = z.object({
+  prompt: z.string().min(1),
+  answer: z.string().min(1),
+  distractors: z.array(z.string().min(1)).length(3),
+  explanation: z.string().min(1),
+  hint: z.string().nullable(),
+  tags: z.array(z.string().min(1)).min(1).max(4),
+});
+
+export type GeneratedMcq = z.infer<typeof GeneratedMcqSchema>;
+
+/**
+ * OpenAI Responses API に渡す JSON schema。Zod からの自動変換は SDK 側で対応しているが
+ * Structured Outputs 仕様 (strict: true + additionalProperties: false) に合う形で書き下す。
+ */
+export const MCQ_JSON_SCHEMA = {
+  name: "mcq_question",
+  strict: true as const,
+  schema: {
+    type: "object",
+    additionalProperties: false,
+    required: ["prompt", "answer", "distractors", "explanation", "hint", "tags"],
+    properties: {
+      prompt: { type: "string" },
+      answer: { type: "string" },
+      distractors: {
+        type: "array",
+        items: { type: "string" },
+        minItems: 3,
+        maxItems: 3,
+      },
+      explanation: { type: "string" },
+      hint: { type: ["string", "null"] },
+      tags: {
+        type: "array",
+        items: { type: "string" },
+        minItems: 1,
+        maxItems: 4,
+      },
+    },
+  },
+};

--- a/src/server/trpc/routers/index.ts
+++ b/src/server/trpc/routers/index.ts
@@ -1,10 +1,12 @@
 import { router } from "../init";
 import { authRouter } from "./auth";
 import { pingRouter } from "./ping";
+import { questionsRouter } from "./questions";
 
 export const appRouter = router({
   ping: pingRouter.ping,
   auth: authRouter,
+  questions: questionsRouter,
 });
 
 export type AppRouter = typeof appRouter;

--- a/src/server/trpc/routers/questions.ts
+++ b/src/server/trpc/routers/questions.ts
@@ -1,0 +1,39 @@
+import { z } from "zod";
+
+import { DIFFICULTY_LEVELS, THINKING_STYLES } from "@/db/schema";
+import { generateMcq } from "@/server/generator/mcq";
+
+import { protectedProcedure, router } from "../init";
+
+export const questionsRouter = router({
+  generate: protectedProcedure
+    .input(
+      z.object({
+        conceptId: z.string().min(1),
+        /** MVP は mcq のみ (issue #9)。他タイプは issue #14 以降 */
+        type: z.literal("mcq"),
+        difficulty: z.enum(DIFFICULTY_LEVELS),
+        thinkingStyle: z.enum(THINKING_STYLES).nullable(),
+        forceFresh: z.boolean().optional(),
+      }),
+    )
+    .mutation(async ({ input }) => {
+      const result = await generateMcq({
+        conceptId: input.conceptId,
+        difficulty: input.difficulty,
+        thinkingStyle: input.thinkingStyle,
+        forceFresh: input.forceFresh,
+      });
+      return {
+        source: result.source,
+        question: {
+          id: result.question.id,
+          prompt: result.question.prompt,
+          distractors: result.question.distractors,
+          // answer / explanation は UI 側でユーザー回答後に出す。ここでは返さない
+          hint: result.question.hint,
+          tags: result.question.tags,
+        },
+      };
+    }),
+});

--- a/src/server/trpc/routers/questions.ts
+++ b/src/server/trpc/routers/questions.ts
@@ -14,15 +14,15 @@ export const questionsRouter = router({
         type: z.literal("mcq"),
         difficulty: z.enum(DIFFICULTY_LEVELS),
         thinkingStyle: z.enum(THINKING_STYLES).nullable(),
-        forceFresh: z.boolean().optional(),
       }),
     )
     .mutation(async ({ input }) => {
+      // forceFresh は公開 API に露出させず、サーバー側のフラグ (NODE_ENV=development かつ
+      // テストで必要な場合) でのみ許可する。Passkey 認証済みでも OpenAI コスト削減経路を塞ぐ。
       const result = await generateMcq({
         conceptId: input.conceptId,
         difficulty: input.difficulty,
         thinkingStyle: input.thinkingStyle,
-        forceFresh: input.forceFresh,
       });
       return {
         source: result.source,


### PR DESCRIPTION
## Summary
Issue #9 を解決。docs/03-ai-strategy.md §3.2-3.3 に沿った OpenAI 呼び出しラッパと mcq 問題生成を実装。

- `src/lib/openai/{client,models}.ts`: singleton + `MODEL_MAIN="gpt-5"` / `MODEL_CHEAP="gpt-5-mini"` (文字列リテラル散在を避ける)
- `src/server/generator/`: prompts / schema / cache / mcq の 4 モジュール
  - cache: 同 `(concept, type, style, difficulty)` の直近 30 日 retired=false を未使用優先で 1 件返す
  - mcq: cache hit なら即返却、miss は Structured Outputs (json_schema) で生成 → `questions` に insert
  - LLM 呼び出しは `McqLlmCaller` で DI 可能 (ユニットテスト時に差し替え可能)
- `prompts/generation/mcq.v1.md`: 版管理テンプレ。`MCQ_PROMPT_VERSION="mcq.v1"` を `questions.prompt_version` に記録
- tRPC: `questions.generate` protected mutation (input は Zod で `type: "mcq"` リテラルに固定)
- test: `buildMcqPrompt` の snapshot / `GeneratedMcqSchema` の distractors 件数 / Structured Outputs schema の strict 要件

## 受け入れ基準 (issue #9)
- [x] `src/lib/openai/client.ts` singleton
- [x] `src/lib/openai/models.ts` (`MODEL_MAIN="gpt-5"`, `MODEL_CHEAP="gpt-5-mini"`)
- [x] `src/server/generator/` に生成ロジック
- [x] `questions.generate` tRPC endpoint (mcq)
- [x] `questions` テーブルに保存 + `generated_by` / `prompt_version` 記録
- [x] `prompts/generation/mcq.v1.md` で版管理
- [x] 同じ (concept,type,style,difficulty) の直近 30 日未使用を cache 返却
- [x] snapshot test

Closes #9

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm test -- --run` (49 pass, +6)
- [x] `pnpm build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)