### PR TITLE
feat(qtype): short / written 生成 + written 採点

### DIFF
--- a/prompts/generation/short.v1.md
+++ b/prompts/generation/short.v1.md
@@ -1,0 +1,51 @@
+# short.v1
+
+short answer (1-2 文の短答) の問題を gpt-5 で生成するプロンプト。
+Output requirements を user 冒頭、可変は末尾 (CLAUDE.md §4.5 prompt caching)。
+
+---
+
+<!-- role:system -->
+
+You are a senior engineer creating a short-answer quiz question for a professional software engineer.
+Output strictly as JSON matching the provided schema. Use 日本語 (Japanese) for all human-readable fields.
+
+<!-- /role -->
+
+<!-- role:user -->
+
+## Output requirements (固定)
+
+- `prompt` (string): 日本語の問題文 (1-2 文の答えで十分なレベル)
+- `answer` (string): 期待される模範解答 (1-2 文)
+- `rubric` (array of object): 採点基準 2-4 項目
+  - `id` (string): 項目識別子 (例: "r1")
+  - `description` (string): この項目が満たされる条件
+  - `weight` (number): 0-1 の重み (合計 1 に近くなるように)
+- `hint` (string | null): 解答前に 1 回だけ表示できるヒント (Optional)
+- `explanation` (string): 模範解答の補足説明 (1-3 文)
+- `tags` (string[]): 1〜4 個の短い英語タグ
+
+## Concept (可変)
+
+id: {{ conceptId }}
+name: {{ conceptName }}
+description: {{ conceptDescription }}
+domain: {{ domainId }}
+subdomain: {{ subdomainId }}
+
+## Spec (可変)
+
+difficulty: {{ difficulty }}
+thinking_style: {{ thinkingStyle }}
+
+## Style instruction (可変)
+
+{{ styleInstruction }}
+
+## Avoid duplicates (可変)
+
+Past recent framings for this concept (last 30 days, if any):
+{{ pastQuestionsSummary }}
+
+<!-- /role -->

--- a/prompts/generation/written.v1.md
+++ b/prompts/generation/written.v1.md
@@ -1,0 +1,51 @@
+# written.v1
+
+written answer (数段落の記述) の問題を gpt-5 で生成するプロンプト。
+
+---
+
+<!-- role:system -->
+
+You are a senior engineer creating a written-answer quiz question for a professional software engineer.
+The answer is expected to be a few paragraphs explaining reasoning, trade-offs, or design decisions.
+Output strictly as JSON matching the provided schema. Use 日本語 (Japanese) for all human-readable fields.
+
+<!-- /role -->
+
+<!-- role:user -->
+
+## Output requirements (固定)
+
+- `prompt` (string): 日本語の問題文 (複数段落の記述が必要なレベル)
+- `answer` (string): 期待される模範解答の骨子 (箇条書きでも可)
+- `rubric` (array of object): 採点基準 3-5 項目
+  - `id` (string)
+  - `description` (string): 例 "TCP 輻輳制御のメカニズムに言及", "バックオフ戦略のトレードオフを議論"
+  - `weight` (number): 0-1
+- `hint` (string | null)
+- `explanation` (string): 模範解答の補足 (2-4 文)
+- `tags` (string[]): 1〜4 個
+
+## Concept (可変)
+
+id: {{ conceptId }}
+name: {{ conceptName }}
+description: {{ conceptDescription }}
+domain: {{ domainId }}
+subdomain: {{ subdomainId }}
+
+## Spec (可変)
+
+difficulty: {{ difficulty }}
+thinking_style: {{ thinkingStyle }}
+
+## Style instruction (可変)
+
+{{ styleInstruction }}
+
+## Avoid duplicates (可変)
+
+Past recent framings for this concept (last 30 days, if any):
+{{ pastQuestionsSummary }}
+
+<!-- /role -->

