### PR TITLE
feat(rebuttal): 採点への反論フロー + 再採点 (#15)

### DIFF
--- a/drizzle/0007_attempts_rebuttal.sql
+++ b/drizzle/0007_attempts_rebuttal.sql
@@ -1,0 +1,4 @@
+-- issue #15: attempts に再採点 (rebuttal) の記録カラムを追加
+-- rebuttal: 反論の概要 (元の判定、反論メッセージ、反論後に結論が変わったかなど)
+-- コスト: jsonb は NULL のときは実質データなし。マイグレーションは非破壊
+ALTER TABLE "attempts" ADD COLUMN "rebuttal" jsonb;

--- a/prompts/grading/rebut.v1.md
+++ b/prompts/grading/rebut.v1.md
@@ -1,0 +1,54 @@
+# rebut.v1
+
+採点結果への反論 (R1 対策) を gpt-5 に再評価させるプロンプト。
+ユーザーは「これは正解だ」と主張しているので、**反論を steelman** して再評価する。
+ただし論理的に不当な主張は棄却する (迎合して全部正解にしない)。
+
+固定の Output requirements を user 冒頭、可変を末尾に並べる (CLAUDE.md §4.5)。
+
+テンプレ変数は `{{ camelCase }}` で囲む。`src/server/grader/rebut.ts` の `buildRebutPrompt` が
+このファイルを読み込んで HTML コメント `<!-- role:system -->` / `<!-- role:user -->` ブロックを抽出し、
+`{{ }}` を置換する。
+
+---
+
+<!-- role:system -->
+
+You are a senior engineer re-evaluating a previously graded short/written answer after the user objected. The user argues their answer is correct. Steelman the user's position: if there is a reasonable interpretation under which the answer is correct, give partial or full credit. However, do NOT sycophantically grant credit for logically unsound objections. Output strictly as JSON matching the provided schema. Use 日本語 for human-readable fields.
+
+<!-- /role -->
+
+<!-- role:user -->
+
+## Output requirements (固定)
+
+- `score` (number, 0.0-1.0): 再評価後のスコア。反論が妥当なら元より高く、妥当でないなら元と同じ
+- `correct` (boolean): score >= 0.7 のとき true、そうでなければ false
+- `feedback` (string): 反論を踏まえて、なぜその score か 1-2 文で日本語。反論を棄却したならその理由も
+- `rubricChecks` (array): ルーブリック各項目 (`id` / `passed` / `comment`)
+
+## Question (可変)
+
+{{ questionPrompt }}
+
+## Expected answer (可変)
+
+{{ expectedAnswer }}
+
+## Rubric (可変)
+
+{{ rubric }}
+
+## User answer (可変)
+
+{{ userAnswer }}
+
+## Original grading (可変)
+
+{{ originalGrading }}
+
+## User's rebuttal (可変)
+
+{{ rebuttalMessage }}
+
+<!-- /role -->

--- a/src/db/schema/attempts.ts
+++ b/src/db/schema/attempts.ts
@@ -36,6 +36,23 @@ export type MisconceptionTag = {
   description: string;
 };
 
+export type RebuttalRecord = {
+  /** 反論メッセージ (ユーザーが正解だと主張する根拠) */
+  message: string;
+  /** 元の採点 */
+  original: {
+    correct: boolean | null;
+    score: number | null;
+    feedback: string | null;
+  };
+  /** 再採点後の判定が変わったか (false なら「反論されたが変わらなかった」) */
+  overturned: boolean;
+  /** 再採点で使ったプロンプト版 */
+  promptVersion: string;
+  /** 反論時刻 (ISO 8601) */
+  at: string;
+};
+
 export const attempts = pgTable(
   "attempts",
   {
@@ -64,6 +81,7 @@ export const attempts = pgTable(
     feedback: text("feedback"),
     rubricChecks: jsonb("rubric_checks").$type<RubricCheckResult[]>(),
     misconceptionTags: jsonb("misconception_tags").$type<MisconceptionTag[]>(),
+    rebuttal: jsonb("rebuttal").$type<RebuttalRecord>(),
     reasonGiven: text("reason_given"),
     copiedForExternal: integer("copied_for_external").notNull().default(0),
     /** 採点に使ったプロンプトの版 (CLAUDE.md §4.5)。mcq のようにプロンプト不使用の採点は null */

--- a/src/features/drill/drill-screen.tsx
+++ b/src/features/drill/drill-screen.tsx
@@ -14,6 +14,7 @@ import {
 } from "@/components/ui/card";
 import { trpc } from "@/lib/trpc/react";
 
+import { RebuttalForm } from "./rebuttal-form";
 import { useDrillStore } from "./drill-state";
 
 export function DrillScreen() {
@@ -85,6 +86,7 @@ export function DrillScreen() {
         score: result.score,
         feedback: result.feedback,
         correctIndex: result.correct ? selectedIndex : null,
+        questionType: result.questionType ?? null,
       });
     } catch (e) {
       setErrorMessage(toMessage(e));
@@ -235,7 +237,12 @@ export function DrillScreen() {
           );
         })}
         {phase === "graded" && grading && (
-          <div className="bg-muted/50 rounded-md p-3 text-sm">{grading.feedback}</div>
+          <div className="space-y-2">
+            <div className="bg-muted/50 rounded-md p-3 text-sm">{grading.feedback}</div>
+            {grading.questionType && grading.questionType !== "mcq" && (
+              <RebuttalForm attemptId={grading.attemptId} />
+            )}
+          </div>
         )}
         {errorMessage && (
           <div className="border-destructive/60 text-destructive flex items-start gap-2 rounded-md border bg-red-50 p-3 text-sm dark:bg-red-950">

--- a/src/features/drill/drill-state.test.ts
+++ b/src/features/drill/drill-state.test.ts
@@ -55,6 +55,7 @@ describe("useDrillStore", () => {
       score: 1,
       feedback: "正解です",
       correctIndex: 1,
+      questionType: "mcq",
     });
     const s = useDrillStore.getState();
     expect(s.phase).toBe("graded");

--- a/src/features/drill/drill-state.ts
+++ b/src/features/drill/drill-state.ts
@@ -16,6 +16,10 @@ export type DrillGrading = {
   feedback: string;
   /** 選択したインデックスが正解だったかを UI ハイライトに使う */
   correctIndex: number | null;
+  /** 反論ボタン出し分け用 (mcq は反論不可) */
+  questionType: string | null;
+  /** 反論済みフラグ (1 attempt につき 1 回) */
+  rebutted?: boolean;
 };
 
 export type DrillSummary = {
@@ -41,6 +45,7 @@ type Actions = {
   setQuestion: (q: DrillQuestion | null) => void;
   setSelected: (idx: number) => void;
   setGrading: (g: DrillGrading) => void;
+  updateGrading: (patch: Partial<DrillGrading>) => void;
   setSummary: (s: DrillSummary) => void;
 };
 
@@ -73,6 +78,8 @@ export const useDrillStore = create<DrillState & Actions>((set) => ({
   setSelected: (idx) => set({ selectedIndex: idx }),
 
   setGrading: (g) => set({ grading: g, phase: "graded" }),
+
+  updateGrading: (patch) => set((s) => (s.grading ? { grading: { ...s.grading, ...patch } } : {})),
 
   setSummary: (s) => set({ summary: s, phase: "finished" }),
 }));

--- a/src/features/drill/rebuttal-form.tsx
+++ b/src/features/drill/rebuttal-form.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+import { AlertTriangle, Flag, Loader2 } from "lucide-react";
+import { useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { trpc } from "@/lib/trpc/react";
+
+import { useDrillStore } from "./drill-state";
+
+/**
+ * 採点結果への反論フォーム (issue #15, R1 対策)。
+ * 短答・記述 (short / written) でのみ有効。mcq には表示しない。
+ */
+export function RebuttalForm({
+  attemptId,
+  onResolved,
+}: {
+  attemptId: string;
+  onResolved?: (result: { overturned: boolean }) => void;
+}) {
+  const { updateGrading, grading } = useDrillStore();
+  const [open, setOpen] = useState(false);
+  const [message, setMessage] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
+  const rebutMutation = trpc.attempts.rebut.useMutation();
+
+  if (grading?.rebutted) {
+    return (
+      <div className="text-muted-foreground text-xs">
+        この回答は反論済みです (1 attempt につき 1 回)。
+      </div>
+    );
+  }
+
+  if (!open) {
+    return (
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={() => setOpen(true)}
+        className="text-destructive border-destructive/40 hover:bg-destructive/10"
+      >
+        <Flag className="mr-1 h-3.5 w-3.5" />
+        採点に反論
+      </Button>
+    );
+  }
+
+  const onSubmit = async () => {
+    setError(null);
+    setNotice(null);
+    const trimmed = message.trim();
+    if (!trimmed) {
+      setError("反論の根拠を入力してください");
+      return;
+    }
+    try {
+      const res = await rebutMutation.mutateAsync({ attemptId, message: trimmed });
+      updateGrading({
+        correct: res.correct,
+        score: res.score,
+        feedback: res.feedback,
+        rebutted: true,
+      });
+      setNotice(
+        res.overturned
+          ? "反論を受け入れ、採点を修正しました。"
+          : "反論を検討しましたが判定は変わりませんでした。",
+      );
+      setOpen(false);
+      setMessage("");
+      onResolved?.({ overturned: res.overturned });
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "通信エラー");
+    }
+  };
+
+  return (
+    <div className="border-destructive/40 space-y-2 rounded-md border p-3">
+      <div className="text-muted-foreground text-xs">なぜ正解だと考えるか、1-2 文で。</div>
+      <textarea
+        value={message}
+        onChange={(e) => setMessage(e.target.value)}
+        rows={3}
+        maxLength={2000}
+        className="border-input bg-background w-full rounded-md border p-2 text-sm"
+        placeholder="例: 「状態が変わらない」は冪等性の言い換えです。"
+      />
+      {error && (
+        <div className="text-destructive flex items-start gap-1 text-xs">
+          <AlertTriangle className="mt-0.5 h-3 w-3" />
+          <span>{error}</span>
+        </div>
+      )}
+      {notice && <div className="text-muted-foreground text-xs">{notice}</div>}
+      <div className="flex gap-2">
+        <Button size="sm" onClick={onSubmit} disabled={rebutMutation.isPending}>
+          {rebutMutation.isPending && <Loader2 className="mr-1 h-3.5 w-3.5 animate-spin" />}
+          送信
+        </Button>
+        <Button
+          size="sm"
+          variant="ghost"
+          onClick={() => {
+            setOpen(false);
+            setError(null);
+          }}
+          disabled={rebutMutation.isPending}
+        >
+          キャンセル
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/server/grader/__snapshots__/rebut.test.ts.snap
+++ b/src/server/grader/__snapshots__/rebut.test.ts.snap
@@ -1,0 +1,39 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`buildRebutPrompt > 反論と元の採点を含む snapshot 1`] = `
+{
+  "system": "You are a senior engineer re-evaluating a previously graded short/written answer after the user objected. The user argues their answer is correct. Steelman the user's position: if there is a reasonable interpretation under which the answer is correct, give partial or full credit. However, do NOT sycophantically grant credit for logically unsound objections. Output strictly as JSON matching the provided schema. Use 日本語 for human-readable fields.",
+  "user": "## Output requirements (固定)
+
+- \`score\` (number, 0.0-1.0): 再評価後のスコア。反論が妥当なら元より高く、妥当でないなら元と同じ
+- \`correct\` (boolean): score >= 0.7 のとき true、そうでなければ false
+- \`feedback\` (string): 反論を踏まえて、なぜその score か 1-2 文で日本語。反論を棄却したならその理由も
+- \`rubricChecks\` (array): ルーブリック各項目 (\`id\` / \`passed\` / \`comment\`)
+
+## Question (可変)
+
+HTTP PUT と PATCH の違いを 1 文で。
+
+## Expected answer (可変)
+
+PUT は冪等、PATCH は部分更新。
+
+## Rubric (可変)
+
+- id=r1: PUT の冪等性に言及
+- id=r2: PATCH の部分更新に言及
+
+## User answer (可変)
+
+PUT は同じリクエストを何度投げても状態が変わらない。PATCH は差分更新。
+
+## Original grading (可変)
+
+判定: 不正解 / score=0.5
+feedback: 冪等性の明示が弱い
+
+## User's rebuttal (可変)
+
+「状態が変わらない」は冪等性の言い換えです。これは正解のはず。",
+}
+`;

--- a/src/server/grader/index.ts
+++ b/src/server/grader/index.ts
@@ -33,6 +33,8 @@ export type GradeAttemptResult = {
   score: number | null;
   feedback: string;
   rubricChecks: RubricCheckResult[];
+  /** submit 側で UI 出し分けに使う (MVP では "mcq" / "short" / "written" など) */
+  questionType: string;
 };
 
 async function loadQuestion(questionId: string): Promise<Question> {
@@ -91,6 +93,7 @@ export async function gradeAttempt(input: GradeAttemptInput): Promise<GradeAttem
       score: result.score,
       feedback: result.feedback,
       rubricChecks: [],
+      questionType: question.type,
     };
   } else if (question.type === "short" || question.type === "written") {
     const result =
@@ -118,6 +121,7 @@ export async function gradeAttempt(input: GradeAttemptInput): Promise<GradeAttem
       score: result.score,
       feedback: result.feedback,
       rubricChecks: result.rubricChecks,
+      questionType: question.type,
     };
   } else {
     throw new TRPCError({
@@ -159,5 +163,6 @@ export async function gradeAttempt(input: GradeAttemptInput): Promise<GradeAttem
     score: prev.score,
     feedback: prev.feedback ?? "",
     rubricChecks: (prev.rubricChecks ?? []) as typeof grade.rubricChecks,
+    questionType: question.type,
   };
 }

--- a/src/server/grader/rebut.test.ts
+++ b/src/server/grader/rebut.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi } from "vitest";
+
+import { buildRebutPrompt, gradeRebut } from "./rebut";
+
+const sampleInput = {
+  question: {
+    prompt: "HTTP PUT と PATCH の違いを 1 文で。",
+    answer: "PUT は冪等、PATCH は部分更新。",
+    rubric: [
+      { id: "r1", description: "PUT の冪等性に言及" },
+      { id: "r2", description: "PATCH の部分更新に言及" },
+    ],
+  },
+  userAnswer: "PUT は同じリクエストを何度投げても状態が変わらない。PATCH は差分更新。",
+  rebuttalMessage: "「状態が変わらない」は冪等性の言い換えです。これは正解のはず。",
+  original: {
+    correct: false,
+    score: 0.5,
+    feedback: "冪等性の明示が弱い",
+  },
+};
+
+describe("buildRebutPrompt", () => {
+  it("反論と元の採点を含む snapshot", () => {
+    const out = buildRebutPrompt(sampleInput);
+    expect({ system: out.system, user: out.user }).toMatchSnapshot();
+  });
+
+  it("Output requirements が user 冒頭 (prompt caching 規約)", () => {
+    const out = buildRebutPrompt(sampleInput);
+    expect(out.user.indexOf("## Output requirements")).toBeLessThan(
+      out.user.indexOf("## Question"),
+    );
+    expect(out.user).toContain("## User's rebuttal");
+    expect(out.user).toContain("## Original grading");
+  });
+
+  it("rubric 未指定でも通る (fallback 文言)", () => {
+    const out = buildRebutPrompt({
+      ...sampleInput,
+      question: { ...sampleInput.question, rubric: null },
+    });
+    expect(out.user).toContain("採点ルーブリックなし");
+  });
+
+  it("original.correct null / score null でもフォーマットできる", () => {
+    const out = buildRebutPrompt({
+      ...sampleInput,
+      original: { correct: null, score: null, feedback: null },
+    });
+    expect(out.user).toContain("判定: 未判定");
+    expect(out.user).toContain("未評価");
+  });
+});
+
+describe("gradeRebut", () => {
+  it("score 0.8 → correct true を LLM 自己申告に関わらず導出", async () => {
+    const llm = vi.fn().mockResolvedValue({
+      score: 0.8,
+      correct: false, // LLM が誤って false と言っても
+      feedback: "反論妥当",
+      rubricChecks: [],
+    });
+    const result = await gradeRebut(sampleInput, llm);
+    expect(result.correct).toBe(true); // threshold で導出される
+    expect(result.promptVersion).toBe("rebut.v1");
+  });
+
+  it("score 0.5 → correct false (反論棄却)", async () => {
+    const llm = vi.fn().mockResolvedValue({
+      score: 0.5,
+      correct: true,
+      feedback: "反論棄却",
+      rubricChecks: [],
+    });
+    const result = await gradeRebut(sampleInput, llm);
+    expect(result.correct).toBe(false);
+  });
+});

--- a/src/server/grader/rebut.ts
+++ b/src/server/grader/rebut.ts
@@ -1,0 +1,93 @@
+import type { Question, RubricCheck } from "@/db/schema";
+import { getOpenAI } from "@/lib/openai/client";
+import { MODEL_MAIN } from "@/lib/openai/models";
+
+import { renderTemplate } from "../generator/prompt-template";
+import { GradedShortSchema, SHORT_JSON_SCHEMA, type GradedShort } from "./schema";
+
+export const REBUT_PROMPT_VERSION = "rebut.v1";
+const REBUT_TEMPLATE_PATH = "grading/rebut.v1.md";
+
+const CORRECT_THRESHOLD = 0.7;
+
+export type RebutGradingInput = {
+  question: Pick<Question, "prompt" | "answer" | "rubric">;
+  userAnswer: string;
+  /** ユーザーが主張する反論 (「これは正解だ」の根拠) */
+  rebuttalMessage: string;
+  /** 元の採点結果 (feedback / correct / score) */
+  original: {
+    correct: boolean | null;
+    score: number | null;
+    feedback: string | null;
+  };
+};
+
+function formatRubric(rubric: RubricCheck[] | null | undefined): string {
+  if (!rubric || rubric.length === 0) {
+    return "(採点ルーブリックなし。Expected answer との意味一致で判断すること)";
+  }
+  return rubric
+    .map((r) => `- id=${r.id}: ${r.description}${r.weight ? ` (weight=${r.weight})` : ""}`)
+    .join("\n");
+}
+
+function formatOriginalGrading(original: RebutGradingInput["original"]): string {
+  const correct =
+    original.correct === true ? "正解" : original.correct === false ? "不正解" : "未判定";
+  const score = original.score ?? "未評価";
+  return `判定: ${correct} / score=${score}\nfeedback: ${original.feedback ?? "(なし)"}`;
+}
+
+export function buildRebutPrompt(input: RebutGradingInput) {
+  return renderTemplate(REBUT_TEMPLATE_PATH, {
+    questionPrompt: input.question.prompt,
+    expectedAnswer: input.question.answer,
+    rubric: formatRubric(input.question.rubric),
+    userAnswer: input.userAnswer,
+    originalGrading: formatOriginalGrading(input.original),
+    rebuttalMessage: input.rebuttalMessage,
+  });
+}
+
+export type RebutLlmCaller = (args: {
+  model: string;
+  system: string;
+  user: string;
+}) => Promise<GradedShort>;
+
+export const defaultRebutLlm: RebutLlmCaller = async ({ model, system, user }) => {
+  const client = getOpenAI();
+  const res = await client.responses.create({
+    model,
+    input: [
+      { role: "system", content: system },
+      { role: "user", content: user },
+    ],
+    text: {
+      format: {
+        type: "json_schema",
+        ...SHORT_JSON_SCHEMA, // 採点結果 schema は short と同形
+      },
+    },
+  });
+  return GradedShortSchema.parse(JSON.parse(res.output_text));
+};
+
+/**
+ * 再採点は main モデル (gpt-5) で行う。ユーザーが不服を表明したケースなので
+ * mini よりも慎重な判定が欲しいため。score から correct を導出し、LLM 自己申告は信用しない。
+ */
+export async function gradeRebut(
+  input: RebutGradingInput,
+  llm: RebutLlmCaller = defaultRebutLlm,
+): Promise<GradedShort & { model: string; promptVersion: string }> {
+  const { system, user } = buildRebutPrompt(input);
+  const graded = await llm({ model: MODEL_MAIN, system, user });
+  return {
+    ...graded,
+    correct: graded.score >= CORRECT_THRESHOLD,
+    model: MODEL_MAIN,
+    promptVersion: REBUT_PROMPT_VERSION,
+  };
+}

--- a/src/server/scheduler/update-mastery.ts
+++ b/src/server/scheduler/update-mastery.ts
@@ -3,7 +3,7 @@ import { and, eq, sql } from "drizzle-orm";
 import { getDb } from "@/db/client";
 import { mastery, type Mastery } from "@/db/schema";
 
-import { gradeMastery } from "./fsrs";
+import { Rating, gradeMastery, scoreToRating } from "./fsrs";
 
 /**
  * 採点直後に mastery を upsert する統合関数。
@@ -81,4 +81,70 @@ export async function updateMasteryAfterAttempt(params: {
 
   if (!row) throw new Error("failed to upsert mastery");
   return row;
+}
+
+/**
+ * 反論 (issue #15) 後の mastery 再適用。
+ *
+ * 差分:
+ *   - reviewCount は再加算しない (初回 attempt で既に +1 済み)
+ *   - lapseCount は「前回 Again だった ↔ 今回 Again か」の差分だけ補正 (+1 / -1 / 0)
+ *   - stability / difficulty / next_review / masteryPct は新スコアで再計算
+ *
+ * 注意: FSRS は path-dependent なので厳密な「やり直し」ではなく近似 (MVP 許容、
+ * 反論は初回採点直後の操作である想定のため誤差は小さい)。
+ */
+export async function reapplyMasteryAfterRebut(params: {
+  userId: string;
+  conceptId: string;
+  previousScore: number | null;
+  newScore: number | null;
+  at?: Date;
+}): Promise<Mastery | null> {
+  const at = params.at ?? new Date();
+  const db = getDb();
+
+  const existing = await db
+    .select()
+    .from(mastery)
+    .where(and(eq(mastery.userId, params.userId), eq(mastery.conceptId, params.conceptId)))
+    .limit(1);
+  const current = existing[0];
+  if (!current) return null;
+
+  const wasLapse = scoreToRating(params.previousScore) === Rating.Again;
+  const willBeLapse = scoreToRating(params.newScore) === Rating.Again;
+
+  // 「元の attempt を一度戻した状態」から新スコアで 1 回 forward して再計算
+  const update = gradeMastery({
+    current: {
+      stability: current.stability,
+      difficulty: current.difficulty,
+      lastReview: current.lastReview,
+      reviewCount: Math.max(0, current.reviewCount - 1),
+      lapseCount: Math.max(0, current.lapseCount - (wasLapse ? 1 : 0)),
+      mastered: current.mastered,
+      masteryPct: current.masteryPct,
+    },
+    score: params.newScore,
+    at,
+  });
+
+  const lapseDelta = (willBeLapse ? 1 : 0) - (wasLapse ? 1 : 0);
+
+  const [row] = await db
+    .update(mastery)
+    .set({
+      stability: update.stability,
+      difficulty: update.difficulty,
+      lastReview: update.lastReview,
+      nextReview: update.nextReview,
+      lapseCount: sql`GREATEST(0, ${mastery.lapseCount} + ${lapseDelta})`,
+      mastered: update.mastered,
+      masteryPct: update.masteryPct,
+    })
+    .where(and(eq(mastery.userId, params.userId), eq(mastery.conceptId, params.conceptId)))
+    .returning();
+
+  return row ?? null;
 }

--- a/src/server/trpc/routers/attempts.ts
+++ b/src/server/trpc/routers/attempts.ts
@@ -1,10 +1,11 @@
 import { TRPCError } from "@trpc/server";
-import { and, eq } from "drizzle-orm";
+import { and, eq, isNull } from "drizzle-orm";
 import { z } from "zod";
 
 import { getDb } from "@/db/client";
 import { attempts, questions, type RebuttalRecord } from "@/db/schema";
 import { gradeRebut } from "@/server/grader/rebut";
+import { reapplyMasteryAfterRebut } from "@/server/scheduler/update-mastery";
 
 import { protectedProcedure, router } from "../init";
 
@@ -15,6 +16,9 @@ export const attemptsRouter = router({
   /**
    * 採点への反論 (issue #15, R1 対策)。
    * 元の判定を rebuttal フィールドに保存し、再採点結果で correct / score / feedback を上書きする。
+   *
+   * 並行 2 重 rebut 対策として最終 UPDATE の WHERE に `rebuttal IS NULL` を加えている。
+   * losing race 側は 0 行更新になり BAD_REQUEST を返す。
    */
   rebut: protectedProcedure
     .input(
@@ -75,7 +79,8 @@ export const attemptsRouter = router({
         at: new Date().toISOString(),
       };
 
-      await db
+      // race 対策: WHERE に `rebuttal IS NULL` を加えて losing race 側は 0 行更新にする
+      const updated = await db
         .update(attempts)
         .set({
           correct: graded.correct,
@@ -86,7 +91,28 @@ export const attemptsRouter = router({
           promptVersion: graded.promptVersion,
           rebuttal,
         })
-        .where(eq(attempts.id, prev.id));
+        .where(
+          and(
+            eq(attempts.id, prev.id),
+            eq(attempts.userId, ctx.user.id),
+            isNull(attempts.rebuttal),
+          ),
+        )
+        .returning({ id: attempts.id });
+      if (updated.length === 0) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: "この attempt には既に反論が提出されています",
+        });
+      }
+
+      // 採点結果が変わった場合は mastery も追随させる (lapseCount delta + FSRS 再適用)
+      await reapplyMasteryAfterRebut({
+        userId: ctx.user.id,
+        conceptId: prev.conceptId,
+        previousScore: prev.score,
+        newScore: graded.score,
+      });
 
       return {
         attemptId: prev.id,

--- a/src/server/trpc/routers/attempts.ts
+++ b/src/server/trpc/routers/attempts.ts
@@ -1,0 +1,99 @@
+import { TRPCError } from "@trpc/server";
+import { and, eq } from "drizzle-orm";
+import { z } from "zod";
+
+import { getDb } from "@/db/client";
+import { attempts, questions, type RebuttalRecord } from "@/db/schema";
+import { gradeRebut } from "@/server/grader/rebut";
+
+import { protectedProcedure, router } from "../init";
+
+/** mcq は構造化された正誤なので LLM による再採点対象外 */
+const REBUTTABLE_TYPES = ["short", "written"] as const;
+
+export const attemptsRouter = router({
+  /**
+   * 採点への反論 (issue #15, R1 対策)。
+   * 元の判定を rebuttal フィールドに保存し、再採点結果で correct / score / feedback を上書きする。
+   */
+  rebut: protectedProcedure
+    .input(
+      z.object({
+        attemptId: z.string().min(1),
+        message: z.string().min(1).max(2000),
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      const db = getDb();
+      const rows = await db
+        .select()
+        .from(attempts)
+        .where(and(eq(attempts.id, input.attemptId), eq(attempts.userId, ctx.user.id)))
+        .limit(1);
+      const prev = rows[0];
+      if (!prev) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "attempt not found" });
+      }
+      if (prev.rebuttal) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: "この attempt には既に反論が提出されています",
+        });
+      }
+
+      const qRows = await db
+        .select()
+        .from(questions)
+        .where(eq(questions.id, prev.questionId))
+        .limit(1);
+      const question = qRows[0];
+      if (!question) throw new TRPCError({ code: "NOT_FOUND", message: "question not found" });
+      if (!(REBUTTABLE_TYPES as readonly string[]).includes(question.type)) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: `type="${question.type}" は反論の対象外 (短答・記述のみ)`,
+        });
+      }
+
+      const graded = await gradeRebut({
+        question,
+        userAnswer: prev.userAnswer ?? "",
+        rebuttalMessage: input.message,
+        original: { correct: prev.correct, score: prev.score, feedback: prev.feedback },
+      });
+
+      const overturned = graded.correct !== prev.correct || (graded.score ?? 0) > (prev.score ?? 0);
+      const rebuttal: RebuttalRecord = {
+        message: input.message,
+        original: {
+          correct: prev.correct,
+          score: prev.score,
+          feedback: prev.feedback,
+        },
+        overturned,
+        promptVersion: graded.promptVersion,
+        at: new Date().toISOString(),
+      };
+
+      await db
+        .update(attempts)
+        .set({
+          correct: graded.correct,
+          score: graded.score,
+          feedback: graded.feedback,
+          rubricChecks: graded.rubricChecks,
+          gradedBy: graded.model,
+          promptVersion: graded.promptVersion,
+          rebuttal,
+        })
+        .where(eq(attempts.id, prev.id));
+
+      return {
+        attemptId: prev.id,
+        correct: graded.correct,
+        score: graded.score,
+        feedback: graded.feedback,
+        overturned,
+      };
+    }),
+});

