### PR TITLE
feat(fsrs): ts-fsrs 統合 + mastery 更新 + 10分ルール + 昇格

### DIFF
--- a/docs/OPEN_QUESTIONS.md
+++ b/docs/OPEN_QUESTIONS.md
@@ -63,6 +63,12 @@
 - **残る論点**: 個人開発で数値目標を持つ意味は薄いが、FSRS / スケジューラの主要関数は 100% 行カバー目指すべきか。
 - **判定**: 数値目標は置かず、「壊れて気付かなかった事故が起きた部分にはテストを足す」帰納的な運用で。
 
+## Q12. mastery upsert の read-modify-write 並行安全
+
+- **現状**: `src/server/scheduler/update-mastery.ts` は `SELECT → gradeMastery() → INSERT ... ON CONFLICT DO UPDATE` の流れ。`reviewCount` / `lapseCount` は SQL の `+1` で atomic 化したが、`stability` / `difficulty` / `nextReview` 等の FSRS 本体状態は絶対値上書き。
+- **残る論点**: Neon HTTP ドライバは transactions 未サポート (`@neondatabase/serverless` の websocket 版で対応可) のため、同一 (userId, conceptId) への並行 attempt で最後の writer が他方の FSRS 遷移を落とす可能性。
+- **判定**: 作者 1 人が使う個人プロジェクト (`01-vision`) のため並行 attempt は事実上発生しない。MVP では現状のまま、将来マルチユーザー化するなら (a) websocket ドライバに切り替えて transaction 化、(b) mastery に version 列を追加して楽観ロック、どちらかを採る。
+
 ## Q11. seed orphan (YAML から削除された concept の DB 側残留)
 
 - **現状**: `src/db/seed/run.ts` は upsert のみで、YAML から消した concept は DB に残り、警告が出るだけ。

--- a/src/server/grader/index.ts
+++ b/src/server/grader/index.ts
@@ -10,6 +10,7 @@ import {
   type Question,
   type RubricCheckResult,
 } from "@/db/schema";
+import { updateMasteryAfterAttempt } from "@/server/scheduler/update-mastery";
 
 import { gradeMcq } from "./mcq";
 import { gradeShort } from "./short";
@@ -128,6 +129,12 @@ export async function gradeAttempt(input: GradeAttemptInput): Promise<GradeAttem
 
   if (inserted[0]) {
     grade.attempt.id = inserted[0].id;
+    // 採点成功したときだけ mastery を更新 (二重 submit の losing race は更新しない)
+    await updateMasteryAfterAttempt({
+      userId: input.userId,
+      conceptId: question.conceptId,
+      score: grade.score,
+    });
     return grade;
   }
 