--- a/prompts/grading/written.v1.md
+++ b/prompts/grading/written.v1.md
@@ -1,0 +1,42 @@
+# written.v1
+
+written answer を gpt-5 で採点するプロンプト。
+
+---
+
+<!-- role:system -->
+
+You are a senior engineer grading a written answer to an engineering question.
+Output strictly as JSON matching the provided schema. Use 日本語 for all human-readable fields.
+
+<!-- /role -->
+
+<!-- role:user -->
+
+## Output requirements (固定)
+
+- `score` (number, 0.0-1.0): ルーブリックの weight で加重した総合点。部分点あり
+- `correct` (boolean): score が閾値を超えたか (サーバー側で上書きするので LLM 値は参考値)
+- `feedback` (string): 合格点 / 不合格点を 2-4 文で日本語 (強み / 弱みの両面)
+- `rubricChecks` (array): ルーブリック各項目の結果
+  - `id` (string): 入力通り
+  - `passed` (boolean): 項目 rubric を満たしたか
+  - `comment` (string): 満たされなかった場合は何が足りないかを 1-2 文で
+
+## Question (可変)
+
+{{ questionPrompt }}
+
+## Expected answer (可変、模範解答の骨子)
+
+{{ expectedAnswer }}
+
+## Rubric (可変、採点基準)
+
+{{ rubric }}
+
+## User answer (可変、被採点テキスト)
+
+{{ userAnswer }}
+
+<!-- /role -->

--- a/src/server/generator/short-written-schema.ts
+++ b/src/server/generator/short-written-schema.ts
@@ -1,0 +1,56 @@
+import { z } from "zod";
+
+export const GeneratedShortWrittenSchema = z.object({
+  prompt: z.string().min(1),
+  answer: z.string().min(1),
+  rubric: z
+    .array(
+      z.object({
+        id: z.string().min(1),
+        description: z.string().min(1),
+        weight: z.number().min(0).max(1),
+      }),
+    )
+    .min(2),
+  hint: z.string().nullable(),
+  explanation: z.string().min(1),
+  tags: z.array(z.string().min(1)).min(1).max(4),
+});
+
+export type GeneratedShortWritten = z.infer<typeof GeneratedShortWrittenSchema>;
+
+export const SHORT_WRITTEN_JSON_SCHEMA = {
+  name: "short_or_written_question",
+  strict: true as const,
+  schema: {
+    type: "object",
+    additionalProperties: false,
+    required: ["prompt", "answer", "rubric", "hint", "explanation", "tags"],
+    properties: {
+      prompt: { type: "string" },
+      answer: { type: "string" },
+      rubric: {
+        type: "array",
+        minItems: 2,
+        items: {
+          type: "object",
+          additionalProperties: false,
+          required: ["id", "description", "weight"],
+          properties: {
+            id: { type: "string" },
+            description: { type: "string" },
+            weight: { type: "number", minimum: 0, maximum: 1 },
+          },
+        },
+      },
+      hint: { type: ["string", "null"] },
+      explanation: { type: "string" },
+      tags: {
+        type: "array",
+        items: { type: "string" },
+        minItems: 1,
+        maxItems: 4,
+      },
+    },
+  },
+};

--- a/src/server/generator/short-written.test.ts
+++ b/src/server/generator/short-written.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+
+import { GeneratedShortWrittenSchema, SHORT_WRITTEN_JSON_SCHEMA } from "./short-written-schema";
+
+describe("GeneratedShortWrittenSchema", () => {
+  it("正常系 (rubric 2 項目以上)", () => {
+    const ok = {
+      prompt: "HTTP PUT と PATCH の違いを 2 文で。",
+      answer: "PUT は冪等、PATCH は部分更新。",
+      rubric: [
+        { id: "r1", description: "PUT の冪等性に言及", weight: 0.5 },
+        { id: "r2", description: "PATCH の部分更新に言及", weight: 0.5 },
+      ],
+      hint: null,
+      explanation: "冪等性とは同じリクエストを何度送っても結果が同じになる性質。",
+      tags: ["rest"],
+    };
+    expect(() => GeneratedShortWrittenSchema.parse(ok)).not.toThrow();
+  });
+
+  it("rubric 1 件なら reject", () => {
+    const bad = {
+      prompt: "x",
+      answer: "y",
+      rubric: [{ id: "r1", description: "d", weight: 1 }],
+      hint: null,
+      explanation: "z",
+      tags: ["t"],
+    };
+    expect(() => GeneratedShortWrittenSchema.parse(bad)).toThrow();
+  });
+
+  it("JSON schema は strict + additionalProperties=false", () => {
+    expect(SHORT_WRITTEN_JSON_SCHEMA.strict).toBe(true);
+    expect(SHORT_WRITTEN_JSON_SCHEMA.schema.additionalProperties).toBe(false);
+    expect(SHORT_WRITTEN_JSON_SCHEMA.schema.required).toContain("rubric");
+  });
+});