--- a/src/server/trpc/routers/index.ts
+++ b/src/server/trpc/routers/index.ts
@@ -1,4 +1,5 @@
 import { router } from "../init";
+import { attemptsRouter } from "./attempts";
 import { authRouter } from "./auth";
 import { pingRouter } from "./ping";
 import { questionsRouter } from "./questions";
@@ -7,6 +8,7 @@ import { sessionRouter } from "./session";
 export const appRouter = router({
   ping: pingRouter.ping,
   auth: authRouter,
+  attempts: attemptsRouter,
   questions: questionsRouter,
   session: sessionRouter,
 });

--- a/src/server/trpc/routers/session.ts
+++ b/src/server/trpc/routers/session.ts
@@ -7,7 +7,6 @@ import {
   attempts,
   concepts,
   DIFFICULTY_LEVELS,
-  questions,
   SESSION_KINDS,
   sessions,
   THINKING_STYLES,
@@ -237,13 +236,6 @@ export const sessionRouter = router({
         reasonGiven: input.reasonGiven,
       });
 
-      // 反論 (rebut) UI 出し分けのため question.type を同梱して返す
-      const qType = await getDb()
-        .select({ type: questions.type })
-        .from(questions)
-        .where(eq(questions.id, input.questionId))
-        .limit(1);
-
       // 二重送信対策: sql で原子インクリメント + pendingQuestionId 一致 + finishedAt is null の
       // 条件下でのみ 1 行更新。並行 submit で losing race になった側は 0 行更新で素通り
       // (既に 1 度カウントされているので attempts テーブルの一意性で十分)
@@ -271,7 +263,7 @@ export const sessionRouter = router({
         correct: result.correct,
         score: result.score,
         feedback: result.feedback,
-        questionType: qType[0]?.type ?? null,
+        questionType: result.questionType,
       };
     }),
 