--- a/src/server/scheduler/fsrs.test.ts
+++ b/src/server/scheduler/fsrs.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from "vitest";
+
+import { gradeMastery, Rating, scoreToRating } from "./fsrs";
+
+describe("scoreToRating", () => {
+  it("score で Easy/Good/Hard/Again を分岐", () => {
+    expect(scoreToRating(1.0)).toBe(Rating.Easy);
+    expect(scoreToRating(0.9)).toBe(Rating.Easy);
+    expect(scoreToRating(0.85)).toBe(Rating.Good);
+    expect(scoreToRating(0.7)).toBe(Rating.Good);
+    expect(scoreToRating(0.6)).toBe(Rating.Hard);
+    expect(scoreToRating(0.49)).toBe(Rating.Again);
+    expect(scoreToRating(null)).toBe(Rating.Again);
+  });
+});
+
+describe("gradeMastery", () => {
+  it("初回 (current=null) でも next_review が未来になる", () => {
+    const now = new Date("2026-04-18T00:00:00Z");
+    const r = gradeMastery({ current: null, score: 0.8, at: now });
+    expect(r.reviewCount).toBe(1);
+    expect(r.lapseCount).toBe(0);
+    expect(r.nextReview.getTime()).toBeGreaterThan(now.getTime());
+  });
+
+  it("Again のときは 10 分ルールで next_review が now+10min に収まる", () => {
+    const now = new Date("2026-04-18T00:00:00Z");
+    const r = gradeMastery({ current: null, score: 0.2, at: now });
+    expect(r.lapseCount).toBe(1);
+    expect(r.nextReview.getTime() - now.getTime()).toBeLessThanOrEqual(10 * 60 * 1000 + 1);
+  });
+
+  it("数日分のシミュレーションで next_review が日数単位で伸びる", () => {
+    let state = gradeMastery({ current: null, score: 0.95, at: new Date("2026-04-18T00:00:00Z") });
+    const day2 = new Date("2026-04-19T00:00:00Z");
+    state = gradeMastery({
+      current: {
+        stability: state.stability,
+        difficulty: state.difficulty,
+        lastReview: state.lastReview,
+        reviewCount: state.reviewCount,
+        lapseCount: state.lapseCount,
+        mastered: state.mastered,
+        masteryPct: state.masteryPct,
+      },
+      score: 0.95,
+      at: day2,
+    });
+    const day3 = new Date("2026-04-20T00:00:00Z");
+    state = gradeMastery({
+      current: {
+        stability: state.stability,
+        difficulty: state.difficulty,
+        lastReview: state.lastReview,
+        reviewCount: state.reviewCount,
+        lapseCount: state.lapseCount,
+        mastered: state.mastered,
+        masteryPct: state.masteryPct,
+      },
+      score: 0.95,
+      at: day3,
+    });
+    expect(state.reviewCount).toBe(3);
+    expect(state.nextReview.getTime() - day3.getTime()).toBeGreaterThan(24 * 60 * 60 * 1000);
+  });
+
+  it("15 回 review で masteryPct>=1 (上限 1.0)", () => {
+    let state = gradeMastery({ current: null, score: 0.95, at: new Date("2026-04-18T00:00:00Z") });
+    for (let i = 2; i <= 15; i++) {
+      state = gradeMastery({
+        current: {
+          stability: state.stability,
+          difficulty: state.difficulty,
+          lastReview: state.lastReview,
+          reviewCount: state.reviewCount,
+          lapseCount: state.lapseCount,
+          mastered: state.mastered,
+          masteryPct: state.masteryPct,
+        },
+        score: 0.95,
+        at: new Date(`2026-04-${18 + i}T00:00:00Z`),
+      });
+    }
+    expect(state.masteryPct).toBe(1);
+    expect(state.mastered).toBe(true);
+  });
+});

--- a/src/server/scheduler/fsrs.ts
+++ b/src/server/scheduler/fsrs.ts
@@ -1,0 +1,111 @@
+import { Rating, createEmptyCard, fsrs, type Card, type Grade, type ReviewLog } from "ts-fsrs";
+
+import type { Mastery } from "@/db/schema";
+
+/**
+ * docs/02-learning-system.md §2.4 の FSRS v5 ラッパ。
+ * - scoreToRating: 0.0-1.0 のスコアから Again/Hard/Good/Easy を決める
+ * - gradeMastery: 現在の mastery と新規 attempt 結果から次回 mastery 値を計算
+ */
+
+/** Grade = Again | Hard | Good | Easy (Manual は除外) */
+export function scoreToRating(score: number | null): Grade {
+  if (score === null) return Rating.Again;
+  if (score >= 0.9) return Rating.Easy;
+  if (score >= 0.7) return Rating.Good;
+  if (score >= 0.5) return Rating.Hard;
+  return Rating.Again;
+}
+
+export type MasteryInput = Pick<
+  Mastery,
+  | "stability"
+  | "difficulty"
+  | "lastReview"
+  | "reviewCount"
+  | "lapseCount"
+  | "mastered"
+  | "masteryPct"
+>;
+
+export type MasteryUpdateResult = {
+  stability: number;
+  difficulty: number;
+  lastReview: Date;
+  nextReview: Date;
+  reviewCount: number;
+  lapseCount: number;
+  mastered: boolean;
+  masteryPct: number;
+  log: ReviewLog;
+};
+
+/** mastery_pct は reviewCount / 15 を上限 0-1 にクリップ (MVP ざっくり) */
+function computeMasteryPct(reviewCount: number, lapseCount: number): number {
+  const base = Math.min(1, reviewCount / 15);
+  const penalty = Math.min(0.3, lapseCount * 0.1);
+  return Math.max(0, base - penalty);
+}
+
+const scheduler = fsrs();
+
+/**
+ * 10 分ルール: Again 時は next_review を now + 10 分で上書き (docs/02 §2.4.4 相当)。
+ * ts-fsrs の出す interval が長すぎると「間違えた直後なのに次回は 1 日後」になるため。
+ */
+const AGAIN_NEXT_REVIEW_MS = 10 * 60 * 1000;
+
+/** mastery の現在値 (未登録なら null) と attempt の結果から次回の mastery 値を返す */
+export function gradeMastery(params: {
+  current: MasteryInput | null;
+  score: number | null;
+  at: Date;
+}): MasteryUpdateResult {
+  const rating = scoreToRating(params.score);
+
+  // ts-fsrs の Card 形式に変換。初回 (current=null) は空カード
+  const currentCard: Card = params.current
+    ? {
+        due: params.current.lastReview ?? params.at,
+        stability: params.current.stability ?? 0,
+        difficulty: params.current.difficulty ?? 0,
+        elapsed_days: 0,
+        scheduled_days: 0,
+        reps: params.current.reviewCount,
+        lapses: params.current.lapseCount,
+        state: 2, // Review state
+        last_review: params.current.lastReview ?? undefined,
+        learning_steps: 0,
+      }
+    : createEmptyCard(params.at);
+
+  const scheduled = scheduler.next(currentCard, params.at, rating);
+
+  let nextReview = scheduled.card.due;
+  // Again のときは 10 分ルールで押さえる
+  if (rating === Rating.Again) {
+    const tenMinAway = new Date(params.at.getTime() + AGAIN_NEXT_REVIEW_MS);
+    if (nextReview.getTime() > tenMinAway.getTime()) {
+      nextReview = tenMinAway;
+    }
+  }
+
+  const reviewCount = (params.current?.reviewCount ?? 0) + 1;
+  const lapseCount = (params.current?.lapseCount ?? 0) + (rating === Rating.Again ? 1 : 0);
+  const masteryPct = computeMasteryPct(reviewCount, lapseCount);
+  const mastered = masteryPct >= 0.8;
+
+  return {
+    stability: scheduled.card.stability,
+    difficulty: scheduled.card.difficulty,
+    lastReview: params.at,
+    nextReview,
+    reviewCount,
+    lapseCount,
+    mastered,
+    masteryPct,
+    log: scheduled.log,
+  };
+}
+
+export { Rating };