--- a/src/server/generator/short-written.ts
+++ b/src/server/generator/short-written.ts
@@ -1,0 +1,147 @@
+import { eq } from "drizzle-orm";
+
+import { getDb } from "@/db/client";
+import {
+  concepts,
+  questions,
+  type Concept,
+  type DifficultyLevel,
+  type Question,
+  type QuestionType,
+  type ThinkingStyle,
+} from "@/db/schema";
+import { getOpenAI } from "@/lib/openai/client";
+import { MODEL_MAIN } from "@/lib/openai/models";
+
+import { findCachedQuestion } from "./cache";
+import { renderTemplate } from "./prompt-template";
+import { styleInstruction } from "./prompts";
+import {
+  GeneratedShortWrittenSchema,
+  SHORT_WRITTEN_JSON_SCHEMA,
+  type GeneratedShortWritten,
+} from "./short-written-schema";
+
+/**
+ * short / written の生成。mcq と同じ `prompts/generation/{short,written}.v1.md` を読む。
+ * JSON schema に distractors はない代わりに rubric が必須。
+ */
+
+const PROMPT_VERSIONS = {
+  short: "short.v1",
+  written: "written.v1",
+} as const;
+
+const TEMPLATE_PATHS = {
+  short: "generation/short.v1.md",
+  written: "generation/written.v1.md",
+} as const;
+
+export type GenerateShortWrittenInput = {
+  conceptId: string;
+  type: "short" | "written";
+  difficulty: DifficultyLevel;
+  thinkingStyle: ThinkingStyle | null;
+  forceFresh?: boolean;
+};
+
+export type GenerateShortWrittenResult = {
+  question: Question;
+  source: "cache" | "generated";
+};
+
+export type ShortWrittenLlmCaller = (args: {
+  model: string;
+  system: string;
+  user: string;
+}) => Promise<GeneratedShortWritten>;
+
+export const defaultShortWrittenLlm: ShortWrittenLlmCaller = async ({ model, system, user }) => {
+  const client = getOpenAI();
+  const res = await client.responses.create({
+    model,
+    input: [
+      { role: "system", content: system },
+      { role: "user", content: user },
+    ],
+    text: {
+      format: {
+        type: "json_schema",
+        ...SHORT_WRITTEN_JSON_SCHEMA,
+      },
+    },
+  });
+  return GeneratedShortWrittenSchema.parse(JSON.parse(res.output_text));
+};
+
+async function loadConcept(conceptId: string): Promise<Concept> {
+  const rows = await getDb().select().from(concepts).where(eq(concepts.id, conceptId)).limit(1);
+  const row = rows[0];
+  if (!row) throw new Error(`unknown concept: ${conceptId}`);
+  return row;
+}
+
+function assertDifficultyAllowed(concept: Concept, difficulty: DifficultyLevel): void {
+  if (!concept.difficultyLevels.includes(difficulty)) {
+    throw new Error(
+      `difficulty ${difficulty} not allowed for concept ${concept.id} (allowed: ${concept.difficultyLevels.join(",")})`,
+    );
+  }
+}
+
+export async function generateShortWritten(
+  input: GenerateShortWrittenInput,
+  llm: ShortWrittenLlmCaller = defaultShortWrittenLlm,
+): Promise<GenerateShortWrittenResult> {
+  const db = getDb();
+  const concept = await loadConcept(input.conceptId);
+  assertDifficultyAllowed(concept, input.difficulty);
+
+  if (!input.forceFresh) {
+    const cached = await findCachedQuestion(db, {
+      conceptId: input.conceptId,
+      type: input.type as QuestionType,
+      thinkingStyle: input.thinkingStyle,
+      difficulty: input.difficulty,
+    });
+    // short/written はまだ cache ローテーション戦略が未成熟なので、cache があれば返す
+    if (cached) return { question: cached, source: "cache" };
+  }
+
+  const rendered = renderTemplate(TEMPLATE_PATHS[input.type], {
+    conceptId: concept.id,
+    conceptName: concept.name,
+    conceptDescription: concept.description ?? "(none)",
+    domainId: concept.domainId,
+    subdomainId: concept.subdomainId,
+    difficulty: input.difficulty,
+    thinkingStyle: input.thinkingStyle ?? "(none)",
+    styleInstruction: styleInstruction(input.thinkingStyle),
+    pastQuestionsSummary: "(none)",
+  });
+
+  const generated = await llm({ model: MODEL_MAIN, system: rendered.system, user: rendered.user });
+
+  const [inserted] = await db
+    .insert(questions)
+    .values({
+      conceptId: input.conceptId,
+      type: input.type,
+      difficulty: input.difficulty,
+      thinkingStyle: input.thinkingStyle,
+      prompt: generated.prompt,
+      answer: generated.answer,
+      rubric: generated.rubric,
+      hint: generated.hint,
+      explanation: generated.explanation,
+      tags: generated.tags,
+      generatedBy: MODEL_MAIN,
+      promptVersion: PROMPT_VERSIONS[input.type],
+      serveCount: 1,
+      lastServedAt: new Date(),
+    })
+    .returning();
+
+  if (!inserted) throw new Error("failed to insert generated question");
+  return { question: inserted, source: "generated" };
+}

