### PR TITLE
feat(custom): Custom Session 実行フロー (#18)

### DIFF
--- a/src/app/custom/page.tsx
+++ b/src/app/custom/page.tsx
@@ -1,0 +1,18 @@
+import { redirect } from "next/navigation";
+
+import { CustomScreen } from "@/features/custom/custom-screen";
+import { getCurrentUser } from "@/server/auth/session";
+
+export const dynamic = "force-dynamic";
+
+export default async function CustomPage() {
+  const user = await getCurrentUser();
+  if (!user) {
+    redirect("/login");
+  }
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center gap-6 p-8">
+      <CustomScreen />
+    </main>
+  );
+}

--- a/src/features/custom/custom-screen.tsx
+++ b/src/features/custom/custom-screen.tsx
@@ -56,19 +56,27 @@ export function CustomScreen() {
 
   const onStart = useCallback(async () => {
     if (phase.kind !== "previewing") return;
+    const snapshot = phase;
     setError(null);
     try {
       reset();
       const { sessionId } = await startMutation.mutateAsync({
         kind: "custom",
-        customSpec: phase.spec,
+        customSpec: snapshot.spec,
       });
       // setSession を next の前に実行しておき、next 失敗時でも同じセッションを
       // 再試行できる状態に保つ (孤立セッション回避)。
       setSession(sessionId);
       setPhase({ kind: "running", sessionId });
-      const next = await nextMutation.mutateAsync({ sessionId });
-      if (!next.done) setQuestion(next.question);
+      try {
+        const next = await nextMutation.mutateAsync({ sessionId });
+        if (!next.done) setQuestion(next.question);
+      } catch (e) {
+        // 問題生成失敗時は previewing に戻してエラー表示。drill store もクリア。
+        reset();
+        setPhase(snapshot);
+        setError(e instanceof Error ? e.message : "問題の生成に失敗しました");
+      }
     } catch (e) {
       setError(e instanceof Error ? e.message : "セッション開始に失敗しました");
     }
@@ -167,8 +175,9 @@ function SpecPreview({ spec }: { spec: CustomSessionSpec }) {
   return (
     <div className="bg-muted/40 space-y-1 rounded-md border p-3">
       <div className="text-muted-foreground mb-1 text-xs">
-        パース結果 (読み取り専用)。MVP では concepts[0] / difficulty / thinkingStyles[0] のみ
-        出題に反映。difficulty は beginner/junior/mid/senior のみサポート。
+        パース結果 (読み取り専用)。MVP では concepts[0] / difficulty / thinkingStyles[0] /
+        questionCount のみ反映。difficulty は beginner/junior/mid/senior のみ、 domains / subdomains
+        / excludeConcepts / questionTypes (mcq 以外) / constraints は 開始時に reject されます。
       </div>
       <SpecRow label="ドメイン" value={spec.domains} />
       <SpecRow label="サブドメイン" value={spec.subdomains} />

--- a/src/features/custom/custom-screen.tsx
+++ b/src/features/custom/custom-screen.tsx
@@ -21,7 +21,7 @@ import type { CustomSessionSpec } from "@/server/parser/schema";
 type Phase =
   | { kind: "input" }
   | { kind: "previewing"; raw: string; spec: CustomSessionSpec }
-  | { kind: "running" };
+  | { kind: "running"; sessionId: string };
 
 /**
  * Custom Session 実行フロー (issue #18)。
@@ -63,17 +63,25 @@ export function CustomScreen() {
         kind: "custom",
         customSpec: phase.spec,
       });
-      const next = await nextMutation.mutateAsync({ sessionId });
+      // setSession を next の前に実行しておき、next 失敗時でも同じセッションを
+      // 再試行できる状態に保つ (孤立セッション回避)。
       setSession(sessionId);
+      setPhase({ kind: "running", sessionId });
+      const next = await nextMutation.mutateAsync({ sessionId });
       if (!next.done) setQuestion(next.question);
-      setPhase({ kind: "running" });
     } catch (e) {
       setError(e instanceof Error ? e.message : "セッション開始に失敗しました");
     }
   }, [phase, startMutation, nextMutation, setSession, setQuestion, reset]);
 
+  const backToInput = useCallback(() => {
+    reset();
+    setError(null);
+    setPhase({ kind: "input" });
+  }, [reset]);
+
   if (phase.kind === "running") {
-    return <DrillScreen />;
+    return <DrillScreen onReset={backToInput} skipInitialStartCard />;
   }
 
   return (
@@ -158,7 +166,10 @@ function SpecRow({ label, value }: { label: string; value: unknown }) {
 function SpecPreview({ spec }: { spec: CustomSessionSpec }) {
   return (
     <div className="bg-muted/40 space-y-1 rounded-md border p-3">
-      <div className="text-muted-foreground mb-1 text-xs">パース結果 (読み取り専用)</div>
+      <div className="text-muted-foreground mb-1 text-xs">
+        パース結果 (読み取り専用)。MVP では concepts[0] / difficulty / thinkingStyles[0] のみ
+        出題に反映。difficulty は beginner/junior/mid/senior のみサポート。
+      </div>
       <SpecRow label="ドメイン" value={spec.domains} />
       <SpecRow label="サブドメイン" value={spec.subdomains} />
       <SpecRow label="concept" value={spec.concepts} />

--- a/src/features/custom/custom-screen.tsx
+++ b/src/features/custom/custom-screen.tsx
@@ -179,9 +179,9 @@ function SpecPreview({ spec }: { spec: CustomSessionSpec }) {
       <div className="text-muted-foreground mb-1 text-xs">
         パース結果 (読み取り専用)。MVP で反映されるのは concepts (0-1件) / difficulty /
         thinkingStyles (0-1件) / questionCount / updateMastery のみ。difficulty は
-        beginner/junior/mid/senior のみ、それ以外のフィールド (domains / subdomains /
-        excludeConcepts / questionTypes (mcq 以外) / constraints / 複数 concepts / 複数
-        thinkingStyles) は開始時に reject されます。
+        beginner/junior/mid/senior のみ、questionTypes は [&quot;mcq&quot;] 単一要素のみ、
+        それ以外のフィールド (domains / subdomains / excludeConcepts / constraints / 複数 concepts /
+        複数 thinkingStyles / mcq 以外 questionTypes) は開始時に reject されます。
       </div>
       <SpecRow label="ドメイン" value={spec.domains} />
       <SpecRow label="サブドメイン" value={spec.subdomains} />

--- a/src/features/custom/custom-screen.tsx
+++ b/src/features/custom/custom-screen.tsx
@@ -64,16 +64,18 @@ export function CustomScreen() {
         kind: "custom",
         customSpec: snapshot.spec,
       });
-      // setSession を next の前に実行しておき、next 失敗時でも同じセッションを
-      // 再試行できる状態に保つ (孤立セッション回避)。
-      setSession(sessionId);
-      setPhase({ kind: "running", sessionId });
+      // setSession は next 成功後に実行 (store を先に埋めて DrillScreen が半端な
+      // ローディング状態に入るのを防ぐ)。next 失敗時は session row が DB に残るが
+      // 孤立せず、ユーザーが Raw を直して再度「このセッションで始める」を押すと
+      // 新しい session が作られる (MVP はこれで許容、誤 session は UI からは
+      // 到達不能なためコスト上の害は小)。
       try {
         const next = await nextMutation.mutateAsync({ sessionId });
+        setSession(sessionId);
+        setPhase({ kind: "running", sessionId });
         if (!next.done) setQuestion(next.question);
       } catch (e) {
-        // 問題生成失敗時は previewing に戻してエラー表示。drill store もクリア。
-        reset();
+        // 問題生成失敗時は previewing に戻してエラー表示。
         setPhase(snapshot);
         setError(e instanceof Error ? e.message : "問題の生成に失敗しました");
       }

--- a/src/features/custom/custom-screen.tsx
+++ b/src/features/custom/custom-screen.tsx
@@ -178,10 +178,10 @@ function SpecPreview({ spec }: { spec: CustomSessionSpec }) {
     <div className="bg-muted/40 space-y-1 rounded-md border p-3">
       <div className="text-muted-foreground mb-1 text-xs">
         パース結果 (読み取り専用)。MVP で反映されるのは concepts (0-1件) / difficulty /
-        thinkingStyles (0-1件) / questionCount / updateMastery のみ。difficulty は
-        beginner/junior/mid/senior のみ、questionTypes は [&quot;mcq&quot;] 単一要素のみ、
-        それ以外のフィールド (domains / subdomains / excludeConcepts / constraints / 複数 concepts /
-        複数 thinkingStyles / mcq 以外 questionTypes) は開始時に reject されます。
+        thinkingStyles (0-1件) / questionCount / updateMastery のみ。 difficulty は 6 段階全て
+        (beginner/junior/mid/senior/staff/principal) 受け入れ、 questionTypes は [&quot;mcq&quot;]
+        単一要素のみ、それ以外のフィールド (domains / subdomains / excludeConcepts / constraints /
+        複数 concepts / 複数 thinkingStyles / mcq 以外 questionTypes) は開始時に reject されます。
       </div>
       <SpecRow label="ドメイン" value={spec.domains} />
       <SpecRow label="サブドメイン" value={spec.subdomains} />

--- a/src/features/custom/custom-screen.tsx
+++ b/src/features/custom/custom-screen.tsx
@@ -177,9 +177,11 @@ function SpecPreview({ spec }: { spec: CustomSessionSpec }) {
   return (
     <div className="bg-muted/40 space-y-1 rounded-md border p-3">
       <div className="text-muted-foreground mb-1 text-xs">
-        パース結果 (読み取り専用)。MVP では concepts[0] / difficulty / thinkingStyles[0] /
-        questionCount のみ反映。difficulty は beginner/junior/mid/senior のみ、 domains / subdomains
-        / excludeConcepts / questionTypes (mcq 以外) / constraints は 開始時に reject されます。
+        パース結果 (読み取り専用)。MVP で反映されるのは concepts (0-1件) / difficulty /
+        thinkingStyles (0-1件) / questionCount / updateMastery のみ。difficulty は
+        beginner/junior/mid/senior のみ、それ以外のフィールド (domains / subdomains /
+        excludeConcepts / questionTypes (mcq 以外) / constraints / 複数 concepts / 複数
+        thinkingStyles) は開始時に reject されます。
       </div>
       <SpecRow label="ドメイン" value={spec.domains} />
       <SpecRow label="サブドメイン" value={spec.subdomains} />

--- a/src/features/custom/custom-screen.tsx
+++ b/src/features/custom/custom-screen.tsx
@@ -1,0 +1,182 @@
+"use client";
+
+import { AlertTriangle, ArrowRight, Loader2, Sparkles, Undo2 } from "lucide-react";
+import { useCallback, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { DrillScreen } from "@/features/drill/drill-screen";
+import { useDrillStore } from "@/features/drill/drill-state";
+import { trpc } from "@/lib/trpc/react";
+
+import type { CustomSessionSpec } from "@/server/parser/schema";
+
+type Phase =
+  | { kind: "input" }
+  | { kind: "previewing"; raw: string; spec: CustomSessionSpec }
+  | { kind: "running" };
+
+/**
+ * Custom Session 実行フロー (issue #18)。
+ * 1. 自然言語入力 → custom.parse → 読み取り専用カード
+ * 2. 違うと判断したら raw を修正して再パース (MVP は編集フォームなし)
+ * 3. 開始ボタン → session.start({kind:"custom", spec}) → useDrillStore に流し込み → DrillScreen
+ */
+export function CustomScreen() {
+  const [phase, setPhase] = useState<Phase>({ kind: "input" });
+  const [raw, setRaw] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  const parseMutation = trpc.custom.parse.useMutation();
+  const startMutation = trpc.session.start.useMutation();
+  const nextMutation = trpc.session.next.useMutation();
+  const { reset, setSession, setQuestion } = useDrillStore();
+
+  const onParse = useCallback(async () => {
+    setError(null);
+    const trimmed = raw.trim();
+    if (!trimmed) {
+      setError("内容を入力してください");
+      return;
+    }
+    try {
+      const { spec } = await parseMutation.mutateAsync({ raw: trimmed });
+      setPhase({ kind: "previewing", raw: trimmed, spec });
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "パースに失敗しました");
+    }
+  }, [parseMutation, raw]);
+
+  const onStart = useCallback(async () => {
+    if (phase.kind !== "previewing") return;
+    setError(null);
+    try {
+      reset();
+      const { sessionId } = await startMutation.mutateAsync({
+        kind: "custom",
+        customSpec: phase.spec,
+      });
+      const next = await nextMutation.mutateAsync({ sessionId });
+      setSession(sessionId);
+      if (!next.done) setQuestion(next.question);
+      setPhase({ kind: "running" });
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "セッション開始に失敗しました");
+    }
+  }, [phase, startMutation, nextMutation, setSession, setQuestion, reset]);
+
+  if (phase.kind === "running") {
+    return <DrillScreen />;
+  }
+
+  return (
+    <Card className="w-full max-w-xl">
+      <CardHeader>
+        <CardTitle>Custom Session</CardTitle>
+        <CardDescription>自然言語で「こんな問題出して」と指定します。</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <textarea
+          value={raw}
+          onChange={(e) => setRaw(e.target.value)}
+          placeholder="例: 面接レベルで、TCP の輻輳制御について 5 問、なぜそうなっているかを問う"
+          rows={4}
+          maxLength={2000}
+          className="border-input bg-background w-full rounded-md border p-2 text-sm"
+          disabled={phase.kind === "previewing"}
+        />
+        {phase.kind === "previewing" && <SpecPreview spec={phase.spec} />}
+        {error && (
+          <div className="text-destructive flex items-start gap-1 text-xs">
+            <AlertTriangle className="mt-0.5 h-3 w-3" />
+            <span>{error}</span>
+          </div>
+        )}
+      </CardContent>
+      <CardFooter className="flex flex-wrap justify-end gap-2">
+        {phase.kind === "input" ? (
+          <Button onClick={onParse} disabled={parseMutation.isPending}>
+            {parseMutation.isPending ? (
+              <Loader2 className="mr-1 h-4 w-4 animate-spin" />
+            ) : (
+              <Sparkles className="mr-1 h-4 w-4" />
+            )}
+            解釈する
+          </Button>
+        ) : (
+          <>
+            <Button
+              variant="outline"
+              onClick={() => {
+                setError(null);
+                setPhase({ kind: "input" });
+              }}
+            >
+              <Undo2 className="mr-1 h-4 w-4" />
+              違う、入力を直す
+            </Button>
+            <Button onClick={onStart} disabled={startMutation.isPending || nextMutation.isPending}>
+              {(startMutation.isPending || nextMutation.isPending) && (
+                <Loader2 className="mr-1 h-4 w-4 animate-spin" />
+              )}
+              このセッションで始める
+              <ArrowRight className="ml-1 h-4 w-4" />
+            </Button>
+          </>
+        )}
+      </CardFooter>
+    </Card>
+  );
+}
+
+function formatValue(value: unknown): string {
+  if (Array.isArray(value)) return value.join(", ");
+  if (value === undefined || value === null) return "-";
+  if (typeof value === "boolean") return value ? "はい" : "いいえ";
+  if (typeof value === "object") return JSON.stringify(value);
+  return String(value);
+}
+
+function SpecRow({ label, value }: { label: string; value: unknown }) {
+  const formatted = formatValue(value);
+  if (formatted === "-" || formatted === "") return null;
+  return (
+    <div className="flex gap-2 text-sm">
+      <div className="text-muted-foreground w-28 shrink-0">{label}</div>
+      <div className="flex-1 break-words">{formatted}</div>
+    </div>
+  );
+}
+
+function SpecPreview({ spec }: { spec: CustomSessionSpec }) {
+  return (
+    <div className="bg-muted/40 space-y-1 rounded-md border p-3">
+      <div className="text-muted-foreground mb-1 text-xs">パース結果 (読み取り専用)</div>
+      <SpecRow label="ドメイン" value={spec.domains} />
+      <SpecRow label="サブドメイン" value={spec.subdomains} />
+      <SpecRow label="concept" value={spec.concepts} />
+      <SpecRow label="除外 concept" value={spec.excludeConcepts} />
+      <SpecRow label="思考スタイル" value={spec.thinkingStyles} />
+      <SpecRow label="問題形式" value={spec.questionTypes} />
+      <SpecRow label="問題数" value={spec.questionCount} />
+      <SpecRow label="難易度" value={spec.difficulty ? spec.difficulty.level : undefined} />
+      {spec.constraints && (
+        <>
+          <SpecRow label="言語" value={spec.constraints.language} />
+          <SpecRow label="コード言語" value={spec.constraints.codeLanguage} />
+          <SpecRow label="時間制限 (秒)" value={spec.constraints.timeLimitSec} />
+          <SpecRow label="必ず含めて" value={spec.constraints.mustInclude} />
+          <SpecRow label="避けて" value={spec.constraints.avoid} />
+        </>
+      )}
+      <SpecRow label="mastery 反映" value={spec.updateMastery} />
+    </div>
+  );
+}

--- a/src/features/drill/drill-screen.tsx
+++ b/src/features/drill/drill-screen.tsx
@@ -18,9 +18,18 @@ import { CopyForLlmButton } from "./copy-for-llm-button";
 import { RebuttalForm } from "./rebuttal-form";
 import { normalizeRubricChecks, useDrillStore } from "./drill-state";
 
-export function DrillScreen() {
+type DrillScreenProps = {
+  /** 完了後「ホームに戻る」を押したときの遷移ハンドラ (例: /custom に戻る)。
+   *  未指定ならデフォルトの useDrillStore.reset() が走り、Daily Drill 開始カードに戻る。 */
+  onReset?: () => void;
+  /** idle で出るスタートカードの挙動を差し替える (例: /custom では使わない) */
+  skipInitialStartCard?: boolean;
+};
+
+export function DrillScreen({ onReset, skipInitialStartCard }: DrillScreenProps = {}) {
   const { phase, sessionId, question, selectedIndex, grading, summary } = useDrillStore();
   const { reset, setSession, setQuestion, setSelected, setGrading, setSummary } = useDrillStore();
+  const handleReset = onReset ?? reset;
 
   const startMutation = trpc.session.start.useMutation();
   const nextMutation = trpc.session.next.useMutation();
@@ -142,6 +151,10 @@ export function DrillScreen() {
   ]);
 
   if (phase === "idle") {
+    if (skipInitialStartCard) {
+      // 親 (/custom 等) が自前で session を用意する構成。何も出さない。
+      return null;
+    }
     return (
       <Card className="w-full max-w-xl">
         <CardHeader>
@@ -169,7 +182,14 @@ export function DrillScreen() {
           </CardDescription>
         </CardHeader>
         <CardFooter>
-          <Button onClick={reset}>ホームに戻る</Button>
+          <Button
+            onClick={() => {
+              reset();
+              handleReset();
+            }}
+          >
+            ホームに戻る
+          </Button>
         </CardFooter>
       </Card>
     );

--- a/src/server/grader/index.ts
+++ b/src/server/grader/index.ts
@@ -25,6 +25,12 @@ export type GradeAttemptInput = {
   elapsedMs?: number;
   /** 「なぜそう答えたか」(任意、誤概念抽出に使う) */
   reasonGiven?: string;
+  /**
+   * FSRS / mastery 更新を行うか。Custom Session で updateMastery=false が指定された
+   * 場合に false を渡すと、attempts への記録はするが mastery テーブルへの波及を抑止する
+   * (docs/04 §4.9.2)。未指定なら true (通常 Drill の挙動)。
+   */
+  updateMastery?: boolean;
 };
 
 export type GradeAttemptResult = {
@@ -144,12 +150,16 @@ export async function gradeAttempt(input: GradeAttemptInput): Promise<GradeAttem
 
   if (inserted[0]) {
     grade.attempt.id = inserted[0].id;
-    // 採点成功したときだけ mastery を更新 (二重 submit の losing race は更新しない)
-    await updateMasteryAfterAttempt({
-      userId: input.userId,
-      conceptId: question.conceptId,
-      score: grade.score,
-    });
+    // 採点成功したときだけ mastery を更新 (二重 submit の losing race は更新しない)。
+    // Custom Session で updateMastery=false が指定されたときは attempts のみ残して
+    // FSRS / mastery は触らない (docs/04 §4.9.2 「お試しモード」)。
+    if (input.updateMastery !== false) {
+      await updateMasteryAfterAttempt({
+        userId: input.userId,
+        conceptId: question.conceptId,
+        score: grade.score,
+      });
+    }
     return grade;
   }
 

--- a/src/server/scheduler/daily.test.ts
+++ b/src/server/scheduler/daily.test.ts
@@ -155,4 +155,20 @@ describe("rankDailyCandidates", () => {
       ]
     `);
   });
+
+  it("rankDailyCandidates は difficultyLevels 非対応の concept も返す (filter は selectDailyCandidates 側で実施)", () => {
+    // rankDailyCandidates 自体は pure 関数で difficulty に関与しない。
+    // 実際の difficulty filter は selectDailyCandidates が DB 層で適用する設計なので、
+    // ここでは rank 関数の責務が広がっていないことをスナップで確認。
+    const result = rankDailyCandidates({
+      concepts: [
+        concept("beginner-only", [], ["beginner"]),
+        concept("senior-only", [], ["senior"]),
+      ],
+      masteries: [],
+      count: 2,
+      now,
+    });
+    expect(result.map((r) => r.concept.id).sort()).toEqual(["beginner-only", "senior-only"]);
+  });
 });

--- a/src/server/scheduler/daily.ts
+++ b/src/server/scheduler/daily.ts
@@ -45,6 +45,13 @@ export type SelectDailyInput = {
   userId: string;
   count: number;
   now?: Date;
+  /**
+   * 与えられた場合、この difficulty を `concept.difficultyLevels` に含む concept のみに
+   * 候補を絞ってから上位 count 件を返す。Custom Session で difficulty を指定した場合に
+   * 「候補が上位でしか切られず、下位に唯一の match が埋もれる」問題を避けるため、
+   * filter は scoring/slicing の前に適用する。
+   */
+  difficultyFilter?: string;
 };
 
 /**
@@ -60,8 +67,14 @@ export async function selectDailyCandidates(input: SelectDailyInput): Promise<Da
     db.select().from(mastery).where(eq(mastery.userId, input.userId)),
   ]);
 
+  const filtered = input.difficultyFilter
+    ? conceptRows.filter((c) =>
+        c.difficultyLevels.includes(input.difficultyFilter as (typeof c.difficultyLevels)[number]),
+      )
+    : conceptRows;
+
   return rankDailyCandidates({
-    concepts: conceptRows,
+    concepts: filtered,
     masteries: masteryRows,
     count: input.count,
     now,

--- a/src/server/trpc/routers/session.custom.test.ts
+++ b/src/server/trpc/routers/session.custom.test.ts
@@ -1,0 +1,31 @@
+import { TRPCError } from "@trpc/server";
+import { describe, expect, it } from "vitest";
+
+import type { User } from "@/db/schema";
+
+import { appRouter } from "./index";
+
+describe("session.start with customSpec validation", () => {
+  const fakeUser = { id: "u-1" } as User;
+  const caller = appRouter.createCaller({ user: fakeUser });
+
+  it("kind='custom' なのに customSpec が無ければ BAD_REQUEST", async () => {
+    await expect(caller.session.start({ kind: "custom" })).rejects.toMatchObject({
+      code: "BAD_REQUEST",
+    });
+  });
+
+  it("kind='daily' なのに customSpec が付いていたら BAD_REQUEST", async () => {
+    // 本来の型定義上は問題ない optional の同時指定。実装側で kind と customSpec の
+    // 整合をチェックしているため、その境界動作を verify する。
+    await expect(
+      caller.session.start({
+        kind: "daily",
+        customSpec: {
+          questionCount: 3,
+          difficulty: { kind: "absolute", level: "junior" },
+        },
+      }),
+    ).rejects.toBeInstanceOf(TRPCError);
+  });
+});

--- a/src/server/trpc/routers/session.custom.test.ts
+++ b/src/server/trpc/routers/session.custom.test.ts
@@ -28,4 +28,45 @@ describe("session.start with customSpec validation", () => {
       }),
     ).rejects.toBeInstanceOf(TRPCError);
   });
+
+  it("MVP 未対応: difficulty=staff / principal は BAD_REQUEST", async () => {
+    await expect(
+      caller.session.start({
+        kind: "custom",
+        customSpec: { questionCount: 3, difficulty: { kind: "absolute", level: "staff" } },
+      }),
+    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+    await expect(
+      caller.session.start({
+        kind: "custom",
+        customSpec: { questionCount: 3, difficulty: { kind: "absolute", level: "principal" } },
+      }),
+    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+  });
+
+  it("MVP 未対応: questionTypes に mcq が含まれないと BAD_REQUEST", async () => {
+    await expect(
+      caller.session.start({
+        kind: "custom",
+        customSpec: {
+          questionCount: 3,
+          difficulty: { kind: "absolute", level: "junior" },
+          questionTypes: ["written"],
+        },
+      }),
+    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+  });
+
+  it("MVP 未対応: constraints の実効フィールドがあれば BAD_REQUEST", async () => {
+    await expect(
+      caller.session.start({
+        kind: "custom",
+        customSpec: {
+          questionCount: 3,
+          difficulty: { kind: "absolute", level: "junior" },
+          constraints: { mustInclude: ["TLS 1.3"] },
+        },
+      }),
+    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+  });
 });

--- a/src/server/trpc/routers/session.custom.test.ts
+++ b/src/server/trpc/routers/session.custom.test.ts
@@ -6,8 +6,10 @@ import type { User } from "@/db/schema";
 import { appRouter } from "./index";
 
 // DB クライアントをスタブ。session.start は insert().values().returning() をチェーンで呼ぶ。
-// 他のテストで session.next / submit の DB アクセスを検証するために capture できる形に。
+// loadConcept は select().from().where().limit() を呼ぶ。
+// テスト間で「次に返す concept」を差し替えるために nextConceptRow を module スコープで保持。
 const valuesSpy = vi.fn();
+let nextConceptRow: { id: string; difficultyLevels: string[] } | null = null;
 vi.mock("@/db/client", () => {
   const returning = vi.fn().mockResolvedValue([{ id: "sess-fake" }]);
   const values = vi.fn((v: unknown) => {
@@ -15,13 +17,18 @@ vi.mock("@/db/client", () => {
     return { returning };
   });
   const insert = vi.fn().mockReturnValue({ values });
+  const limit = vi.fn(async () => (nextConceptRow ? [nextConceptRow] : []));
+  const whereFn = vi.fn(() => ({ limit }));
+  const fromFn = vi.fn(() => ({ where: whereFn }));
+  const selectFn = vi.fn(() => ({ from: fromFn }));
   return {
-    getDb: vi.fn().mockReturnValue({ insert }),
+    getDb: vi.fn().mockReturnValue({ insert, select: selectFn }),
   };
 });
 
 beforeEach(() => {
   valuesSpy.mockClear();
+  nextConceptRow = null;
 });
 
 describe("session.start with customSpec validation", () => {
@@ -171,7 +178,44 @@ describe("session.start with customSpec validation", () => {
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
   });
 
+  it("concepts[0] と difficulty が不整合なら start 時点で BAD_REQUEST (Round 9 #1)", async () => {
+    nextConceptRow = {
+      id: "programming.basics.value_vs_reference",
+      difficultyLevels: ["beginner", "junior"],
+    };
+    await expect(
+      caller.session.start({
+        kind: "custom",
+        customSpec: {
+          questionCount: 3,
+          difficulty: { kind: "absolute", level: "senior" },
+          concepts: ["programming.basics.value_vs_reference"],
+        },
+      }),
+    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+  });
+
+  it("concepts[0] と difficulty が整合する場合は accept", async () => {
+    nextConceptRow = {
+      id: "db.rdb.btree_index",
+      difficultyLevels: ["junior", "mid", "senior"],
+    };
+    const res = await caller.session.start({
+      kind: "custom",
+      customSpec: {
+        questionCount: 3,
+        difficulty: { kind: "absolute", level: "senior" },
+        concepts: ["db.rdb.btree_index"],
+      },
+    });
+    expect(res.sessionId).toBe("sess-fake");
+  });
+
   it("正ケース: accept → insert payload に customSpec / kind='custom' / userId が積まれる", async () => {
+    nextConceptRow = {
+      id: "network.tcp.basics",
+      difficultyLevels: ["beginner", "junior", "mid"],
+    };
     const inputSpec = {
       questionCount: 3,
       difficulty: { kind: "absolute" as const, level: "junior" as const },

--- a/src/server/trpc/routers/session.custom.test.ts
+++ b/src/server/trpc/routers/session.custom.test.ts
@@ -126,6 +126,32 @@ describe("session.start with customSpec validation", () => {
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
   });
 
+  it("MVP 未対応: thinkingStyles 2 件以上は BAD_REQUEST", async () => {
+    await expect(
+      caller.session.start({
+        kind: "custom",
+        customSpec: {
+          questionCount: 3,
+          difficulty: { kind: "absolute", level: "junior" },
+          thinkingStyles: ["trade_off", "edge_case"],
+        },
+      }),
+    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+  });
+
+  it("MVP 未対応: concepts 2 件以上は BAD_REQUEST", async () => {
+    await expect(
+      caller.session.start({
+        kind: "custom",
+        customSpec: {
+          questionCount: 3,
+          difficulty: { kind: "absolute", level: "junior" },
+          concepts: ["network.tcp.basics", "network.tcp.congestion"],
+        },
+      }),
+    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+  });
+
   it("questionTypes=['mcq'] 単体は accept (正のケース: DB まで到達する)", async () => {
     // DB へのアクセスは fake user ではエラーになるので、start 入力バリデーションを通過して
     // DB 層に到達したことの確認として、バリデーション以外のエラーに落ちれば OK。

--- a/src/server/trpc/routers/session.custom.test.ts
+++ b/src/server/trpc/routers/session.custom.test.ts
@@ -1,19 +1,27 @@
 import { TRPCError } from "@trpc/server";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { User } from "@/db/schema";
 
 import { appRouter } from "./index";
 
 // DB クライアントをスタブ。session.start は insert().values().returning() をチェーンで呼ぶ。
+// 他のテストで session.next / submit の DB アクセスを検証するために capture できる形に。
+const valuesSpy = vi.fn();
 vi.mock("@/db/client", () => {
   const returning = vi.fn().mockResolvedValue([{ id: "sess-fake" }]);
-  const values = vi.fn().mockReturnValue({ returning });
+  const values = vi.fn((v: unknown) => {
+    valuesSpy(v);
+    return { returning };
+  });
   const insert = vi.fn().mockReturnValue({ values });
   return {
     getDb: vi.fn().mockReturnValue({ insert }),
-    __getDbMocks: { insert, values, returning },
   };
+});
+
+beforeEach(() => {
+  valuesSpy.mockClear();
 });
 
 describe("session.start with customSpec validation", () => {
@@ -163,21 +171,43 @@ describe("session.start with customSpec validation", () => {
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
   });
 
-  it("正ケース: questionTypes=['mcq'] / thinkingStyles=[one] / concepts=[one] は全て accept し DB insert へ到達", async () => {
-    // 入力バリデーションを全て通過すると getDb().insert(sessions).values().returning() が呼ばれる。
-    // 返り値はモック で { id: 'sess-fake' }。
-    const res = await caller.session.start({
-      kind: "custom",
-      customSpec: {
-        questionCount: 3,
-        difficulty: { kind: "absolute", level: "junior" },
-        questionTypes: ["mcq"],
-        thinkingStyles: ["trade_off"],
-        concepts: ["network.tcp.basics"],
-      },
-    });
+  it("正ケース: accept → insert payload に customSpec / kind='custom' / userId が積まれる", async () => {
+    const inputSpec = {
+      questionCount: 3,
+      difficulty: { kind: "absolute" as const, level: "junior" as const },
+      questionTypes: ["mcq" as const],
+      thinkingStyles: ["trade_off" as const],
+      concepts: ["network.tcp.basics"],
+      updateMastery: false,
+    };
+    const res = await caller.session.start({ kind: "custom", customSpec: inputSpec });
     expect(res.sessionId).toBe("sess-fake");
     expect(res.targetCount).toBe(3);
+
+    // values() payload の中身検証: userId / kind / spec.customSpec が正しく積まれている
+    expect(valuesSpy).toHaveBeenCalledTimes(1);
+    const payload = valuesSpy.mock.calls[0]?.[0] as {
+      userId: string;
+      kind: string;
+      spec: { targetCount: number; pendingQuestionId: null; customSpec: typeof inputSpec };
+    };
+    expect(payload.userId).toBe("u-1");
+    expect(payload.kind).toBe("custom");
+    expect(payload.spec.targetCount).toBe(3);
+    expect(payload.spec.pendingQuestionId).toBeNull();
+    expect(payload.spec.customSpec).toEqual(inputSpec);
+  });
+
+  it("正ケース: kind='daily' (customSpec なし) は insert payload に customSpec を積まない", async () => {
+    await caller.session.start({ kind: "daily", targetCount: 7 });
+    expect(valuesSpy).toHaveBeenCalledTimes(1);
+    const payload = valuesSpy.mock.calls[0]?.[0] as {
+      kind: string;
+      spec: { targetCount: number; customSpec?: unknown };
+    };
+    expect(payload.kind).toBe("daily");
+    expect(payload.spec.targetCount).toBe(7);
+    expect(payload.spec.customSpec).toBeUndefined();
   });
 
   it("MVP 未対応: constraints の実効フィールドがあれば BAD_REQUEST", async () => {

--- a/src/server/trpc/routers/session.custom.test.ts
+++ b/src/server/trpc/routers/session.custom.test.ts
@@ -67,6 +67,17 @@ describe("session.start with customSpec validation", () => {
         },
       }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+    // mcq 重複 (length !== 1) も reject (Round 4 厳格化)
+    await expect(
+      caller.session.start({
+        kind: "custom",
+        customSpec: {
+          questionCount: 3,
+          difficulty: { kind: "absolute", level: "junior" },
+          questionTypes: ["mcq", "mcq"],
+        },
+      }),
+    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
   });
 
   it("MVP 未対応: domains / subdomains / excludeConcepts は BAD_REQUEST", async () => {

--- a/src/server/trpc/routers/session.custom.test.ts
+++ b/src/server/trpc/routers/session.custom.test.ts
@@ -1,9 +1,20 @@
 import { TRPCError } from "@trpc/server";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import type { User } from "@/db/schema";
 
 import { appRouter } from "./index";
+
+// DB クライアントをスタブ。session.start は insert().values().returning() をチェーンで呼ぶ。
+vi.mock("@/db/client", () => {
+  const returning = vi.fn().mockResolvedValue([{ id: "sess-fake" }]);
+  const values = vi.fn().mockReturnValue({ returning });
+  const insert = vi.fn().mockReturnValue({ values });
+  return {
+    getDb: vi.fn().mockReturnValue({ insert }),
+    __getDbMocks: { insert, values, returning },
+  };
+});
 
 describe("session.start with customSpec validation", () => {
   const fakeUser = { id: "u-1" } as User;
@@ -152,20 +163,21 @@ describe("session.start with customSpec validation", () => {
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
   });
 
-  it("questionTypes=['mcq'] 単体は accept (正のケース: DB まで到達する)", async () => {
-    // DB へのアクセスは fake user ではエラーになるので、start 入力バリデーションを通過して
-    // DB 層に到達したことの確認として、バリデーション以外のエラーに落ちれば OK。
-    const promise = caller.session.start({
+  it("正ケース: questionTypes=['mcq'] / thinkingStyles=[one] / concepts=[one] は全て accept し DB insert へ到達", async () => {
+    // 入力バリデーションを全て通過すると getDb().insert(sessions).values().returning() が呼ばれる。
+    // 返り値はモック で { id: 'sess-fake' }。
+    const res = await caller.session.start({
       kind: "custom",
       customSpec: {
         questionCount: 3,
         difficulty: { kind: "absolute", level: "junior" },
         questionTypes: ["mcq"],
+        thinkingStyles: ["trade_off"],
+        concepts: ["network.tcp.basics"],
       },
     });
-    await expect(promise).rejects.not.toMatchObject({
-      message: expect.stringContaining("questionTypes"),
-    });
+    expect(res.sessionId).toBe("sess-fake");
+    expect(res.targetCount).toBe(3);
   });
 
   it("MVP 未対応: constraints の実効フィールドがあれば BAD_REQUEST", async () => {

--- a/src/server/trpc/routers/session.custom.test.ts
+++ b/src/server/trpc/routers/session.custom.test.ts
@@ -113,6 +113,35 @@ describe("session.start with customSpec validation", () => {
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
   });
 
+  it("MVP 未対応: constraints.language も BAD_REQUEST", async () => {
+    await expect(
+      caller.session.start({
+        kind: "custom",
+        customSpec: {
+          questionCount: 3,
+          difficulty: { kind: "absolute", level: "junior" },
+          constraints: { language: "en" },
+        },
+      }),
+    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+  });
+
+  it("questionTypes=['mcq'] 単体は accept (正のケース: DB まで到達する)", async () => {
+    // DB へのアクセスは fake user ではエラーになるので、start 入力バリデーションを通過して
+    // DB 層に到達したことの確認として、バリデーション以外のエラーに落ちれば OK。
+    const promise = caller.session.start({
+      kind: "custom",
+      customSpec: {
+        questionCount: 3,
+        difficulty: { kind: "absolute", level: "junior" },
+        questionTypes: ["mcq"],
+      },
+    });
+    await expect(promise).rejects.not.toMatchObject({
+      message: expect.stringContaining("questionTypes"),
+    });
+  });
+
   it("MVP 未対応: constraints の実効フィールドがあれば BAD_REQUEST", async () => {
     await expect(
       caller.session.start({

--- a/src/server/trpc/routers/session.custom.test.ts
+++ b/src/server/trpc/routers/session.custom.test.ts
@@ -44,7 +44,8 @@ describe("session.start with customSpec validation", () => {
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
   });
 
-  it("MVP 未対応: questionTypes に mcq が含まれないと BAD_REQUEST", async () => {
+  it("MVP 未対応: questionTypes が mcq 以外を含むと BAD_REQUEST", async () => {
+    // mcq 単体ケース
     await expect(
       caller.session.start({
         kind: "custom",
@@ -52,6 +53,17 @@ describe("session.start with customSpec validation", () => {
           questionCount: 3,
           difficulty: { kind: "absolute", level: "junior" },
           questionTypes: ["written"],
+        },
+      }),
+    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+    // mcq と混在していても reject (Round 3 厳格化)
+    await expect(
+      caller.session.start({
+        kind: "custom",
+        customSpec: {
+          questionCount: 3,
+          difficulty: { kind: "absolute", level: "junior" },
+          questionTypes: ["mcq", "written"],
         },
       }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });

--- a/src/server/trpc/routers/session.custom.test.ts
+++ b/src/server/trpc/routers/session.custom.test.ts
@@ -55,19 +55,19 @@ describe("session.start with customSpec validation", () => {
     ).rejects.toBeInstanceOf(TRPCError);
   });
 
-  it("MVP 未対応: difficulty=staff / principal は BAD_REQUEST", async () => {
+  it("difficulty=staff / principal も受け入れる (Round 10: 6 段階統一)", async () => {
     await expect(
       caller.session.start({
         kind: "custom",
         customSpec: { questionCount: 3, difficulty: { kind: "absolute", level: "staff" } },
       }),
-    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+    ).resolves.toHaveProperty("sessionId");
     await expect(
       caller.session.start({
         kind: "custom",
         customSpec: { questionCount: 3, difficulty: { kind: "absolute", level: "principal" } },
       }),
-    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+    ).resolves.toHaveProperty("sessionId");
   });
 
   it("MVP 未対応: questionTypes が mcq 以外を含むと BAD_REQUEST", async () => {

--- a/src/server/trpc/routers/session.custom.test.ts
+++ b/src/server/trpc/routers/session.custom.test.ts
@@ -57,6 +57,39 @@ describe("session.start with customSpec validation", () => {
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
   });
 
+  it("MVP 未対応: domains / subdomains / excludeConcepts は BAD_REQUEST", async () => {
+    await expect(
+      caller.session.start({
+        kind: "custom",
+        customSpec: {
+          questionCount: 3,
+          difficulty: { kind: "absolute", level: "junior" },
+          domains: ["network"],
+        },
+      }),
+    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+    await expect(
+      caller.session.start({
+        kind: "custom",
+        customSpec: {
+          questionCount: 3,
+          difficulty: { kind: "absolute", level: "junior" },
+          subdomains: ["network.tcp"],
+        },
+      }),
+    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+    await expect(
+      caller.session.start({
+        kind: "custom",
+        customSpec: {
+          questionCount: 3,
+          difficulty: { kind: "absolute", level: "junior" },
+          excludeConcepts: ["network.tcp.basics"],
+        },
+      }),
+    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+  });
+
   it("MVP 未対応: constraints の実効フィールドがあれば BAD_REQUEST", async () => {
     await expect(
       caller.session.start({

--- a/src/server/trpc/routers/session.ts
+++ b/src/server/trpc/routers/session.ts
@@ -49,17 +49,25 @@ async function loadSession(sessionId: string, userId: string) {
   return row;
 }
 
-async function pickConceptForDrill(userId: string) {
+async function pickConceptForDrill(userId: string, requiredDifficulty?: DifficultyLevel) {
   // Daily Drill の優先度アルゴリズム (docs/06 §6.4) に委譲。
   // due / blind_spot のどちらも空 (= mastered な concept が無く、かつ prereqs が空の concept も無い)
   // だと候補が 0 件になる。MVP の seed (10 concept) では prereqs なし concept が複数あり bootstrap 時も候補が埋まるが、
   // 念のため PRECONDITION_FAILED でクライアントに状況を知らせる。
-  const candidates = await selectDailyCandidates({ userId, count: 1 });
-  if (candidates[0]) return candidates[0].concept;
+  // Custom Session の difficulty 指定時は、上位 10 件からその難易度を許容する concept を選ぶ。
+  const candidates = await selectDailyCandidates({
+    userId,
+    count: requiredDifficulty ? 10 : 1,
+  });
+  const compatible = requiredDifficulty
+    ? candidates.filter((c) => c.concept.difficultyLevels.includes(requiredDifficulty))
+    : candidates;
+  if (compatible[0]) return compatible[0].concept;
   throw new TRPCError({
     code: "PRECONDITION_FAILED",
-    message:
-      "no drill candidate: seed にある concept が 0 件か、全 concept の prereqs が未充足。seed を確認してください",
+    message: requiredDifficulty
+      ? `difficulty=${requiredDifficulty} を許容する concept が候補に無い。concepts を明示指定してください`
+      : "no drill candidate: seed にある concept が 0 件か、全 concept の prereqs が未充足。seed を確認してください",
   });
 }
 
@@ -261,9 +269,12 @@ export const sessionRouter = router({
         const effectiveConceptId = customSpec
           ? (customConceptId ?? null)
           : (input.conceptId ?? null);
+        // Custom で concept 未指定 + difficulty 指定時は、pickConceptForDrill で
+        // その難易度を許容する concept のみを候補にする (start 時の整合は
+        // concept 未指定ケースで検証できないので、ここでも補完的に filter)。
         const conceptRow = effectiveConceptId
           ? await loadConcept(effectiveConceptId)
-          : await pickConceptForDrill(ctx.user.id);
+          : await pickConceptForDrill(ctx.user.id, customSpec?.difficulty?.level);
 
         // 直近 STREAK_FOR_PROMOTION 件の同 concept の attempts を見て、3 連続正解なら次出題を 1 段昇格
         const recent = await getDb()

--- a/src/server/trpc/routers/session.ts
+++ b/src/server/trpc/routers/session.ts
@@ -118,11 +118,13 @@ export const sessionRouter = router({
           });
         }
       }
-      // MVP は mcq 生成のみ。questionTypes が指定されていて mcq 以外を 1 つでも含む場合は reject。
-      // (UI 注記と一致させるため、mcq 混在でも厳密に弾く)
+      // MVP は mcq 生成のみ。UI 注記と一致させるため、正確に ['mcq'] (単一要素) だけ許可する。
+      // ['mcq', 'written'] などの混在、['mcq', 'mcq'] のような重複も reject。
       if (input.customSpec?.questionTypes && input.customSpec.questionTypes.length > 0) {
-        const onlyMcq = input.customSpec.questionTypes.every((t) => t === "mcq");
-        if (!onlyMcq) {
+        const isExactMcqSingleton =
+          input.customSpec.questionTypes.length === 1 &&
+          input.customSpec.questionTypes[0] === "mcq";
+        if (!isExactMcqSingleton) {
           throw new TRPCError({
             code: "BAD_REQUEST",
             message: "Custom Session MVP は questionTypes=['mcq'] のみ許可です",

--- a/src/server/trpc/routers/session.ts
+++ b/src/server/trpc/routers/session.ts
@@ -107,17 +107,11 @@ export const sessionRouter = router({
         });
       }
 
-      // MVP 受け入れ基準 (Issue #18): 絶対難易度は beginner/junior/mid/senior のみ。
-      // staff/principal は Custom Session では Phase 5+ で解禁するためここで reject する。
-      if (input.customSpec?.difficulty) {
-        const level = input.customSpec.difficulty.level;
-        if (level !== "beginner" && level !== "junior" && level !== "mid" && level !== "senior") {
-          throw new TRPCError({
-            code: "BAD_REQUEST",
-            message: `Custom Session MVP は difficulty=${level} に未対応 (beginner/junior/mid/senior のみ)`,
-          });
-        }
-      }
+      // 絶対難易度 6 段階 (beginner/junior/mid/senior/staff/principal) を全て受け入れる。
+      // Issue #18 AC の「beginner/junior/mid/senior のみ」記述は保守的な初期値で、
+      // parser / prompt / docs (§4.10.1) / _constants.ts は 6 段階で統一されているため
+      // session.start もそれに合わせる (Round 10 指摘)。
+      // DifficultyAbsoluteSchema.level が 6 段階 enum なので実装追加の validation は不要。
       // MVP は mcq 生成のみ。UI 注記と一致させるため、正確に ['mcq'] (単一要素) だけ許可する。
       // ['mcq', 'written'] などの混在、['mcq', 'mcq'] のような重複も reject。
       if (input.customSpec?.questionTypes && input.customSpec.questionTypes.length > 0) {

--- a/src/server/trpc/routers/session.ts
+++ b/src/server/trpc/routers/session.ts
@@ -118,16 +118,16 @@ export const sessionRouter = router({
           });
         }
       }
-      // MVP は mcq 生成のみ (questionTypes が指定されていて mcq を含まなければ reject)。
-      if (
-        input.customSpec?.questionTypes &&
-        input.customSpec.questionTypes.length > 0 &&
-        !input.customSpec.questionTypes.includes("mcq")
-      ) {
-        throw new TRPCError({
-          code: "BAD_REQUEST",
-          message: "Custom Session MVP は mcq のみ生成可能です",
-        });
+      // MVP は mcq 生成のみ。questionTypes が指定されていて mcq 以外を 1 つでも含む場合は reject。
+      // (UI 注記と一致させるため、mcq 混在でも厳密に弾く)
+      if (input.customSpec?.questionTypes && input.customSpec.questionTypes.length > 0) {
+        const onlyMcq = input.customSpec.questionTypes.every((t) => t === "mcq");
+        if (!onlyMcq) {
+          throw new TRPCError({
+            code: "BAD_REQUEST",
+            message: "Custom Session MVP は questionTypes=['mcq'] のみ許可です",
+          });
+        }
       }
       // constraints は MVP で生成プロンプトに反映されないため、該当フィールドがあれば reject
       // (プレビューで「指定した」と見えて実行時に無視されるのは虚偽表示に近い挙動なので)。

--- a/src/server/trpc/routers/session.ts
+++ b/src/server/trpc/routers/session.ts
@@ -51,18 +51,15 @@ async function loadSession(sessionId: string, userId: string) {
 
 async function pickConceptForDrill(userId: string, requiredDifficulty?: DifficultyLevel) {
   // Daily Drill の優先度アルゴリズム (docs/06 §6.4) に委譲。
-  // due / blind_spot のどちらも空 (= mastered な concept が無く、かつ prereqs が空の concept も無い)
-  // だと候補が 0 件になる。MVP の seed (10 concept) では prereqs なし concept が複数あり bootstrap 時も候補が埋まるが、
-  // 念のため PRECONDITION_FAILED でクライアントに状況を知らせる。
-  // Custom Session の difficulty 指定時は、上位 10 件からその難易度を許容する concept を選ぶ。
+  // due / blind_spot のどちらも空だと候補が 0 件になるので PRECONDITION_FAILED。
+  // Custom Session の difficulty 指定時は selectDailyCandidates の difficultyFilter を使って
+  // concept 総数が増えても上位に埋もれないよう scoring/slice の前に filter する。
   const candidates = await selectDailyCandidates({
     userId,
-    count: requiredDifficulty ? 10 : 1,
+    count: 1,
+    difficultyFilter: requiredDifficulty,
   });
-  const compatible = requiredDifficulty
-    ? candidates.filter((c) => c.concept.difficultyLevels.includes(requiredDifficulty))
-    : candidates;
-  if (compatible[0]) return compatible[0].concept;
+  if (candidates[0]) return candidates[0].concept;
   throw new TRPCError({
     code: "PRECONDITION_FAILED",
     message: requiredDifficulty

--- a/src/server/trpc/routers/session.ts
+++ b/src/server/trpc/routers/session.ts
@@ -141,6 +141,19 @@ export const sessionRouter = router({
           });
         }
       }
+      // domains / subdomains / excludeConcepts も現状プロンプトに反映されないため、
+      // 同じ理由 (虚偽表示回避) で reject する。MVP は concepts[0] で concept を直接指定する運用。
+      if (
+        input.customSpec?.domains?.length ||
+        input.customSpec?.subdomains?.length ||
+        input.customSpec?.excludeConcepts?.length
+      ) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message:
+            "Custom Session MVP は domains / subdomains / excludeConcepts 未対応です (concepts[0] で直接指定してください)",
+        });
+      }
 
       const db = getDb();
       // 問題数は customSpec.questionCount があれば優先。なければ input.targetCount、なければ既定 5
@@ -209,7 +222,8 @@ export const sessionRouter = router({
       let questionMeta: CopyForLlmQuestionMeta | null = null;
       try {
         // Custom Session は spec.customSpec (absolute difficulty + thinking_style 等) を優先する。
-        // concept 選定は customSpec.concepts → customSpec.domains → daily pick の順で fallback。
+        // MVP での concept 選定: customSpec.concepts[0] → daily pick の 2 段階。
+        // domains / subdomains / excludeConcepts は session.start で reject 済みのためここには来ない。
         const customSpec = spec.customSpec;
         const customConceptId = customSpec?.concepts?.[0];
         const conceptRow = input.conceptId

--- a/src/server/trpc/routers/session.ts
+++ b/src/server/trpc/routers/session.ts
@@ -131,6 +131,21 @@ export const sessionRouter = router({
           });
         }
       }
+      // MVP は thinkingStyles を 1 件までしか出題に反映できない (next は [0] のみ参照)。
+      // 2 件以上指定は「指定が黙示に捨てられる」虚偽表示になるため reject。
+      if (input.customSpec?.thinkingStyles && input.customSpec.thinkingStyles.length > 1) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: "Custom Session MVP は thinkingStyles を 1 件のみ指定できます",
+        });
+      }
+      // MVP は concepts も 1 件まで (next は [0] のみ参照、2 件目以降は使われない)
+      if (input.customSpec?.concepts && input.customSpec.concepts.length > 1) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: "Custom Session MVP は concepts を 1 件のみ指定できます",
+        });
+      }
       // constraints は MVP で生成プロンプトに反映されないため、該当フィールドがあれば reject
       // (プレビューで「指定した」と見えて実行時に無視されるのは虚偽表示に近い挙動なので)。
       if (input.customSpec?.constraints) {

--- a/src/server/trpc/routers/session.ts
+++ b/src/server/trpc/routers/session.ts
@@ -146,6 +146,18 @@ export const sessionRouter = router({
           message: "Custom Session MVP は concepts を 1 件のみ指定できます",
         });
       }
+      // concepts[0] と difficulty 両方が指定されていれば concept.difficultyLevels と
+      // 整合することを start 時点でチェック (session.next が後続で失敗するのを避ける)。
+      if (input.customSpec?.concepts?.[0] && input.customSpec.difficulty) {
+        const concept = await loadConcept(input.customSpec.concepts[0]);
+        const level = input.customSpec.difficulty.level;
+        if (!concept.difficultyLevels.includes(level)) {
+          throw new TRPCError({
+            code: "BAD_REQUEST",
+            message: `concept "${concept.id}" は difficulty=${level} をサポートしていません (対応: ${concept.difficultyLevels.join(", ")})`,
+          });
+        }
+      }
       // constraints は MVP で生成プロンプトに反映されないため、該当フィールドがあれば reject
       // (プレビューで「指定した」と見えて実行時に無視されるのは虚偽表示に近い挙動なので)。
       if (input.customSpec?.constraints) {

--- a/src/server/trpc/routers/session.ts
+++ b/src/server/trpc/routers/session.ts
@@ -280,9 +280,13 @@ export const sessionRouter = router({
           .where(and(eq(attempts.userId, ctx.user.id), eq(attempts.conceptId, conceptRow.id)))
           .orderBy(desc(attempts.createdAt))
           .limit(STREAK_FOR_PROMOTION);
-        // custom spec があれば絶対難易度を優先 (昇格は無視。ユーザー指定を尊重)
-        const requestedDifficulty: DifficultyLevel =
-          customSpec?.difficulty?.level ?? input.difficulty;
+        // custom spec があれば絶対難易度を優先 (昇格は無視。ユーザー指定を尊重)。
+        // customSpec.difficulty が未指定のときは concept がサポートする最初の難易度を
+        // fallback として使う (input.difficulty 既定 junior が concept 非対応で
+        // generateMcq が落ちるのを避ける)。
+        const requestedDifficulty: DifficultyLevel = customSpec
+          ? (customSpec.difficulty?.level ?? conceptRow.difficultyLevels[0] ?? input.difficulty)
+          : input.difficulty;
         const promoted = customSpec
           ? null
           : computePromotion({

--- a/src/server/trpc/routers/session.ts
+++ b/src/server/trpc/routers/session.ts
@@ -135,11 +135,17 @@ export const sessionRouter = router({
       // (プレビューで「指定した」と見えて実行時に無視されるのは虚偽表示に近い挙動なので)。
       if (input.customSpec?.constraints) {
         const c = input.customSpec.constraints;
-        if (c.codeLanguage || c.timeLimitSec || c.mustInclude?.length || c.avoid?.length) {
+        if (
+          c.language ||
+          c.codeLanguage ||
+          c.timeLimitSec ||
+          c.mustInclude?.length ||
+          c.avoid?.length
+        ) {
           throw new TRPCError({
             code: "BAD_REQUEST",
             message:
-              "Custom Session MVP は constraints (codeLanguage/timeLimitSec/mustInclude/avoid) 未対応です",
+              "Custom Session MVP は constraints (language/codeLanguage/timeLimitSec/mustInclude/avoid) 未対応です",
           });
         }
       }
@@ -226,13 +232,17 @@ export const sessionRouter = router({
         // Custom Session は spec.customSpec (absolute difficulty + thinking_style 等) を優先する。
         // MVP での concept 選定: customSpec.concepts[0] → daily pick の 2 段階。
         // domains / subdomains / excludeConcepts は session.start で reject 済みのためここには来ない。
+        //
+        // 認可境界: kind='custom' のときは input.conceptId で保存済み spec を迂回できないよう
+        // customSpec.concepts[0] を強制する (セッション開始時に確定した spec が唯一の真実の源)。
         const customSpec = spec.customSpec;
         const customConceptId = customSpec?.concepts?.[0];
-        const conceptRow = input.conceptId
-          ? await loadConcept(input.conceptId)
-          : customConceptId
-            ? await loadConcept(customConceptId)
-            : await pickConceptForDrill(ctx.user.id);
+        const effectiveConceptId = customSpec
+          ? (customConceptId ?? null)
+          : (input.conceptId ?? null);
+        const conceptRow = effectiveConceptId
+          ? await loadConcept(effectiveConceptId)
+          : await pickConceptForDrill(ctx.user.id);
 
         // 直近 STREAK_FOR_PROMOTION 件の同 concept の attempts を見て、3 連続正解なら次出題を 1 段昇格
         const recent = await getDb()
@@ -325,6 +335,8 @@ export const sessionRouter = router({
         });
       }
 
+      // Custom Session の updateMastery=false は FSRS/mastery 更新をスキップ (docs/04 §4.9.2)
+      const submitUpdateMastery = spec.customSpec?.updateMastery ?? true;
       const result = await gradeAttempt({
         userId: ctx.user.id,
         sessionId: session.id,
@@ -332,6 +344,7 @@ export const sessionRouter = router({
         userAnswer: input.userAnswer,
         elapsedMs: input.elapsedMs,
         reasonGiven: input.reasonGiven,
+        updateMastery: submitUpdateMastery,
       });
 
       // 二重送信対策: sql で原子インクリメント + pendingQuestionId 一致 + finishedAt is null の

--- a/src/server/trpc/routers/session.ts
+++ b/src/server/trpc/routers/session.ts
@@ -15,6 +15,7 @@ import {
 import type { CopyForLlmQuestionMeta } from "@/lib/share/copy-for-llm";
 import { generateMcq } from "@/server/generator/mcq";
 import { gradeAttempt } from "@/server/grader";
+import { CustomSessionSpecSchema, type CustomSessionSpec } from "@/server/parser/schema";
 import { selectDailyCandidates } from "@/server/scheduler/daily";
 import { STREAK_FOR_PROMOTION, computePromotion } from "@/server/scheduler/promotion";
 
@@ -30,6 +31,8 @@ type SessionSpec = {
   targetCount?: number;
   /** 出題中の question.id。submit 時に一致チェックして「別問題への水増し submit」を防ぐ */
   pendingQuestionId?: string | null;
+  /** Custom Session 指定 (kind: 'custom' のときだけ埋まる。issue #18) */
+  customSpec?: CustomSessionSpec;
 };
 
 async function loadSession(sessionId: string, userId: string) {
@@ -86,20 +89,39 @@ export const sessionRouter = router({
       z.object({
         kind: SessionKindEnum.default("daily"),
         targetCount: z.number().int().min(1).max(20).optional(),
+        /** Custom Session 指定時のみ。パース結果 (CustomSessionSpec) を Zod で再検証 */
+        customSpec: CustomSessionSpecSchema.optional(),
       }),
     )
     .mutation(async ({ ctx, input }) => {
+      if (input.kind === "custom" && !input.customSpec) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: "kind='custom' には customSpec が必要です",
+        });
+      }
+      if (input.kind !== "custom" && input.customSpec) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: "customSpec は kind='custom' のときだけ指定できます",
+        });
+      }
+
       const db = getDb();
+      // 問題数は customSpec.questionCount があれば優先。なければ input.targetCount、なければ既定 5
+      const targetCount =
+        input.customSpec?.questionCount ?? input.targetCount ?? DEFAULT_DRILL_LENGTH;
       const spec: SessionSpec = {
-        targetCount: input.targetCount ?? DEFAULT_DRILL_LENGTH,
+        targetCount,
         pendingQuestionId: null,
+        ...(input.customSpec ? { customSpec: input.customSpec } : {}),
       };
       const [session] = await db
         .insert(sessions)
         .values({ userId: ctx.user.id, kind: input.kind, spec })
         .returning();
       if (!session) throw new TRPCError({ code: "INTERNAL_SERVER_ERROR" });
-      return { sessionId: session.id, targetCount: spec.targetCount };
+      return { sessionId: session.id, targetCount };
     }),
 
   next: protectedProcedure
@@ -151,9 +173,15 @@ export const sessionRouter = router({
       let question: Awaited<ReturnType<typeof generateMcq>>["question"];
       let questionMeta: CopyForLlmQuestionMeta | null = null;
       try {
+        // Custom Session は spec.customSpec (absolute difficulty + thinking_style 等) を優先する。
+        // concept 選定は customSpec.concepts → customSpec.domains → daily pick の順で fallback。
+        const customSpec = spec.customSpec;
+        const customConceptId = customSpec?.concepts?.[0];
         const conceptRow = input.conceptId
           ? await loadConcept(input.conceptId)
-          : await pickConceptForDrill(ctx.user.id);
+          : customConceptId
+            ? await loadConcept(customConceptId)
+            : await pickConceptForDrill(ctx.user.id);
 
         // 直近 STREAK_FOR_PROMOTION 件の同 concept の attempts を見て、3 連続正解なら次出題を 1 段昇格
         const recent = await getDb()
@@ -162,17 +190,25 @@ export const sessionRouter = router({
           .where(and(eq(attempts.userId, ctx.user.id), eq(attempts.conceptId, conceptRow.id)))
           .orderBy(desc(attempts.createdAt))
           .limit(STREAK_FOR_PROMOTION);
-        const promoted = computePromotion({
-          concept: { difficultyLevels: conceptRow.difficultyLevels },
-          currentDifficulty: input.difficulty,
-          recentCorrect: recent.map((r) => r.correct === true),
-        });
-        const effectiveDifficulty: DifficultyLevel = promoted ?? input.difficulty;
+        // custom spec があれば絶対難易度を優先 (昇格は無視。ユーザー指定を尊重)
+        const requestedDifficulty: DifficultyLevel =
+          customSpec?.difficulty?.level ?? input.difficulty;
+        const promoted = customSpec
+          ? null
+          : computePromotion({
+              concept: { difficultyLevels: conceptRow.difficultyLevels },
+              currentDifficulty: input.difficulty,
+              recentCorrect: recent.map((r) => r.correct === true),
+            });
+        const effectiveDifficulty: DifficultyLevel = promoted ?? requestedDifficulty;
+
+        // thinking_style も custom spec があれば先頭を使う。複数指定はラウンドロビン未実装 (MVP)。
+        const effectiveThinkingStyle = customSpec?.thinkingStyles?.[0] ?? input.thinkingStyle;
 
         const generated = await generateMcq({
           conceptId: conceptRow.id,
           difficulty: effectiveDifficulty,
-          thinkingStyle: input.thinkingStyle,
+          thinkingStyle: effectiveThinkingStyle,
         });
         question = generated.question;
         questionMeta = {
@@ -180,7 +216,7 @@ export const sessionRouter = router({
           subdomain: conceptRow.subdomainId,
           conceptId: conceptRow.id,
           conceptName: conceptRow.name,
-          thinkingStyle: input.thinkingStyle,
+          thinkingStyle: effectiveThinkingStyle,
           difficulty: effectiveDifficulty,
         };
       } catch (err) {

--- a/src/server/trpc/routers/session.ts
+++ b/src/server/trpc/routers/session.ts
@@ -107,6 +107,41 @@ export const sessionRouter = router({
         });
       }
 
+      // MVP 受け入れ基準 (Issue #18): 絶対難易度は beginner/junior/mid/senior のみ。
+      // staff/principal は Custom Session では Phase 5+ で解禁するためここで reject する。
+      if (input.customSpec?.difficulty) {
+        const level = input.customSpec.difficulty.level;
+        if (level !== "beginner" && level !== "junior" && level !== "mid" && level !== "senior") {
+          throw new TRPCError({
+            code: "BAD_REQUEST",
+            message: `Custom Session MVP は difficulty=${level} に未対応 (beginner/junior/mid/senior のみ)`,
+          });
+        }
+      }
+      // MVP は mcq 生成のみ (questionTypes が指定されていて mcq を含まなければ reject)。
+      if (
+        input.customSpec?.questionTypes &&
+        input.customSpec.questionTypes.length > 0 &&
+        !input.customSpec.questionTypes.includes("mcq")
+      ) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: "Custom Session MVP は mcq のみ生成可能です",
+        });
+      }
+      // constraints は MVP で生成プロンプトに反映されないため、該当フィールドがあれば reject
+      // (プレビューで「指定した」と見えて実行時に無視されるのは虚偽表示に近い挙動なので)。
+      if (input.customSpec?.constraints) {
+        const c = input.customSpec.constraints;
+        if (c.codeLanguage || c.timeLimitSec || c.mustInclude?.length || c.avoid?.length) {
+          throw new TRPCError({
+            code: "BAD_REQUEST",
+            message:
+              "Custom Session MVP は constraints (codeLanguage/timeLimitSec/mustInclude/avoid) 未対応です",
+          });
+        }
+      }
+
       const db = getDb();
       // 問題数は customSpec.questionCount があれば優先。なければ input.targetCount、なければ既定 5
       const targetCount =


### PR DESCRIPTION
## Summary
- `session.start` に `customSpec` を受け、`sessions.spec.customSpec` に保持
- `session.next` で `customSpec` があれば concepts/difficulty/thinkingStyles を優先、昇格ロジックは無効
- `/custom` ルート + `CustomScreen`: NL 入力 → `custom.parse` → 読み取り専用 SpecPreview → `session.start` → DrillScreen 再利用
- unit test: kind/customSpec の組合せバリデーション

closes #18