--- a/src/server/scheduler/promotion.test.ts
+++ b/src/server/scheduler/promotion.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from "vitest";
+
+import { computePromotion, nextAllowedDifficulty } from "./promotion";
+
+describe("nextAllowedDifficulty", () => {
+  const concept = { difficultyLevels: ["beginner", "junior", "mid"] as const };
+
+  it("junior → mid に昇格", () => {
+    expect(
+      nextAllowedDifficulty({ difficultyLevels: [...concept.difficultyLevels] }, "junior"),
+    ).toBe("mid");
+  });
+
+  it("mid は daily cap に達しているので null", () => {
+    expect(nextAllowedDifficulty({ difficultyLevels: [...concept.difficultyLevels] }, "mid")).toBe(
+      null,
+    );
+  });
+
+  it("concept が許可していない難易度はスキップ", () => {
+    const sparse = { difficultyLevels: ["beginner", "mid"] as const };
+    expect(
+      nextAllowedDifficulty({ difficultyLevels: [...sparse.difficultyLevels] }, "beginner"),
+    ).toBe("mid");
+  });
+});
+
+describe("computePromotion", () => {
+  const concept = { difficultyLevels: ["beginner", "junior", "mid", "senior"] as const };
+
+  it("3 連続正解 (新しい順) で 1 段昇格", () => {
+    const r = computePromotion({
+      concept: { difficultyLevels: [...concept.difficultyLevels] },
+      currentDifficulty: "junior",
+      recentCorrect: [true, true, true],
+    });
+    expect(r).toBe("mid");
+  });
+
+  it("2 連続だけなら null", () => {
+    const r = computePromotion({
+      concept: { difficultyLevels: [...concept.difficultyLevels] },
+      currentDifficulty: "junior",
+      recentCorrect: [true, true],
+    });
+    expect(r).toBe(null);
+  });
+
+  it("直近 3 件に 1 つでも不正解が混ざれば null", () => {
+    const r = computePromotion({
+      concept: { difficultyLevels: [...concept.difficultyLevels] },
+      currentDifficulty: "junior",
+      recentCorrect: [true, false, true],
+    });
+    expect(r).toBe(null);
+  });
+
+  it("Daily cap (mid) を超えて senior にはならない", () => {
+    const r = computePromotion({
+      concept: { difficultyLevels: [...concept.difficultyLevels] },
+      currentDifficulty: "mid",
+      recentCorrect: [true, true, true],
+    });
+    expect(r).toBe(null);
+  });
+});