--- a/src/server/grader/__snapshots__/written.test.ts.snap
+++ b/src/server/grader/__snapshots__/written.test.ts.snap
@@ -1,0 +1,35 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`buildWrittenGradingPrompt > snapshot: 代表入力 (rubric あり) 1`] = `
+{
+  "system": "You are a senior engineer grading a written answer to an engineering question.
+Output strictly as JSON matching the provided schema. Use 日本語 for all human-readable fields.",
+  "user": "## Output requirements (固定)
+
+- \`score\` (number, 0.0-1.0): ルーブリックの weight で加重した総合点。部分点あり
+- \`correct\` (boolean): score が閾値を超えたか (サーバー側で上書きするので LLM 値は参考値)
+- \`feedback\` (string): 合格点 / 不合格点を 2-4 文で日本語 (強み / 弱みの両面)
+- \`rubricChecks\` (array): ルーブリック各項目の結果
+  - \`id\` (string): 入力通り
+  - \`passed\` (boolean): 項目 rubric を満たしたか
+  - \`comment\` (string): 満たされなかった場合は何が足りないかを 1-2 文で
+
+## Question (可変)
+
+TCP 輻輳制御の基本アルゴリズムを複数段落で説明。
+
+## Expected answer (可変、模範解答の骨子)
+
+Slow start / Congestion avoidance / Fast retransmit / Fast recovery の 4 段階。
+
+## Rubric (可変、採点基準)
+
+- id=r1: slow start に言及 (weight=0.25)
+- id=r2: cwnd 増加の式に言及 (weight=0.25)
+- id=r3: fast retransmit / fast recovery の違い (weight=0.5)
+
+## User answer (可変、被採点テキスト)
+
+TCP の輻輳制御は slow start で指数関数的に cwnd を増やし、閾値を超えたら AIMD で線形に増やす。3 ACK が来たら fast retransmit で再送する。",
+}
+`;

--- a/src/server/grader/index.ts
+++ b/src/server/grader/index.ts
@@ -14,6 +14,7 @@ import { updateMasteryAfterAttempt } from "@/server/scheduler/update-mastery";
 
 import { gradeMcq } from "./mcq";
 import { gradeShort } from "./short";
