### PR TITLE
feat(grader): mcq 完全一致 + short gpt-5-mini ルーブリック採点

### DIFF
--- a/drizzle/0005_attempts_grading_prompt_version.sql
+++ b/drizzle/0005_attempts_grading_prompt_version.sql
@@ -1,0 +1,4 @@
+-- attempts に採点プロンプトの版を記録するカラムを追加。
+-- mcq (LLM 未使用) では NULL、short/written などでは prompts/grading/*.vN.md の `vN` を記録。
+ALTER TABLE "attempts" ADD COLUMN "prompt_version" text;--> statement-breakpoint
+ALTER TABLE "attempts" ADD COLUMN "graded_by" text;

--- a/prompts/grading/short.v1.md
+++ b/prompts/grading/short.v1.md
@@ -1,0 +1,46 @@
+# short.v1
+
+short answer (自由記述の短い答え) を gpt-5-mini に採点させるプロンプト。
+固定の Output requirements を user 冒頭、可変 (question / answer / rubric / user_answer) を末尾に並べる (CLAUDE.md §4.5)。
+
+テンプレ変数は `{{ camelCase }}` で囲む。`src/server/grader/prompts.ts` の `buildShortGradingPrompt` が
+このファイルを読み込んで HTML コメント `<!-- role:system -->` / `<!-- role:user -->` ブロックを抽出し、
+`{{ }}` を置換する。
+
+---
+
+<!-- role:system -->
+
+You are a senior engineer grading a short answer. Output strictly as JSON matching the provided schema. Use 日本語 for human-readable fields.
+
+<!-- /role -->
+
+<!-- role:user -->
+
+## Output requirements (固定)
+
+- `score` (number, 0.0-1.0): 0 は完全に誤り、1 は完全に正しい。ルーブリックの必須項目すべて満たすとき 1.0 近く
+- `correct` (boolean): score >= 0.7 のとき true、そうでなければ false
+- `feedback` (string): なぜその score か、合格/不合格の根拠を 1-2 文で日本語
+- `rubricChecks` (array): ルーブリック各項目が満たされているかのチェック結果
+  - `id` (string): ルーブリック項目の id (入力の通り)
+  - `passed` (boolean)
+  - `comment` (string): 採点理由 (満たされなかった場合は何が足りないか)
+
+## Question (可変)
+
+{{ questionPrompt }}
+
+## Expected answer (可変)
+
+{{ expectedAnswer }}
+
+## Rubric (可変)
+
+{{ rubric }}
+
+## User answer (可変)
+
+{{ userAnswer }}
+
+<!-- /role -->

--- a/src/db/schema/attempts.ts
+++ b/src/db/schema/attempts.ts
@@ -65,6 +65,9 @@ export const attempts = pgTable(
     misconceptionTags: jsonb("misconception_tags").$type<MisconceptionTag[]>(),
     reasonGiven: text("reason_given"),
     copiedForExternal: integer("copied_for_external").notNull().default(0),
+    /** 採点に使ったプロンプトの版 (CLAUDE.md §4.5)。mcq のようにプロンプト不使用の採点は null */
+    promptVersion: text("prompt_version"),
+    gradedBy: text("graded_by"),
     /**
      * 全文検索用 tsvector (ADR-0003 / §6.2.2)。
      * user_answer / reason_given / feedback の連結を 'simple' analyzer で index 化する。

--- a/src/server/grader/__snapshots__/short.test.ts.snap
+++ b/src/server/grader/__snapshots__/short.test.ts.snap
@@ -1,0 +1,33 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`buildShortGradingPrompt > 代表入力の組み立て結果 snapshot (Issue #10 受け入れ基準) 1`] = `
+{
+  "system": "You are a senior engineer grading a short answer. Output strictly as JSON matching the provided schema. Use 日本語 for human-readable fields.",
+  "user": "## Output requirements (固定)
+
+- \`score\` (number, 0.0-1.0): 0 は完全に誤り、1 は完全に正しい。ルーブリックの必須項目すべて満たすとき 1.0 近く
+- \`correct\` (boolean): score >= 0.7 のとき true、そうでなければ false
+- \`feedback\` (string): なぜその score か、合格/不合格の根拠を 1-2 文で日本語
+- \`rubricChecks\` (array): ルーブリック各項目が満たされているかのチェック結果
+  - \`id\` (string): ルーブリック項目の id (入力の通り)
+  - \`passed\` (boolean)
+  - \`comment\` (string): 採点理由 (満たされなかった場合は何が足りないか)
+
+## Question (可変)
+
+HTTP PUT と PATCH の違いを 1 文で。
+
+## Expected answer (可変)
+
+PUT は冪等、PATCH は部分更新。
+
+## Rubric (可変)
+
+- id=r1: PUT の冪等性に言及
+- id=r2: PATCH の部分更新に言及
+
+## User answer (可変)
+
+PUT は毎回同じ結果、PATCH は一部だけ変える。",
+}
+`;

--- a/src/server/grader/index.ts
+++ b/src/server/grader/index.ts
@@ -1,9 +1,11 @@
-import { eq } from "drizzle-orm";
+import { TRPCError } from "@trpc/server";
+import { and, eq } from "drizzle-orm";
 
 import { getDb } from "@/db/client";
 import {
   attempts,
   questions,
+  sessions,
   type NewAttempt,
   type Question,
   type RubricCheckResult,
@@ -34,8 +36,23 @@ export type GradeAttemptResult = {
 async function loadQuestion(questionId: string): Promise<Question> {
   const rows = await getDb().select().from(questions).where(eq(questions.id, questionId)).limit(1);
   const q = rows[0];
-  if (!q) throw new Error(`unknown question: ${questionId}`);
+  if (!q) throw new TRPCError({ code: "NOT_FOUND", message: `unknown question: ${questionId}` });
   return q;
+}
+
+/** session が呼び出し元ユーザーのものであることを確認。別 user の session への書き込みを防ぐ */
+async function assertSessionOwnership(sessionId: string, userId: string): Promise<void> {
+  const rows = await getDb()
+    .select({ id: sessions.id })
+    .from(sessions)
+    .where(and(eq(sessions.id, sessionId), eq(sessions.userId, userId)))
+    .limit(1);
+  if (!rows[0]) {
+    throw new TRPCError({
+      code: "FORBIDDEN",
+      message: "session does not belong to the authenticated user",
+    });
+  }
 }
 
 /**
@@ -43,6 +60,7 @@ async function loadQuestion(questionId: string): Promise<Question> {
  * 問題タイプによって mcq / short 等にディスパッチする (現在サポート: mcq, short)。
  */
 export async function gradeAttempt(input: GradeAttemptInput): Promise<GradeAttemptResult> {
+  await assertSessionOwnership(input.sessionId, input.userId);
   const question = await loadQuestion(input.questionId);
 
   let row: NewAttempt;

--- a/src/server/grader/index.ts
+++ b/src/server/grader/index.ts
@@ -1,0 +1,107 @@
+import { eq } from "drizzle-orm";
+
+import { getDb } from "@/db/client";
+import {
+  attempts,
+  questions,
+  type NewAttempt,
+  type Question,
+  type RubricCheckResult,
+} from "@/db/schema";
+
+import { gradeMcq } from "./mcq";
+import { gradeShort } from "./short";
+
+export type GradeAttemptInput = {
+  userId: string;
+  sessionId: string;
+  questionId: string;
+  userAnswer: string;
+  /** 回答に要したミリ秒 (UI 側で計測して渡す) */
+  elapsedMs?: number;
+  /** 「なぜそう答えたか」(任意、誤概念抽出に使う) */
+  reasonGiven?: string;
+};
+
+export type GradeAttemptResult = {
+  attempt: { id: string };
+  correct: boolean;
+  score: number | null;
+  feedback: string;
+  rubricChecks: RubricCheckResult[];
+};
+
+async function loadQuestion(questionId: string): Promise<Question> {
+  const rows = await getDb().select().from(questions).where(eq(questions.id, questionId)).limit(1);
+  const q = rows[0];
+  if (!q) throw new Error(`unknown question: ${questionId}`);
+  return q;
+}
+
+/**
+ * 採点 → attempts に永続化する統合関数。
+ * 問題タイプによって mcq / short 等にディスパッチする (現在サポート: mcq, short)。
+ */
+export async function gradeAttempt(input: GradeAttemptInput): Promise<GradeAttemptResult> {
+  const question = await loadQuestion(input.questionId);
+
+  let row: NewAttempt;
+  let grade: GradeAttemptResult;
+
+  if (question.type === "mcq") {
+    const result = gradeMcq(question, input.userAnswer);
+    row = {
+      userId: input.userId,
+      sessionId: input.sessionId,
+      questionId: question.id,
+      conceptId: question.conceptId,
+      userAnswer: input.userAnswer,
+      correct: result.correct,
+      score: result.score,
+      feedback: result.feedback,
+      rubricChecks: [],
+      reasonGiven: input.reasonGiven,
+      elapsedMs: input.elapsedMs,
+      gradedBy: null,
+      promptVersion: null,
+    };
+    grade = {
+      attempt: { id: "" },
+      correct: result.correct,
+      score: result.score,
+      feedback: result.feedback,
+      rubricChecks: [],
+    };
+  } else if (question.type === "short") {
+    const result = await gradeShort({ question, userAnswer: input.userAnswer });
+    row = {
+      userId: input.userId,
+      sessionId: input.sessionId,
+      questionId: question.id,
+      conceptId: question.conceptId,
+      userAnswer: input.userAnswer,
+      correct: result.correct,
+      score: result.score,
+      feedback: result.feedback,
+      rubricChecks: result.rubricChecks,
+      reasonGiven: input.reasonGiven,
+      elapsedMs: input.elapsedMs,
+      gradedBy: result.model,
+      promptVersion: result.promptVersion,
+    };
+    grade = {
+      attempt: { id: "" },
+      correct: result.correct,
+      score: result.score,
+      feedback: result.feedback,
+      rubricChecks: result.rubricChecks,
+    };
+  } else {
+    throw new Error(`grading for type="${question.type}" is not implemented (issue #14+)`);
+  }
+
+  const [inserted] = await getDb().insert(attempts).values(row).returning();
+  if (!inserted) throw new Error("failed to insert attempt");
+  grade.attempt.id = inserted.id;
+  return grade;
+}

--- a/src/server/grader/mcq.test.ts
+++ b/src/server/grader/mcq.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+
+import { gradeMcq } from "./mcq";
+
+describe("gradeMcq", () => {
+  const q = {
+    answer: "PUT は冪等、PATCH は部分更新",
+    distractors: ["PUT は body 不要", "PATCH はキャッシュされる", "両方とも冪等"],
+  };
+
+  it("正解と完全一致なら correct=true, score=1", () => {
+    const r = gradeMcq(q, "PUT は冪等、PATCH は部分更新");
+    expect(r.correct).toBe(true);
+    expect(r.score).toBe(1);
+    expect(r.feedback).toBe("正解です");
+  });
+
+  it("前後の空白は trim して許容", () => {
+    const r = gradeMcq(q, "  PUT は冪等、PATCH は部分更新  ");
+    expect(r.correct).toBe(true);
+    expect(r.score).toBe(1);
+  });
+
+  it("distractor そのまま選んだら不正解", () => {
+    const r = gradeMcq(q, "PUT は body 不要");
+    expect(r.correct).toBe(false);
+    expect(r.score).toBe(0);
+    expect(r.feedback).toContain("正解は");
+  });
+
+  it("空文字は不正解", () => {
+    const r = gradeMcq(q, "");
+    expect(r.correct).toBe(false);
+    expect(r.score).toBe(0);
+  });
+
+  it("大文字/小文字の違いは別回答とみなす (日本語文章の意味差を誤検知しないため、完全一致)", () => {
+    const q2 = { answer: "Good", distractors: ["Bad"] };
+    const r = gradeMcq(q2, "good");
+    expect(r.correct).toBe(false);
+  });
+});

--- a/src/server/grader/mcq.ts
+++ b/src/server/grader/mcq.ts
@@ -1,0 +1,25 @@
+import type { Question } from "@/db/schema";
+
+export type McqGradeResult = {
+  correct: boolean;
+  score: 0 | 1;
+  feedback: string;
+};
+
+/**
+ * mcq の採点は LLM を使わず完全一致判定のみ (docs/03 §3.4.1)。
+ * 受け入れるのは answer テキストそのもの、または distractors に含まれるテキスト。
+ * 正解以外はすべて不正解。
+ */
+export function gradeMcq(
+  question: Pick<Question, "answer" | "distractors">,
+  userAnswer: string,
+): McqGradeResult {
+  const trimmed = userAnswer.trim();
+  const isCorrect = trimmed === question.answer.trim();
+  return {
+    correct: isCorrect,
+    score: isCorrect ? 1 : 0,
+    feedback: isCorrect ? "正解です" : `正解は: ${question.answer}`,
+  };
+}

--- a/src/server/grader/prompts.ts
+++ b/src/server/grader/prompts.ts
@@ -1,0 +1,32 @@
+import type { Question, RubricCheck } from "@/db/schema";
+
+import { renderTemplate } from "../generator/prompt-template";
+
+export const SHORT_PROMPT_VERSION = "short.v1";
+const SHORT_TEMPLATE_PATH = "grading/short.v1.md";
+
+export type ShortGradingInput = {
+  question: Pick<Question, "prompt" | "answer" | "rubric">;
+  userAnswer: string;
+};
+
+function formatRubric(rubric: RubricCheck[] | null | undefined): string {
+  if (!rubric || rubric.length === 0) {
+    return "(採点ルーブリックなし。Expected answer との意味一致で判断すること)";
+  }
+  return rubric
+    .map((r) => `- id=${r.id}: ${r.description}${r.weight ? ` (weight=${r.weight})` : ""}`)
+    .join("\n");
+}
+
+export function buildShortGradingPrompt(input: ShortGradingInput): {
+  system: string;
+  user: string;
+} {
+  return renderTemplate(SHORT_TEMPLATE_PATH, {
+    questionPrompt: input.question.prompt,
+    expectedAnswer: input.question.answer,
+    rubric: formatRubric(input.question.rubric),
+    userAnswer: input.userAnswer,
+  });
+}

--- a/src/server/grader/schema.ts
+++ b/src/server/grader/schema.ts
@@ -1,0 +1,46 @@
+import { z } from "zod";
+
+export const GradedShortSchema = z.object({
+  score: z.number().min(0).max(1),
+  correct: z.boolean(),
+  feedback: z.string().min(1),
+  rubricChecks: z
+    .array(
+      z.object({
+        id: z.string().min(1),
+        passed: z.boolean(),
+        comment: z.string(),
+      }),
+    )
+    .default([]),
+});
+
+export type GradedShort = z.infer<typeof GradedShortSchema>;
+
+export const SHORT_JSON_SCHEMA = {
+  name: "short_grading",
+  strict: true as const,
+  schema: {
+    type: "object",
+    additionalProperties: false,
+    required: ["score", "correct", "feedback", "rubricChecks"],
+    properties: {
+      score: { type: "number", minimum: 0, maximum: 1 },
+      correct: { type: "boolean" },
+      feedback: { type: "string" },
+      rubricChecks: {
+        type: "array",
+        items: {
+          type: "object",
+          additionalProperties: false,
+          required: ["id", "passed", "comment"],
+          properties: {
+            id: { type: "string" },
+            passed: { type: "boolean" },
+            comment: { type: "string" },
+          },
+        },
+      },
+    },
+  },
+};

--- a/src/server/grader/short-derive.test.ts
+++ b/src/server/grader/short-derive.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+
+import { gradeShort } from "./short";
+
+describe("gradeShort: correct は score から導出 (LLM 自己申告を信用しない)", () => {
+  const input = {
+    question: { prompt: "x", answer: "y", rubric: null },
+    userAnswer: "z",
+  };
+
+  it("LLM が score 0.3 / correct true を返しても correct は false に矯正", async () => {
+    const result = await gradeShort(input, async () => ({
+      score: 0.3,
+      correct: true,
+      feedback: "矛盾する LLM 出力",
+      rubricChecks: [],
+    }));
+    expect(result.correct).toBe(false);
+    expect(result.score).toBe(0.3);
+  });
+
+  it("score 0.7 以上なら correct=true", async () => {
+    const result = await gradeShort(input, async () => ({
+      score: 0.8,
+      correct: false,
+      feedback: "x",
+      rubricChecks: [],
+    }));
+    expect(result.correct).toBe(true);
+  });
+
+  it("境界値 0.7 は correct=true", async () => {
+    const result = await gradeShort(input, async () => ({
+      score: 0.7,
+      correct: false,
+      feedback: "x",
+      rubricChecks: [],
+    }));
+    expect(result.correct).toBe(true);
+  });
+});

--- a/src/server/grader/short.test.ts
+++ b/src/server/grader/short.test.ts
@@ -4,20 +4,25 @@ import { buildShortGradingPrompt } from "./prompts";
 import { GradedShortSchema, SHORT_JSON_SCHEMA } from "./schema";
 
 describe("buildShortGradingPrompt", () => {
-  it("snapshot: 代表入力 (rubric あり) に対する組み立て結果", () => {
-    const out = buildShortGradingPrompt({
-      question: {
-        prompt: "HTTP PUT と PATCH の違いを 1 文で。",
-        answer: "PUT は冪等、PATCH は部分更新。",
-        rubric: [
-          { id: "r1", description: "PUT の冪等性に言及" },
-          { id: "r2", description: "PATCH の部分更新に言及" },
-        ],
-      },
-      userAnswer: "PUT は毎回同じ結果、PATCH は一部だけ変える。",
-    });
+  const sampleInput = {
+    question: {
+      prompt: "HTTP PUT と PATCH の違いを 1 文で。",
+      answer: "PUT は冪等、PATCH は部分更新。",
+      rubric: [
+        { id: "r1", description: "PUT の冪等性に言及" },
+        { id: "r2", description: "PATCH の部分更新に言及" },
+      ],
+    },
+    userAnswer: "PUT は毎回同じ結果、PATCH は一部だけ変える。",
+  };
 
-    // Output requirements は冒頭 (prompt caching)
+  it("代表入力の組み立て結果 snapshot (Issue #10 受け入れ基準)", () => {
+    const out = buildShortGradingPrompt(sampleInput);
+    expect({ system: out.system, user: out.user }).toMatchSnapshot();
+  });
+
+  it("Output requirements が user 冒頭 (prompt caching 規約)", () => {
+    const out = buildShortGradingPrompt(sampleInput);
     expect(out.user.indexOf("## Output requirements")).toBeLessThan(
       out.user.indexOf("## Question"),
     );

--- a/src/server/grader/short.test.ts
+++ b/src/server/grader/short.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+
+import { buildShortGradingPrompt } from "./prompts";
+import { GradedShortSchema, SHORT_JSON_SCHEMA } from "./schema";
+
+describe("buildShortGradingPrompt", () => {
+  it("snapshot: 代表入力 (rubric あり) に対する組み立て結果", () => {
+    const out = buildShortGradingPrompt({
+      question: {
+        prompt: "HTTP PUT と PATCH の違いを 1 文で。",
+        answer: "PUT は冪等、PATCH は部分更新。",
+        rubric: [
+          { id: "r1", description: "PUT の冪等性に言及" },
+          { id: "r2", description: "PATCH の部分更新に言及" },
+        ],
+      },
+      userAnswer: "PUT は毎回同じ結果、PATCH は一部だけ変える。",
+    });
+
+    // Output requirements は冒頭 (prompt caching)
+    expect(out.user.indexOf("## Output requirements")).toBeLessThan(
+      out.user.indexOf("## Question"),
+    );
+    expect(out.user).toContain("id=r1");
+    expect(out.user).toContain("PUT は毎回同じ結果");
+  });
+
+  it("rubric 未指定でも通る (fallback 文言)", () => {
+    const out = buildShortGradingPrompt({
+      question: {
+        prompt: "x?",
+        answer: "y",
+        rubric: null,
+      },
+      userAnswer: "z",
+    });
+    expect(out.user).toContain("採点ルーブリックなし");
+  });
+});
+
+describe("GradedShortSchema", () => {
+  it("score 0.8 / correct true / feedback / rubricChecks の正常系", () => {
+    const ok = {
+      score: 0.8,
+      correct: true,
+      feedback: "概ね合格",
+      rubricChecks: [{ id: "r1", passed: true, comment: "ok" }],
+    };
+    expect(() => GradedShortSchema.parse(ok)).not.toThrow();
+  });
+
+  it("score > 1 は reject", () => {
+    const bad = { score: 1.2, correct: true, feedback: "x", rubricChecks: [] };
+    expect(() => GradedShortSchema.parse(bad)).toThrow();
+  });
+
+  it("SHORT_JSON_SCHEMA は strict + additionalProperties:false", () => {
+    expect(SHORT_JSON_SCHEMA.strict).toBe(true);
+    expect(SHORT_JSON_SCHEMA.schema.additionalProperties).toBe(false);
+  });
+});

--- a/src/server/grader/short.ts
+++ b/src/server/grader/short.ts
@@ -32,6 +32,9 @@ export const defaultShortLlm: ShortLlmCaller = async ({ model, system, user }) =
  * short answer を gpt-5-mini にルーブリック採点させる (docs/03 §3.4.2)。
  * LLM 呼び出しは DI 可能 (テスト時に差し替え)。
  */
+/** 採点結果の `correct` は LLM の自己申告を信用せず score から導出 (docs/03 §3.4.2) */
+const CORRECT_THRESHOLD = 0.7;
+
 export async function gradeShort(
   input: ShortGradingInput,
   llm: ShortLlmCaller = defaultShortLlm,
@@ -40,6 +43,7 @@ export async function gradeShort(
   const graded = await llm({ model: MODEL_CHEAP, system, user });
   return {
     ...graded,
+    correct: graded.score >= CORRECT_THRESHOLD,
     model: MODEL_CHEAP,
     promptVersion: "short.v1",
   };

--- a/src/server/grader/short.ts
+++ b/src/server/grader/short.ts
@@ -1,0 +1,46 @@
+import { getOpenAI } from "@/lib/openai/client";
+import { MODEL_CHEAP } from "@/lib/openai/models";
+
+import { buildShortGradingPrompt, type ShortGradingInput } from "./prompts";
+import { GradedShortSchema, SHORT_JSON_SCHEMA, type GradedShort } from "./schema";
+
+export type ShortLlmCaller = (args: {
+  model: string;
+  system: string;
+  user: string;
+}) => Promise<GradedShort>;
+
+export const defaultShortLlm: ShortLlmCaller = async ({ model, system, user }) => {
+  const client = getOpenAI();
+  const res = await client.responses.create({
+    model,
+    input: [
+      { role: "system", content: system },
+      { role: "user", content: user },
+    ],
+    text: {
+      format: {
+        type: "json_schema",
+        ...SHORT_JSON_SCHEMA,
+      },
+    },
+  });
+  return GradedShortSchema.parse(JSON.parse(res.output_text));
+};
+
+/**
+ * short answer を gpt-5-mini にルーブリック採点させる (docs/03 §3.4.2)。
+ * LLM 呼び出しは DI 可能 (テスト時に差し替え)。
+ */
+export async function gradeShort(
+  input: ShortGradingInput,
+  llm: ShortLlmCaller = defaultShortLlm,
+): Promise<GradedShort & { model: string; promptVersion: string }> {
+  const { system, user } = buildShortGradingPrompt(input);
+  const graded = await llm({ model: MODEL_CHEAP, system, user });
+  return {
+    ...graded,
+    model: MODEL_CHEAP,
+    promptVersion: "short.v1",
+  };
+}


### PR DESCRIPTION
## Summary
Issue #10 を解決。docs/03-ai-strategy.md §3.4 に沿って採点ロジックを実装。

- `src/server/grader/`: mcq (完全一致) / short (gpt-5-mini + Structured Outputs) / gradeAttempt 統合 + attempts insert
- `prompts/grading/short.v1.md`: Output requirements を user 冒頭、可変 (question/answer/rubric/userAnswer) を末尾 (prompt caching 規約)
- `attempts` に `prompt_version` と `graded_by` カラムを追加 (migration 0005)
- test: mcq 5 ケース / short のプロンプト構造 + Zod バリデーション

## 受け入れ基準 (issue #10)
- [x] `src/server/grader/` に採点ロジック
- [x] mcq は answer と完全一致判定、LLM 呼ばない
- [x] short は gpt-5-mini + ルーブリック Structured Outputs
- [x] `attempts` に score / correct / feedback / rubric_checks / prompt_version 保存
- [x] プロンプトは `prompts/grading/short.v1.md`
- [x] unit test (mcq 網羅 + short snapshot)

Closes #10

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm test -- --run` (59 pass, +10)
- [x] `pnpm build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)