--- a/src/server/scheduler/promotion.ts
+++ b/src/server/scheduler/promotion.ts
@@ -1,0 +1,43 @@
+import { DIFFICULTY_LEVELS, type Concept, type DifficultyLevel } from "@/db/schema";
+
+/** 3 連続正解で 1 段昇格 (docs/02-learning-system.md §2.4.5) */
+export const STREAK_FOR_PROMOTION = 3;
+
+/**
+ * Daily Drill で自動昇格できる上限。senior 以上は明示指定のみ (ADR-0001)。
+ */
+export const DAILY_AUTO_PROMOTION_CAP: DifficultyLevel = "mid";
+
+/** concept の許可 difficulty のうち、現在の difficulty から 1 段上で許可される値 */
+export function nextAllowedDifficulty(
+  concept: Pick<Concept, "difficultyLevels">,
+  current: DifficultyLevel,
+  cap: DifficultyLevel = DAILY_AUTO_PROMOTION_CAP,
+): DifficultyLevel | null {
+  const levels = concept.difficultyLevels;
+  const currentIdx = DIFFICULTY_LEVELS.indexOf(current);
+  const capIdx = DIFFICULTY_LEVELS.indexOf(cap);
+  if (currentIdx < 0 || capIdx < 0) return null;
+  for (let i = currentIdx + 1; i <= capIdx; i++) {
+    const level = DIFFICULTY_LEVELS[i];
+    if (level && levels.includes(level)) return level;
+  }
+  return null;
+}
+
+/**
+ * 直近の attempts から連続正解数を数え、n 連続正解なら 1 段昇格する difficulty を返す。
+ * 連続が足りないか昇格可能な上位難易度がなければ null。
+ */
+export function computePromotion(params: {
+  concept: Pick<Concept, "difficultyLevels">;
+  currentDifficulty: DifficultyLevel;
+  /** 新しい順。最大 STREAK_FOR_PROMOTION 件見れば足りる */
+  recentCorrect: boolean[];
+  cap?: DifficultyLevel;
+}): DifficultyLevel | null {
+  const streak = params.recentCorrect.slice(0, STREAK_FOR_PROMOTION);
+  if (streak.length < STREAK_FOR_PROMOTION) return null;
+  if (!streak.every((c) => c === true)) return null;
+  return nextAllowedDifficulty(params.concept, params.currentDifficulty, params.cap);
+}

--- a/src/server/scheduler/update-mastery.ts
+++ b/src/server/scheduler/update-mastery.ts
@@ -1,0 +1,76 @@
+import { and, eq } from "drizzle-orm";
+
+import { getDb } from "@/db/client";
+import { mastery, type Mastery } from "@/db/schema";
+
+import { gradeMastery } from "./fsrs";
+
+/**
+ * 採点直後に mastery を upsert する統合関数。grader からフローで呼ばれる想定。
+ */
+export async function updateMasteryAfterAttempt(params: {
+  userId: string;
+  conceptId: string;
+  score: number | null;
+  at?: Date;
+}): Promise<Mastery> {
+  const at = params.at ?? new Date();
+  const db = getDb();
+
+  const existing = await db
+    .select()
+    .from(mastery)
+    .where(and(eq(mastery.userId, params.userId), eq(mastery.conceptId, params.conceptId)))
+    .limit(1);
+  const current = existing[0] ?? null;
+
+  const update = gradeMastery({
+    current: current
+      ? {
+          stability: current.stability,
+          difficulty: current.difficulty,
+          lastReview: current.lastReview,
+          reviewCount: current.reviewCount,
+          lapseCount: current.lapseCount,
+          mastered: current.mastered,
+          masteryPct: current.masteryPct,
+        }
+      : null,
+    score: params.score,
+    at,
+  });
+
+  const values = {
+    userId: params.userId,
+    conceptId: params.conceptId,
+    stability: update.stability,
+    difficulty: update.difficulty,
+    lastReview: update.lastReview,
+    nextReview: update.nextReview,
+    reviewCount: update.reviewCount,
+    lapseCount: update.lapseCount,
+    mastered: update.mastered,
+    masteryPct: update.masteryPct,
+  };
+
+  const [row] = await db
+    .insert(mastery)
+    .values(values)
+    .onConflictDoUpdate({
+      target: [mastery.userId, mastery.conceptId],
+      set: {
+        stability: values.stability,
+        difficulty: values.difficulty,
+        lastReview: values.lastReview,
+        nextReview: values.nextReview,
+        reviewCount: values.reviewCount,
+        lapseCount: values.lapseCount,
+        mastered: values.mastered,
+        masteryPct: values.masteryPct,
+      },
+    })
+    .returning();
+
+  if (!row) throw new Error("failed to upsert mastery");
+  return row;
+}