+import { gradeWritten } from "./written";
 
 export type GradeAttemptInput = {
   userId: string;
@@ -91,8 +92,11 @@ export async function gradeAttempt(input: GradeAttemptInput): Promise<GradeAttem
       feedback: result.feedback,
       rubricChecks: [],
     };
-  } else if (question.type === "short") {
-    const result = await gradeShort({ question, userAnswer: input.userAnswer });
+  } else if (question.type === "short" || question.type === "written") {
+    const result =
+      question.type === "short"
+        ? await gradeShort({ question, userAnswer: input.userAnswer })
+        : await gradeWritten({ question, userAnswer: input.userAnswer });
     row = {
       userId: input.userId,
       sessionId: input.sessionId,
@@ -116,7 +120,10 @@ export async function gradeAttempt(input: GradeAttemptInput): Promise<GradeAttem
       rubricChecks: result.rubricChecks,
     };
   } else {
-    throw new Error(`grading for type="${question.type}" is not implemented (issue #14+)`);
+    throw new TRPCError({
+      code: "NOT_IMPLEMENTED",
+      message: `grading for type="${question.type}" is not implemented yet`,
+    });
   }
 
   // (session_id, question_id) の unique index で二重 submit を防ぐ。

--- a/src/server/grader/written.test.ts
+++ b/src/server/grader/written.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+
+import { buildWrittenGradingPrompt, gradeWritten } from "./written";
+
+describe("buildWrittenGradingPrompt", () => {
+  it("snapshot: 代表入力 (rubric あり)", () => {
+    const out = buildWrittenGradingPrompt({
+      question: {
+        prompt: "TCP 輻輳制御の基本アルゴリズムを複数段落で説明。",
+        answer: "Slow start / Congestion avoidance / Fast retransmit / Fast recovery の 4 段階。",
+        rubric: [
+          { id: "r1", description: "slow start に言及", weight: 0.25 },
+          { id: "r2", description: "cwnd 増加の式に言及", weight: 0.25 },
+          { id: "r3", description: "fast retransmit / fast recovery の違い", weight: 0.5 },
+        ],
+      },
+      userAnswer:
+        "TCP の輻輳制御は slow start で指数関数的に cwnd を増やし、閾値を超えたら AIMD で線形に増やす。3 ACK が来たら fast retransmit で再送する。",
+    });
+    expect({ system: out.system, user: out.user }).toMatchSnapshot();
+  });
+});
+
+describe("gradeWritten: LLM の correct は score から導出する", () => {
+  const question = {
+    prompt: "説明せよ",
+    answer: "模範回答",
+    rubric: [{ id: "r1", description: "x", weight: 1 }],
+  };
+
+  it("score 0.6 は correct=false (部分点だが合格閾値 0.7 未満)", async () => {
+    const r = await gradeWritten({ question, userAnswer: "xxx" }, async () => ({
+      score: 0.6,
+      correct: true, // LLM 自己申告は信用しない
+      feedback: "x",
+      rubricChecks: [],
+    }));
+    expect(r.correct).toBe(false);
+  });
+
+  it("score 0.8 は correct=true", async () => {
+    const r = await gradeWritten({ question, userAnswer: "xxx" }, async () => ({
+      score: 0.8,
+      correct: false,
+      feedback: "x",
+      rubricChecks: [],
+    }));
+    expect(r.correct).toBe(true);
+  });
+});