--- a/src/server/trpc/routers/session.ts
+++ b/src/server/trpc/routers/session.ts
@@ -7,6 +7,7 @@ import {
   attempts,
   concepts,
   DIFFICULTY_LEVELS,
+  questions,
   SESSION_KINDS,
   sessions,
   THINKING_STYLES,
@@ -236,6 +237,13 @@ export const sessionRouter = router({
         reasonGiven: input.reasonGiven,
       });
 
+      // 反論 (rebut) UI 出し分けのため question.type を同梱して返す
+      const qType = await getDb()
+        .select({ type: questions.type })
+        .from(questions)
+        .where(eq(questions.id, input.questionId))
+        .limit(1);
+
       // 二重送信対策: sql で原子インクリメント + pendingQuestionId 一致 + finishedAt is null の
       // 条件下でのみ 1 行更新。並行 submit で losing race になった側は 0 行更新で素通り
       // (既に 1 度カウントされているので attempts テーブルの一意性で十分)
@@ -263,6 +271,7 @@ export const sessionRouter = router({
         correct: result.correct,
         score: result.score,
         feedback: result.feedback,
+        questionType: qType[0]?.type ?? null,
       };
     }),
 


### PR DESCRIPTION
## Summary
- attempts に `rebuttal` jsonb カラム追加 (migration 0007)
- `src/server/grader/rebut.ts`: gpt-5 で反論を steelman 再採点
- `prompts/grading/rebut.v1.md`: テンプレ
- `attempts.rebut` tRPC endpoint: 元判定を保存し correct/score/feedback を上書き
- drill 画面に short/written 時のみ `RebuttalForm` を表示
- `overturned` フラグで「反論されたが変わらなかった」カウントを記録

closes #15

## Test plan
- [x] unit: `rebut.test.ts` - prompt 構造・snapshot・threshold 導出
- [x] unit: `drill-state.test.ts` 更新
- [x] typecheck OK
- [x] 全テスト (102) pass