--- a/src/server/scheduler/update-mastery.ts
+++ b/src/server/scheduler/update-mastery.ts
@@ -8,9 +8,12 @@ import { gradeMastery } from "./fsrs";
 /**
  * 採点直後に mastery を upsert する統合関数。
  *
- * 原子性: 現在値を読んで gradeMastery で次状態を計算した後、書き戻す際は
- * reviewCount と lapseCount のみ SQL の +1 / +0 増分で書く。stability や next_review 等の
- * 絶対値は同じ呼び出し内では read-calc-write のままだが、MVP (作者 1 人) ではほぼ並行しない。
+ * 原子性 (docs/OPEN_QUESTIONS.md Q12):
+ *   - reviewCount / lapseCount は SQL +1 で atomic
+ *   - stability / nextReview などの FSRS 本体状態は read-calc-write のままで、
+ *     並行 attempt で最後の writer が他方の遷移を落とす可能性が残る
+ *   - 作者 1 人の MVP では並行 attempt は事実上発生しないため許容。マルチユーザー化時に
+ *     websocket ドライバ + transaction、または mastery に version 列を追加して楽観ロックに切り替える。
  */
 export async function updateMasteryAfterAttempt(params: {
   userId: string;

--- a/src/server/scheduler/update-mastery.ts
+++ b/src/server/scheduler/update-mastery.ts
@@ -1,4 +1,4 @@
-import { and, eq } from "drizzle-orm";
+import { and, eq, sql } from "drizzle-orm";
 
 import { getDb } from "@/db/client";
 import { mastery, type Mastery } from "@/db/schema";
@@ -6,7 +6,11 @@ import { mastery, type Mastery } from "@/db/schema";
 import { gradeMastery } from "./fsrs";
 
 /**
- * 採点直後に mastery を upsert する統合関数。grader からフローで呼ばれる想定。
+ * 採点直後に mastery を upsert する統合関数。
+ *
+ * 原子性: 現在値を読んで gradeMastery で次状態を計算した後、書き戻す際は
+ * reviewCount と lapseCount のみ SQL の +1 / +0 増分で書く。stability や next_review 等の
+ * 絶対値は同じ呼び出し内では read-calc-write のままだが、MVP (作者 1 人) ではほぼ並行しない。
  */
 export async function updateMasteryAfterAttempt(params: {
   userId: string;
@@ -40,33 +44,34 @@ export async function updateMasteryAfterAttempt(params: {
     at,
   });
 
-  const values = {
-    userId: params.userId,
-    conceptId: params.conceptId,
-    stability: update.stability,
-    difficulty: update.difficulty,
-    lastReview: update.lastReview,
-    nextReview: update.nextReview,
-    reviewCount: update.reviewCount,
-    lapseCount: update.lapseCount,
-    mastered: update.mastered,
-    masteryPct: update.masteryPct,
-  };
+  const lapsed = update.lapseCount > (current?.lapseCount ?? 0);
 
   const [row] = await db
     .insert(mastery)
-    .values(values)
+    .values({
+      userId: params.userId,
+      conceptId: params.conceptId,
+      stability: update.stability,
+      difficulty: update.difficulty,
+      lastReview: update.lastReview,
+      nextReview: update.nextReview,
+      reviewCount: update.reviewCount,
+      lapseCount: update.lapseCount,
+      mastered: update.mastered,
+      masteryPct: update.masteryPct,
+    })
     .onConflictDoUpdate({
       target: [mastery.userId, mastery.conceptId],
       set: {
-        stability: values.stability,
-        difficulty: values.difficulty,
-        lastReview: values.lastReview,
-        nextReview: values.nextReview,
-        reviewCount: values.reviewCount,
-        lapseCount: values.lapseCount,
-        mastered: values.mastered,
-        masteryPct: values.masteryPct,
+        stability: update.stability,
+        difficulty: update.difficulty,
+        lastReview: update.lastReview,
+        nextReview: update.nextReview,
+        // review_count / lapse_count は並行競合でも増分が落ちないよう SQL 側で atomic に +1
+        reviewCount: sql`${mastery.reviewCount} + 1`,
+        lapseCount: lapsed ? sql`${mastery.lapseCount} + 1` : sql`${mastery.lapseCount}`,
+        mastered: update.mastered,
+        masteryPct: update.masteryPct,
       },
     })
     .returning();

--- a/src/server/trpc/routers/session.ts
+++ b/src/server/trpc/routers/session.ts
@@ -1,5 +1,5 @@
 import { TRPCError } from "@trpc/server";
-import { and, eq, isNull, sql } from "drizzle-orm";
+import { and, desc, eq, isNull, sql } from "drizzle-orm";
 import { z } from "zod";
 
 import { getDb } from "@/db/client";
@@ -10,9 +10,11 @@ import {
   SESSION_KINDS,
   sessions,
   THINKING_STYLES,
+  type DifficultyLevel,
 } from "@/db/schema";
 import { generateMcq } from "@/server/generator/mcq";
 import { gradeAttempt } from "@/server/grader";
+import { STREAK_FOR_PROMOTION, computePromotion } from "@/server/scheduler/promotion";
 
 import { protectedProcedure, router } from "../init";
 
@@ -48,6 +50,13 @@ async function pickConceptForDrill() {
   if (!row) {
     throw new TRPCError({ code: "PRECONDITION_FAILED", message: "no seeded concept" });
   }
+  return row;
+}
+
+async function loadConcept(conceptId: string) {
+  const rows = await getDb().select().from(concepts).where(eq(concepts.id, conceptId)).limit(1);
+  const row = rows[0];
+  if (!row) throw new TRPCError({ code: "NOT_FOUND", message: `unknown concept: ${conceptId}` });
   return row;
 }
 
@@ -132,13 +141,29 @@ export const sessionRouter = router({
       }
 
       // 予約後に問題生成が失敗したら pendingQuestionId を null に戻してセッションを復帰させる。
-      // finally では throw を再送出するので、ロールバック自体が成功しなくても本体エラーが優先される
       let question: Awaited<ReturnType<typeof generateMcq>>["question"];
       try {
-        const concept = input.conceptId ? { id: input.conceptId } : await pickConceptForDrill();
+        const conceptRow = input.conceptId
+          ? await loadConcept(input.conceptId)
+          : await pickConceptForDrill();
+
+        // 直近 STREAK_FOR_PROMOTION 件の同 concept の attempts を見て、3 連続正解なら次出題を 1 段昇格
+        const recent = await getDb()
+          .select({ correct: attempts.correct })
+          .from(attempts)
+          .where(and(eq(attempts.userId, ctx.user.id), eq(attempts.conceptId, conceptRow.id)))
+          .orderBy(desc(attempts.createdAt))
+          .limit(STREAK_FOR_PROMOTION);
+        const promoted = computePromotion({
+          concept: { difficultyLevels: conceptRow.difficultyLevels },
+          currentDifficulty: input.difficulty,
+          recentCorrect: recent.map((r) => r.correct === true),
+        });
+        const effectiveDifficulty: DifficultyLevel = promoted ?? input.difficulty;
+
         const generated = await generateMcq({
-          conceptId: concept.id,
-          difficulty: input.difficulty,
+          conceptId: conceptRow.id,
+          difficulty: effectiveDifficulty,
           thinkingStyle: input.thinkingStyle,
         });
         question = generated.question;


### PR DESCRIPTION
## Summary
Issue #12 を解決。docs/02-learning-system.md §2.4 の FSRS v5 統合を実装。

- `src/server/scheduler/fsrs.ts`: scoreToRating + gradeMastery (ts-fsrs ラップ) + 10 分ルール
- `src/server/scheduler/update-mastery.ts`: mastery を upsert する統合
- `src/server/scheduler/promotion.ts`: 3 連続正解 × Daily cap (mid) で自動昇格 (ADR-0001)
- `src/server/grader/index.ts`: attempt insert 成功時のみ mastery を更新 (二重 submit の losing race では skip)

## 受け入れ基準 (#12)
- [x] scheduler/fsrs.ts で ts-fsrs をラップ
- [x] スコア→rating 変換 (>=0.9 Easy, >=0.7 Good, >=0.5 Hard, else Again)
- [x] 3 連続正解で mid まで昇格 (Daily Drill は senior 以上に自動昇格しない)
- [x] attempt 成功時に mastery を upsert
- [x] 10 分ルール (Again 時 next_review <= now+10min)
- [x] unit test: 数日シミュレーションで next_review が日数単位で伸びる

Closes #12

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm test -- --run` (82 pass, +12)
- [x] `pnpm build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)