--- a/src/server/grader/written.ts
+++ b/src/server/grader/written.ts
@@ -1,0 +1,71 @@
+import type { Question, RubricCheck } from "@/db/schema";
+import { getOpenAI } from "@/lib/openai/client";
+import { MODEL_MAIN } from "@/lib/openai/models";
+
+import { renderTemplate } from "../generator/prompt-template";
+import { GradedShortSchema, SHORT_JSON_SCHEMA, type GradedShort } from "./schema";
+
+export const WRITTEN_PROMPT_VERSION = "written.v1";
+const WRITTEN_TEMPLATE_PATH = "grading/written.v1.md";
+
+const CORRECT_THRESHOLD = 0.7;
+
+export type WrittenGradingInput = {
+  question: Pick<Question, "prompt" | "answer" | "rubric">;
+  userAnswer: string;
+};
+
+function formatRubric(rubric: RubricCheck[] | null | undefined): string {
+  if (!rubric || rubric.length === 0) return "(none)";
+  return rubric
+    .map((r) => `- id=${r.id}: ${r.description}${r.weight ? ` (weight=${r.weight})` : ""}`)
+    .join("\n");
+}
+
+export function buildWrittenGradingPrompt(input: WrittenGradingInput) {
+  return renderTemplate(WRITTEN_TEMPLATE_PATH, {
+    questionPrompt: input.question.prompt,
+    expectedAnswer: input.question.answer,
+    rubric: formatRubric(input.question.rubric),
+    userAnswer: input.userAnswer,
+  });
+}
+
+export type WrittenLlmCaller = (args: {
+  model: string;
+  system: string;
+  user: string;
+}) => Promise<GradedShort>;
+
+export const defaultWrittenLlm: WrittenLlmCaller = async ({ model, system, user }) => {
+  const client = getOpenAI();
+  const res = await client.responses.create({
+    model,
+    input: [
+      { role: "system", content: system },
+      { role: "user", content: user },
+    ],
+    text: {
+      format: {
+        type: "json_schema",
+        ...SHORT_JSON_SCHEMA, // 採点結果の schema は short と同じ (score/correct/feedback/rubricChecks)
+      },
+    },
+  });
+  return GradedShortSchema.parse(JSON.parse(res.output_text));
+};
+
+/** written 採点は gpt-5。score から correct を導出 (LLM 自己申告は信用しない) */
+export async function gradeWritten(
+  input: WrittenGradingInput,
+  llm: WrittenLlmCaller = defaultWrittenLlm,
+) {
+  const { system, user } = buildWrittenGradingPrompt(input);
+  const graded = await llm({ model: MODEL_MAIN, system, user });
+  return {
+    ...graded,
+    correct: graded.score >= CORRECT_THRESHOLD,
+    model: MODEL_MAIN,
+    promptVersion: WRITTEN_PROMPT_VERSION,
+  };
+}

--- a/src/server/scheduler/fsrs.test.ts
+++ b/src/server/scheduler/fsrs.test.ts
@@ -3,12 +3,15 @@ import { describe, it, expect } from "vitest";
 import { gradeMastery, Rating, scoreToRating } from "./fsrs";
 
 describe("scoreToRating", () => {
-  it("score で Easy/Good/Hard/Again を分岐", () => {
+  it("score で Easy/Good/Hard/Again を分岐 (部分正解 0.5-0.9 未満は Hard)", () => {
     expect(scoreToRating(1.0)).toBe(Rating.Easy);
-    expect(scoreToRating(0.9)).toBe(Rating.Easy);
-    expect(scoreToRating(0.85)).toBe(Rating.Good);
-    expect(scoreToRating(0.7)).toBe(Rating.Good);
-    expect(scoreToRating(0.6)).toBe(Rating.Hard);
+    expect(scoreToRating(0.95)).toBe(Rating.Easy);
+    expect(scoreToRating(0.9)).toBe(Rating.Good);
+    // 部分正解帯
+    expect(scoreToRating(0.85)).toBe(Rating.Hard);
+    expect(scoreToRating(0.7)).toBe(Rating.Hard);
+    expect(scoreToRating(0.5)).toBe(Rating.Hard);
+    // 不正解帯
     expect(scoreToRating(0.49)).toBe(Rating.Again);
     expect(scoreToRating(null)).toBe(Rating.Again);
   });

--- a/src/server/scheduler/fsrs.ts
+++ b/src/server/scheduler/fsrs.ts
@@ -8,11 +8,15 @@ import type { Mastery } from "@/db/schema";
  * - gradeMastery: 現在の mastery と新規 attempt 結果から次回 mastery 値を計算
  */
 
-/** Grade = Again | Hard | Good | Easy (Manual は除外) */
+/**
+ * Grade = Again | Hard | Good | Easy (Manual は除外)。
+ * mcq (0 or 1) は Again / Easy の二値。short / written の部分正解 (0.5 <= score < 0.9) は
+ * Hard として FSRS に送る (docs/02-learning-system.md §2.4 / issue #14 受け入れ基準)。
+ */
 export function scoreToRating(score: number | null): Grade {
   if (score === null) return Rating.Again;
-  if (score >= 0.9) return Rating.Easy;
-  if (score >= 0.7) return Rating.Good;
+  if (score >= 0.95) return Rating.Easy;
+  if (score >= 0.9) return Rating.Good;
   if (score >= 0.5) return Rating.Hard;
   return Rating.Again;
 }

--- a/src/server/trpc/routers/questions.ts
+++ b/src/server/trpc/routers/questions.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 
 import { DIFFICULTY_LEVELS, THINKING_STYLES } from "@/db/schema";
 import { generateMcq } from "@/server/generator/mcq";
+import { generateShortWritten } from "@/server/generator/short-written";
 
 import { protectedProcedure, router } from "../init";
 
@@ -10,17 +11,33 @@ export const questionsRouter = router({
     .input(
       z.object({
         conceptId: z.string().min(1),
-        /** MVP は mcq のみ (issue #9)。他タイプは issue #14 以降 */
-        type: z.literal("mcq"),
+        type: z.enum(["mcq", "short", "written"]),
         difficulty: z.enum(DIFFICULTY_LEVELS),
         thinkingStyle: z.enum(THINKING_STYLES).nullable(),
       }),
     )
     .mutation(async ({ input }) => {
-      // forceFresh は公開 API に露出させず、サーバー側のフラグ (NODE_ENV=development かつ
-      // テストで必要な場合) でのみ許可する。Passkey 認証済みでも OpenAI コスト削減経路を塞ぐ。
-      const result = await generateMcq({
+      if (input.type === "mcq") {
+        const result = await generateMcq({
+          conceptId: input.conceptId,
+          difficulty: input.difficulty,
+          thinkingStyle: input.thinkingStyle,
+        });
+        return {
+          source: result.source,
+          question: {
+            id: result.question.id,
+            type: "mcq" as const,
+            prompt: result.question.prompt,
+            distractors: result.question.distractors,
+            hint: result.question.hint,
+            tags: result.question.tags,
+          },
+        };
+      }
+      const result = await generateShortWritten({
         conceptId: input.conceptId,
+        type: input.type,
         difficulty: input.difficulty,
         thinkingStyle: input.thinkingStyle,
       });
@@ -28,11 +45,11 @@ export const questionsRouter = router({
         source: result.source,
         question: {
           id: result.question.id,
+          type: input.type,
           prompt: result.question.prompt,
-          distractors: result.question.distractors,
-          // answer / explanation は UI 側でユーザー回答後に出す。ここでは返さない
           hint: result.question.hint,
           tags: result.question.tags,
+          // short / written は textarea 回答。rubric は採点前に UI に出さない (バイアス防止)
         },
       };
     }),


### PR DESCRIPTION
## Summary
Issue #14 を解決。docs/02 §2.2 / docs/03 §3.4.2 に沿って short / written をサポート。

- `prompts/generation/{short,written}.v1.md`: Output requirements を user 冒頭
- `prompts/grading/written.v1.md`: gpt-5 採点プロンプト
- `src/server/generator/short-written*.ts`: 生成 + rubric 2+ 件の Zod 検証
- `src/server/grader/written.ts`: gpt-5 + 部分点対応。correct は score >= 0.7 から導出
- `src/server/grader/index.ts`: type=short/written のディスパッチ追加
- `src/server/scheduler/fsrs.ts`: 部分正解 (0.5-0.9) を Hard、0.9+ Good、0.95+ Easy

## 受け入れ基準
- [x] 生成プロンプト short / written.v1 + gpt-5 Structured Outputs
- [x] 採点 written.v1 + gpt-5 / short は gpt-5-mini
- [ ] UI: textarea (本 PR では backend のみ。textarea UI は #18 Custom Session でまとめて実装)
- [x] 部分正解は Hard として FSRS に送る
- [x] snapshot test

Closes #14

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm test -- --run` (96 pass, +6)
- [x] `pnpm build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)