### PR TITLE
feat(misconception): 誤概念抽出 + 生成プロンプト注入 (#19)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,7 @@ next-env.d.ts
 # --- Drizzle ---
 *.db
 *.db-journal
-drizzle/meta/
+# drizzle/meta/ は journal + snapshot を track する (本番 migrate で必要)
 .drizzle/
 
 # --- Vercel ---

--- a/drizzle/0008_misconceptions_unique.sql
+++ b/drizzle/0008_misconceptions_unique.sql
@@ -2,7 +2,48 @@
 -- (user_id, concept_id, description) の unique index を追加。
 -- これにより ON CONFLICT DO UPDATE で count 加算を原子的に実行できる。
 --
--- 既存重複がある環境では失敗するが、本 issue 実装時点では
--- misconceptions テーブルは空運用のため問題なし。
+-- 既存重複がある環境でも安全に適用できるよう、事前に dedupe を実施:
+--   同一 (user_id, concept_id, description) のうち最古 (created_at 降順で最も小さい
+--   firstSeen を代表) に count を集約し、他を削除する。
+-- MVP 時点で misconceptions は空運用だが、防御的に保持する。
+
+WITH ranked AS (
+  SELECT
+    id,
+    user_id,
+    concept_id,
+    description,
+    count,
+    last_seen,
+    first_seen,
+    ROW_NUMBER() OVER (
+      PARTITION BY user_id, concept_id, description
+      ORDER BY first_seen ASC, id ASC
+    ) AS rn,
+    SUM(count) OVER (PARTITION BY user_id, concept_id, description) AS total_count,
+    MAX(last_seen) OVER (PARTITION BY user_id, concept_id, description) AS max_last_seen
+  FROM misconceptions
+)
+UPDATE misconceptions m
+SET
+  count = r.total_count,
+  last_seen = r.max_last_seen
+FROM ranked r
+WHERE m.id = r.id AND r.rn = 1;
+
+DELETE FROM misconceptions
+WHERE id IN (
+  SELECT id FROM (
+    SELECT
+      id,
+      ROW_NUMBER() OVER (
+        PARTITION BY user_id, concept_id, description
+        ORDER BY first_seen ASC, id ASC
+      ) AS rn
+    FROM misconceptions
+  ) t
+  WHERE t.rn > 1
+);
+
 CREATE UNIQUE INDEX IF NOT EXISTS "uq_misconceptions_user_concept_desc"
   ON "misconceptions" ("user_id", "concept_id", "description");

--- a/drizzle/0008_misconceptions_unique.sql
+++ b/drizzle/0008_misconceptions_unique.sql
@@ -1,0 +1,8 @@
+-- issue #19: misconceptions の description 完全一致で upsert できるよう
+-- (user_id, concept_id, description) の unique index を追加。
+-- これにより ON CONFLICT DO UPDATE で count 加算を原子的に実行できる。
+--
+-- 既存重複がある環境では失敗するが、本 issue 実装時点では
+-- misconceptions テーブルは空運用のため問題なし。
+CREATE UNIQUE INDEX IF NOT EXISTS "uq_misconceptions_user_concept_desc"
+  ON "misconceptions" ("user_id", "concept_id", "description");

--- a/drizzle/meta/0000_snapshot.json
+++ b/drizzle/meta/0000_snapshot.json
@@ -1,0 +1,1392 @@
+{
+  "id": "ef8cb1b5-cc40-41d0-a91e-5ea3024d0720",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.attempts": {
+      "name": "attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "concept_id": {
+          "name": "concept_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_answer": {
+          "name": "user_answer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "correct": {
+          "name": "correct",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "score": {
+          "name": "score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "self_rating": {
+          "name": "self_rating",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "elapsed_ms": {
+          "name": "elapsed_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feedback": {
+          "name": "feedback",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rubric_checks": {
+          "name": "rubric_checks",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "misconception_tags": {
+          "name": "misconception_tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason_given": {
+          "name": "reason_given",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "copied_for_external": {
+          "name": "copied_for_external",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "search_tsv": {
+          "name": "search_tsv",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "to_tsvector('simple', coalesce(user_answer, '') || ' ' || coalesce(reason_given, '') || ' ' || coalesce(feedback, ''))",
+            "type": "stored"
+          }
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_attempts_user_concept": {
+          "name": "idx_attempts_user_concept",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "concept_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_attempts_user_created": {
+          "name": "idx_attempts_user_created",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_attempts_search": {
+          "name": "idx_attempts_search",
+          "columns": [
+            {
+              "expression": "search_tsv",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_attempts_trgm": {
+          "name": "idx_attempts_trgm",
+          "columns": [
+            {
+              "expression": "\"user_answer\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "attempts_user_id_users_id_fk": {
+          "name": "attempts_user_id_users_id_fk",
+          "tableFrom": "attempts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "attempts_session_id_sessions_id_fk": {
+          "name": "attempts_session_id_sessions_id_fk",
+          "tableFrom": "attempts",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "attempts_question_id_questions_id_fk": {
+          "name": "attempts_question_id_questions_id_fk",
+          "tableFrom": "attempts",
+          "tableTo": "questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "attempts_concept_id_concepts_id_fk": {
+          "name": "attempts_concept_id_concepts_id_fk",
+          "tableFrom": "attempts",
+          "tableTo": "concepts",
+          "columnsFrom": [
+            "concept_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.concepts": {
+      "name": "concepts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "domain_id": {
+          "name": "domain_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subdomain_id": {
+          "name": "subdomain_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prereqs": {
+          "name": "prereqs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "difficulty_levels": {
+          "name": "difficulty_levels",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_concepts_domain": {
+          "name": "idx_concepts_domain",
+          "columns": [
+            {
+              "expression": "domain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_concepts_tags": {
+          "name": "idx_concepts_tags",
+          "columns": [
+            {
+              "expression": "tags",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.credentials": {
+      "name": "credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counter": {
+          "name": "counter",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "device_type": {
+          "name": "device_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "backed_up": {
+          "name": "backed_up",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "transports": {
+          "name": "transports",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "nickname": {
+          "name": "nickname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_credentials_user": {
+          "name": "idx_credentials_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "credentials_user_id_users_id_fk": {
+          "name": "credentials_user_id_users_id_fk",
+          "tableFrom": "credentials",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.daily_stats": {
+      "name": "daily_stats",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempts_count": {
+          "name": "attempts_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "correct_count": {
+          "name": "correct_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "concepts_touched": {
+          "name": "concepts_touched",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "study_time_sec": {
+          "name": "study_time_sec",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "domains_touched": {
+          "name": "domains_touched",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "daily_stats_user_id_users_id_fk": {
+          "name": "daily_stats_user_id_users_id_fk",
+          "tableFrom": "daily_stats",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "daily_stats_user_id_date_pk": {
+          "name": "daily_stats_user_id_date_pk",
+          "columns": [
+            "user_id",
+            "date"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'Asia/Tokyo'"
+        },
+        "daily_goal": {
+          "name": "daily_goal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 15
+        },
+        "notification_time": {
+          "name": "notification_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions_auth": {
+      "name": "sessions_auth",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_sessions_auth_user": {
+          "name": "idx_sessions_auth_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sessions_auth_expires": {
+          "name": "idx_sessions_auth_expires",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_auth_user_id_users_id_fk": {
+          "name": "sessions_auth_user_id_users_id_fk",
+          "tableFrom": "sessions_auth",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webauthn_challenges": {
+      "name": "webauthn_challenges",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "challenge": {
+          "name": "challenge",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "webauthn_challenges_user_id_users_id_fk": {
+          "name": "webauthn_challenges_user_id_users_id_fk",
+          "tableFrom": "webauthn_challenges",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.questions": {
+      "name": "questions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "concept_id": {
+          "name": "concept_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thinking_style": {
+          "name": "thinking_style",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "answer": {
+          "name": "answer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rubric": {
+          "name": "rubric",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "distractors": {
+          "name": "distractors",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hint": {
+          "name": "hint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "explanation": {
+          "name": "explanation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "generated_by": {
+          "name": "generated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompt_version": {
+          "name": "prompt_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retired": {
+          "name": "retired",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "retired_reason": {
+          "name": "retired_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_served_at": {
+          "name": "last_served_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "serve_count": {
+          "name": "serve_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "idx_questions_concept_type_style": {
+          "name": "idx_questions_concept_type_style",
+          "columns": [
+            {
+              "expression": "concept_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "thinking_style",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "difficulty",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"questions\".\"retired\" = FALSE",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "questions_concept_id_concepts_id_fk": {
+          "name": "questions_concept_id_concepts_id_fk",
+          "tableFrom": "questions",
+          "tableTo": "concepts",
+          "columnsFrom": [
+            "concept_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session_templates": {
+      "name": "session_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_request": {
+          "name": "raw_request",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spec": {
+          "name": "spec",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "use_count": {
+          "name": "use_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_templates_user_id_users_id_fk": {
+          "name": "session_templates_user_id_users_id_fk",
+          "tableFrom": "session_templates",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "spec": {
+          "name": "spec",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "question_count": {
+          "name": "question_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "correct_count": {
+          "name": "correct_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "idx_sessions_user_started": {
+          "name": "idx_sessions_user_started",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sessions_template_id_session_templates_id_fk": {
+          "name": "sessions_template_id_session_templates_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "session_templates",
+          "columnsFrom": [
+            "template_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mastery": {
+      "name": "mastery",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "concept_id": {
+          "name": "concept_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stability": {
+          "name": "stability",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_review": {
+          "name": "last_review",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_review": {
+          "name": "next_review",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "review_count": {
+          "name": "review_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lapse_count": {
+          "name": "lapse_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "mastered": {
+          "name": "mastered",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "mastery_pct": {
+          "name": "mastery_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "idx_mastery_next_review": {
+          "name": "idx_mastery_next_review",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_review",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mastery_user_id_users_id_fk": {
+          "name": "mastery_user_id_users_id_fk",
+          "tableFrom": "mastery",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mastery_concept_id_concepts_id_fk": {
+          "name": "mastery_concept_id_concepts_id_fk",
+          "tableFrom": "mastery",
+          "tableTo": "concepts",
+          "columnsFrom": [
+            "concept_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "mastery_user_id_concept_id_pk": {
+          "name": "mastery_user_id_concept_id_pk",
+          "columns": [
+            "user_id",
+            "concept_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.misconceptions": {
+      "name": "misconceptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "concept_id": {
+          "name": "concept_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_seen": {
+          "name": "first_seen",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen": {
+          "name": "last_seen",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "resolved": {
+          "name": "resolved",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "misconceptions_user_id_users_id_fk": {
+          "name": "misconceptions_user_id_users_id_fk",
+          "tableFrom": "misconceptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "misconceptions_concept_id_concepts_id_fk": {
+          "name": "misconceptions_concept_id_concepts_id_fk",
+          "tableFrom": "misconceptions",
+          "tableTo": "concepts",
+          "columnsFrom": [
+            "concept_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/0001_snapshot.json
+++ b/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,1392 @@
+{
+  "id": "a9b24153-c706-41d8-8059-b8e64f306f84",
+  "prevId": "ef8cb1b5-cc40-41d0-a91e-5ea3024d0720",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.attempts": {
+      "name": "attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "concept_id": {
+          "name": "concept_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_answer": {
+          "name": "user_answer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "correct": {
+          "name": "correct",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "score": {
+          "name": "score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "self_rating": {
+          "name": "self_rating",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "elapsed_ms": {
+          "name": "elapsed_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feedback": {
+          "name": "feedback",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rubric_checks": {
+          "name": "rubric_checks",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "misconception_tags": {
+          "name": "misconception_tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason_given": {
+          "name": "reason_given",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "copied_for_external": {
+          "name": "copied_for_external",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "search_tsv": {
+          "name": "search_tsv",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "to_tsvector('simple', coalesce(user_answer, '') || ' ' || coalesce(reason_given, '') || ' ' || coalesce(feedback, ''))",
+            "type": "stored"
+          }
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_attempts_user_concept": {
+          "name": "idx_attempts_user_concept",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "concept_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_attempts_user_created": {
+          "name": "idx_attempts_user_created",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_attempts_search": {
+          "name": "idx_attempts_search",
+          "columns": [
+            {
+              "expression": "search_tsv",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_attempts_trgm": {
+          "name": "idx_attempts_trgm",
+          "columns": [
+            {
+              "expression": "\"user_answer\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "attempts_user_id_users_id_fk": {
+          "name": "attempts_user_id_users_id_fk",
+          "tableFrom": "attempts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "attempts_session_id_sessions_id_fk": {
+          "name": "attempts_session_id_sessions_id_fk",
+          "tableFrom": "attempts",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "attempts_question_id_questions_id_fk": {
+          "name": "attempts_question_id_questions_id_fk",
+          "tableFrom": "attempts",
+          "tableTo": "questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "attempts_concept_id_concepts_id_fk": {
+          "name": "attempts_concept_id_concepts_id_fk",
+          "tableFrom": "attempts",
+          "tableTo": "concepts",
+          "columnsFrom": [
+            "concept_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.concepts": {
+      "name": "concepts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "domain_id": {
+          "name": "domain_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subdomain_id": {
+          "name": "subdomain_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prereqs": {
+          "name": "prereqs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "difficulty_levels": {
+          "name": "difficulty_levels",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_concepts_domain": {
+          "name": "idx_concepts_domain",
+          "columns": [
+            {
+              "expression": "domain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_concepts_tags": {
+          "name": "idx_concepts_tags",
+          "columns": [
+            {
+              "expression": "tags",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.credentials": {
+      "name": "credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counter": {
+          "name": "counter",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "device_type": {
+          "name": "device_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "backed_up": {
+          "name": "backed_up",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "transports": {
+          "name": "transports",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "nickname": {
+          "name": "nickname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_credentials_user": {
+          "name": "idx_credentials_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "credentials_user_id_users_id_fk": {
+          "name": "credentials_user_id_users_id_fk",
+          "tableFrom": "credentials",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.daily_stats": {
+      "name": "daily_stats",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempts_count": {
+          "name": "attempts_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "correct_count": {
+          "name": "correct_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "concepts_touched": {
+          "name": "concepts_touched",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "study_time_sec": {
+          "name": "study_time_sec",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "domains_touched": {
+          "name": "domains_touched",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "daily_stats_user_id_users_id_fk": {
+          "name": "daily_stats_user_id_users_id_fk",
+          "tableFrom": "daily_stats",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "daily_stats_user_id_date_pk": {
+          "name": "daily_stats_user_id_date_pk",
+          "columns": [
+            "user_id",
+            "date"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'Asia/Tokyo'"
+        },
+        "daily_goal": {
+          "name": "daily_goal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 15
+        },
+        "notification_time": {
+          "name": "notification_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions_auth": {
+      "name": "sessions_auth",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_sessions_auth_user": {
+          "name": "idx_sessions_auth_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sessions_auth_expires": {
+          "name": "idx_sessions_auth_expires",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_auth_user_id_users_id_fk": {
+          "name": "sessions_auth_user_id_users_id_fk",
+          "tableFrom": "sessions_auth",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webauthn_challenges": {
+      "name": "webauthn_challenges",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "challenge": {
+          "name": "challenge",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "webauthn_challenges_user_id_users_id_fk": {
+          "name": "webauthn_challenges_user_id_users_id_fk",
+          "tableFrom": "webauthn_challenges",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.questions": {
+      "name": "questions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "concept_id": {
+          "name": "concept_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thinking_style": {
+          "name": "thinking_style",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "answer": {
+          "name": "answer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rubric": {
+          "name": "rubric",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "distractors": {
+          "name": "distractors",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hint": {
+          "name": "hint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "explanation": {
+          "name": "explanation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "generated_by": {
+          "name": "generated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompt_version": {
+          "name": "prompt_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retired": {
+          "name": "retired",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "retired_reason": {
+          "name": "retired_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_served_at": {
+          "name": "last_served_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "serve_count": {
+          "name": "serve_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "idx_questions_concept_type_style": {
+          "name": "idx_questions_concept_type_style",
+          "columns": [
+            {
+              "expression": "concept_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "thinking_style",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "difficulty",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"questions\".\"retired\" = FALSE",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "questions_concept_id_concepts_id_fk": {
+          "name": "questions_concept_id_concepts_id_fk",
+          "tableFrom": "questions",
+          "tableTo": "concepts",
+          "columnsFrom": [
+            "concept_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session_templates": {
+      "name": "session_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_request": {
+          "name": "raw_request",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spec": {
+          "name": "spec",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "use_count": {
+          "name": "use_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_templates_user_id_users_id_fk": {
+          "name": "session_templates_user_id_users_id_fk",
+          "tableFrom": "session_templates",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "spec": {
+          "name": "spec",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "question_count": {
+          "name": "question_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "correct_count": {
+          "name": "correct_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "idx_sessions_user_started": {
+          "name": "idx_sessions_user_started",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sessions_template_id_session_templates_id_fk": {
+          "name": "sessions_template_id_session_templates_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "session_templates",
+          "columnsFrom": [
+            "template_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mastery": {
+      "name": "mastery",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "concept_id": {
+          "name": "concept_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stability": {
+          "name": "stability",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_review": {
+          "name": "last_review",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_review": {
+          "name": "next_review",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "review_count": {
+          "name": "review_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lapse_count": {
+          "name": "lapse_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "mastered": {
+          "name": "mastered",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "mastery_pct": {
+          "name": "mastery_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "idx_mastery_next_review": {
+          "name": "idx_mastery_next_review",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_review",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mastery_user_id_users_id_fk": {
+          "name": "mastery_user_id_users_id_fk",
+          "tableFrom": "mastery",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mastery_concept_id_concepts_id_fk": {
+          "name": "mastery_concept_id_concepts_id_fk",
+          "tableFrom": "mastery",
+          "tableTo": "concepts",
+          "columnsFrom": [
+            "concept_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "mastery_user_id_concept_id_pk": {
+          "name": "mastery_user_id_concept_id_pk",
+          "columns": [
+            "user_id",
+            "concept_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.misconceptions": {
+      "name": "misconceptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "concept_id": {
+          "name": "concept_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_seen": {
+          "name": "first_seen",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen": {
+          "name": "last_seen",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "resolved": {
+          "name": "resolved",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "misconceptions_user_id_users_id_fk": {
+          "name": "misconceptions_user_id_users_id_fk",
+          "tableFrom": "misconceptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "misconceptions_concept_id_concepts_id_fk": {
+          "name": "misconceptions_concept_id_concepts_id_fk",
+          "tableFrom": "misconceptions",
+          "tableTo": "concepts",
+          "columnsFrom": [
+            "concept_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/0005_snapshot.json
+++ b/drizzle/meta/0005_snapshot.json
@@ -1,0 +1,1408 @@
+{
+  "id": "8b790005-bdfe-4b7a-bfce-a95c959ebd16",
+  "prevId": "a9b24153-c706-41d8-8059-b8e64f306f84",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.attempts": {
+      "name": "attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "concept_id": {
+          "name": "concept_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_answer": {
+          "name": "user_answer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "correct": {
+          "name": "correct",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "score": {
+          "name": "score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "self_rating": {
+          "name": "self_rating",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "elapsed_ms": {
+          "name": "elapsed_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feedback": {
+          "name": "feedback",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rubric_checks": {
+          "name": "rubric_checks",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "misconception_tags": {
+          "name": "misconception_tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason_given": {
+          "name": "reason_given",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "copied_for_external": {
+          "name": "copied_for_external",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "prompt_version": {
+          "name": "prompt_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "graded_by": {
+          "name": "graded_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "search_tsv": {
+          "name": "search_tsv",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "to_tsvector('simple', coalesce(user_answer, '') || ' ' || coalesce(reason_given, '') || ' ' || coalesce(feedback, ''))",
+            "type": "stored"
+          }
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_attempts_user_concept": {
+          "name": "idx_attempts_user_concept",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "concept_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_attempts_user_created": {
+          "name": "idx_attempts_user_created",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_attempts_search": {
+          "name": "idx_attempts_search",
+          "columns": [
+            {
+              "expression": "search_tsv",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_attempts_trgm": {
+          "name": "idx_attempts_trgm",
+          "columns": [
+            {
+              "expression": "\"user_answer\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "attempts_user_id_users_id_fk": {
+          "name": "attempts_user_id_users_id_fk",
+          "tableFrom": "attempts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "attempts_session_id_sessions_id_fk": {
+          "name": "attempts_session_id_sessions_id_fk",
+          "tableFrom": "attempts",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "attempts_question_id_questions_id_fk": {
+          "name": "attempts_question_id_questions_id_fk",
+          "tableFrom": "attempts",
+          "tableTo": "questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "attempts_concept_id_concepts_id_fk": {
+          "name": "attempts_concept_id_concepts_id_fk",
+          "tableFrom": "attempts",
+          "tableTo": "concepts",
+          "columnsFrom": [
+            "concept_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.concepts": {
+      "name": "concepts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "domain_id": {
+          "name": "domain_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subdomain_id": {
+          "name": "subdomain_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prereqs": {
+          "name": "prereqs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "difficulty_levels": {
+          "name": "difficulty_levels",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_concepts_domain": {
+          "name": "idx_concepts_domain",
+          "columns": [
+            {
+              "expression": "domain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_concepts_tags": {
+          "name": "idx_concepts_tags",
+          "columns": [
+            {
+              "expression": "tags",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "concepts_difficulty_levels_nonempty_chk": {
+          "name": "concepts_difficulty_levels_nonempty_chk",
+          "value": "jsonb_typeof(\"concepts\".\"difficulty_levels\") = 'array' AND jsonb_array_length(\"concepts\".\"difficulty_levels\") >= 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.credentials": {
+      "name": "credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counter": {
+          "name": "counter",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "device_type": {
+          "name": "device_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "backed_up": {
+          "name": "backed_up",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "transports": {
+          "name": "transports",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "nickname": {
+          "name": "nickname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_credentials_user": {
+          "name": "idx_credentials_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "credentials_user_id_users_id_fk": {
+          "name": "credentials_user_id_users_id_fk",
+          "tableFrom": "credentials",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.daily_stats": {
+      "name": "daily_stats",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempts_count": {
+          "name": "attempts_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "correct_count": {
+          "name": "correct_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "concepts_touched": {
+          "name": "concepts_touched",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "study_time_sec": {
+          "name": "study_time_sec",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "domains_touched": {
+          "name": "domains_touched",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "daily_stats_user_id_users_id_fk": {
+          "name": "daily_stats_user_id_users_id_fk",
+          "tableFrom": "daily_stats",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "daily_stats_user_id_date_pk": {
+          "name": "daily_stats_user_id_date_pk",
+          "columns": [
+            "user_id",
+            "date"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'Asia/Tokyo'"
+        },
+        "daily_goal": {
+          "name": "daily_goal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 15
+        },
+        "notification_time": {
+          "name": "notification_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions_auth": {
+      "name": "sessions_auth",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_sessions_auth_user": {
+          "name": "idx_sessions_auth_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sessions_auth_expires": {
+          "name": "idx_sessions_auth_expires",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_auth_user_id_users_id_fk": {
+          "name": "sessions_auth_user_id_users_id_fk",
+          "tableFrom": "sessions_auth",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webauthn_challenges": {
+      "name": "webauthn_challenges",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "challenge": {
+          "name": "challenge",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "webauthn_challenges_user_id_users_id_fk": {
+          "name": "webauthn_challenges_user_id_users_id_fk",
+          "tableFrom": "webauthn_challenges",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.questions": {
+      "name": "questions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "concept_id": {
+          "name": "concept_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thinking_style": {
+          "name": "thinking_style",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "answer": {
+          "name": "answer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rubric": {
+          "name": "rubric",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "distractors": {
+          "name": "distractors",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hint": {
+          "name": "hint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "explanation": {
+          "name": "explanation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "generated_by": {
+          "name": "generated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompt_version": {
+          "name": "prompt_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retired": {
+          "name": "retired",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "retired_reason": {
+          "name": "retired_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_served_at": {
+          "name": "last_served_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "serve_count": {
+          "name": "serve_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "idx_questions_concept_type_style": {
+          "name": "idx_questions_concept_type_style",
+          "columns": [
+            {
+              "expression": "concept_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "thinking_style",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "difficulty",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"questions\".\"retired\" = FALSE",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "questions_concept_id_concepts_id_fk": {
+          "name": "questions_concept_id_concepts_id_fk",
+          "tableFrom": "questions",
+          "tableTo": "concepts",
+          "columnsFrom": [
+            "concept_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session_templates": {
+      "name": "session_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_request": {
+          "name": "raw_request",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spec": {
+          "name": "spec",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "use_count": {
+          "name": "use_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_templates_user_id_users_id_fk": {
+          "name": "session_templates_user_id_users_id_fk",
+          "tableFrom": "session_templates",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "spec": {
+          "name": "spec",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "question_count": {
+          "name": "question_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "correct_count": {
+          "name": "correct_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "idx_sessions_user_started": {
+          "name": "idx_sessions_user_started",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sessions_template_id_session_templates_id_fk": {
+          "name": "sessions_template_id_session_templates_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "session_templates",
+          "columnsFrom": [
+            "template_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mastery": {
+      "name": "mastery",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "concept_id": {
+          "name": "concept_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stability": {
+          "name": "stability",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_review": {
+          "name": "last_review",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_review": {
+          "name": "next_review",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "review_count": {
+          "name": "review_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lapse_count": {
+          "name": "lapse_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "mastered": {
+          "name": "mastered",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "mastery_pct": {
+          "name": "mastery_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "idx_mastery_next_review": {
+          "name": "idx_mastery_next_review",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_review",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mastery_user_id_users_id_fk": {
+          "name": "mastery_user_id_users_id_fk",
+          "tableFrom": "mastery",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mastery_concept_id_concepts_id_fk": {
+          "name": "mastery_concept_id_concepts_id_fk",
+          "tableFrom": "mastery",
+          "tableTo": "concepts",
+          "columnsFrom": [
+            "concept_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "mastery_user_id_concept_id_pk": {
+          "name": "mastery_user_id_concept_id_pk",
+          "columns": [
+            "user_id",
+            "concept_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.misconceptions": {
+      "name": "misconceptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "concept_id": {
+          "name": "concept_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_seen": {
+          "name": "first_seen",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen": {
+          "name": "last_seen",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "resolved": {
+          "name": "resolved",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "misconceptions_user_id_users_id_fk": {
+          "name": "misconceptions_user_id_users_id_fk",
+          "tableFrom": "misconceptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "misconceptions_concept_id_concepts_id_fk": {
+          "name": "misconceptions_concept_id_concepts_id_fk",
+          "tableFrom": "misconceptions",
+          "tableTo": "concepts",
+          "columnsFrom": [
+            "concept_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -1,0 +1,69 @@
+{
+  "version": "7",
+  "dialect": "postgresql",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "7",
+      "when": 1776476397938,
+      "tag": "0000_initial_schema",
+      "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1776486442752,
+      "tag": "0001_concepts_subdomain_required",
+      "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1776487000000,
+      "tag": "0002_concepts_difficulty_levels_check",
+      "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1776487100000,
+      "tag": "0003_concepts_difficulty_levels_not_null",
+      "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1776487200000,
+      "tag": "0004_concepts_difficulty_levels_drop_default",
+      "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1776491381822,
+      "tag": "0005_attempts_grading_prompt_version",
+      "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1776494000000,
+      "tag": "0006_attempts_unique_session_question",
+      "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1776495000000,
+      "tag": "0007_attempts_rebuttal",
+      "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1776496000000,
+      "tag": "0008_misconceptions_unique",
+      "breakpoints": true
+    }
+  ]
+}

--- a/prompts/generation/mcq.v1.md
+++ b/prompts/generation/mcq.v1.md
@@ -50,4 +50,8 @@ thinking_style: {{ thinkingStyle }}
 Past recent framings for this concept (last 30 days, if any):
 {{ pastQuestionsSummary }}
 
+## User misconceptions to correct (可変、任意)
+
+{{ userMisconceptions }}
+
 <!-- /role -->

--- a/prompts/grading/extract-misconception.v1.md
+++ b/prompts/grading/extract-misconception.v1.md
@@ -1,0 +1,47 @@
+# extract-misconception.v1
+
+誤答時に reason_given (「なぜそう答えたか」) と expected answer から、ユーザーが抱えている
+誤概念を抽出する (issue #19, docs/03 §3.4.1, docs/05 §5.8)。
+
+固定の Output requirements を user 冒頭、可変を末尾に置く (CLAUDE.md §4.5)。
+gpt-5 を使う。LLM は「誤解の要旨を 1 文で、短く、再発検知しやすい表現」で書く。
+
+---
+
+<!-- role:system -->
+
+You are a senior engineer diagnosing a student's misconception. Given the expected answer and what the student actually answered (plus their reasoning), extract the misconception. Output strictly as JSON matching the provided schema. Use 日本語 for the misconception description.
+
+<!-- /role -->
+
+<!-- role:user -->
+
+## Output requirements (固定)
+
+- `description` (string): 誤解の要旨を 1 文 (最大 100 文字) で日本語で。後で集計キーに使うため、再発を検知しやすい定型表現に (例: 「TLS 1.3 の鍵交換は RSA と誤解」)。
+- `confidence` (number 0.0-1.0): この抽出が確度高いかの自己申告。理由 (reason_given) が空 / 曖昧なら低めに。
+
+空な (抽出できない / ユーザーが単に勘違いではなく完全な無知など) 場合は `description: ""` + `confidence: 0` を返すこと。
+
+## Concept (可変)
+
+id: {{ conceptId }}
+name: {{ conceptName }}
+
+## Question (可変)
+
+{{ questionPrompt }}
+
+## Expected answer (可変)
+
+{{ expectedAnswer }}
+
+## User's answer (可変)
+
+{{ userAnswer }}
+
+## User's reasoning (可変)
+
+{{ reasonGiven }}
+
+<!-- /role -->

--- a/src/db/schema/misconceptions.ts
+++ b/src/db/schema/misconceptions.ts
@@ -1,25 +1,38 @@
 import { sql } from "drizzle-orm";
-import { boolean, integer, pgTable, text, timestamp } from "drizzle-orm/pg-core";
+import { boolean, integer, pgTable, text, timestamp, uniqueIndex } from "drizzle-orm/pg-core";
 
 import { concepts } from "./concepts";
 import { users } from "./users";
 
-export const misconceptions = pgTable("misconceptions", {
-  id: text("id")
-    .primaryKey()
-    .default(sql`gen_random_uuid()::text`),
-  userId: text("user_id")
-    .notNull()
-    .references(() => users.id, { onDelete: "cascade" }),
-  conceptId: text("concept_id")
-    .notNull()
-    .references(() => concepts.id),
-  description: text("description").notNull(),
-  firstSeen: timestamp("first_seen", { withTimezone: true }).notNull().defaultNow(),
-  lastSeen: timestamp("last_seen", { withTimezone: true }).notNull().defaultNow(),
-  count: integer("count").notNull().default(1),
-  resolved: boolean("resolved").notNull().default(false),
-});
+export const misconceptions = pgTable(
+  "misconceptions",
+  {
+    id: text("id")
+      .primaryKey()
+      .default(sql`gen_random_uuid()::text`),
+    userId: text("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    conceptId: text("concept_id")
+      .notNull()
+      .references(() => concepts.id),
+    description: text("description").notNull(),
+    firstSeen: timestamp("first_seen", { withTimezone: true }).notNull().defaultNow(),
+    lastSeen: timestamp("last_seen", { withTimezone: true }).notNull().defaultNow(),
+    count: integer("count").notNull().default(1),
+    resolved: boolean("resolved").notNull().default(false),
+  },
+  (table) => [
+    // issue #19: ON CONFLICT DO UPDATE で原子的に count+1 するため、
+    // (user_id, concept_id, description) で一意制約を張る。description は
+    // normalize 済み (trim + lower) で書き込まれる前提。
+    uniqueIndex("uq_misconceptions_user_concept_desc").on(
+      table.userId,
+      table.conceptId,
+      table.description,
+    ),
+  ],
+);
 
 export type Misconception = typeof misconceptions.$inferSelect;
 export type NewMisconception = typeof misconceptions.$inferInsert;

--- a/src/server/generator/mcq.ts
+++ b/src/server/generator/mcq.ts
@@ -13,6 +13,8 @@ import {
 import { getOpenAI } from "@/lib/openai/client";
 import { MODEL_MAIN } from "@/lib/openai/models";
 
+import { fetchUnresolvedMisconceptionsForGeneration } from "../grader/extract-misconception";
+
 import { findCachedQuestion } from "./cache";
 import { buildMcqPrompt, MCQ_PROMPT_VERSION } from "./prompts";
 import { GeneratedMcqSchema, MCQ_JSON_SCHEMA, type GeneratedMcq } from "./schema";
@@ -23,6 +25,11 @@ export type GenerateMcqInput = {
   thinkingStyle: ThinkingStyle | null;
   /** true のときキャッシュを使わず必ず新規生成 (開発用) */
   forceFresh?: boolean;
+  /**
+   * 指定されると prompt に「この concept で繰り返している誤概念」を矯正指示として
+   * 注入する (issue #19, docs/03 §3.4.1)。未指定なら注入しない。
+   */
+  userId?: string;
 };
 
 export type GenerateMcqResult = {
@@ -177,11 +184,18 @@ export async function generateMcq(
   }
 
   const past = await fetchPastSummaries(input.conceptId);
+  const userMisconceptions = input.userId
+    ? await fetchUnresolvedMisconceptionsForGeneration({
+        userId: input.userId,
+        conceptId: input.conceptId,
+      })
+    : [];
   const { system, user } = buildMcqPrompt({
     concept,
     difficulty: input.difficulty,
     thinkingStyle: input.thinkingStyle,
     pastQuestionsSummary: past,
+    userMisconceptions,
   });
 
   const generated = await llm({ model: MODEL_MAIN, system, user });

--- a/src/server/generator/mcq.ts
+++ b/src/server/generator/mcq.ts
@@ -151,7 +151,18 @@ export async function generateMcq(
   const concept = await loadConcept(input.conceptId);
   assertDifficultyAllowed(concept, input.difficulty);
 
-  if (!input.forceFresh) {
+  // 誤概念矯正モード: ユーザーが繰り返している誤解がある場合、その矯正を狙う問題は
+  // user-specific。共有 questions キャッシュを汚染しないよう、このパスでは cache を
+  // 一切使わず / 書き込みもせず必ず新規生成する (Codex Round 2 P1-b)。
+  const userMisconceptions = input.userId
+    ? await fetchUnresolvedMisconceptionsForGeneration({
+        userId: input.userId,
+        conceptId: input.conceptId,
+      })
+    : [];
+  const correctiveMode = userMisconceptions.length > 0;
+
+  if (!input.forceFresh && !correctiveMode) {
     // キャッシュが十分育っていれば 50/50 で cache hit / 新規生成を選ぶ (docs/03 §3.3.4)
     const cacheCount = await countCachedQuestions({
       conceptId: input.conceptId,
@@ -184,12 +195,6 @@ export async function generateMcq(
   }
 
   const past = await fetchPastSummaries(input.conceptId);
-  const userMisconceptions = input.userId
-    ? await fetchUnresolvedMisconceptionsForGeneration({
-        userId: input.userId,
-        conceptId: input.conceptId,
-      })
-    : [];
   const { system, user } = buildMcqPrompt({
     concept,
     difficulty: input.difficulty,
@@ -216,9 +221,14 @@ export async function generateMcq(
       tags: generated.tags,
       generatedBy: MODEL_MAIN,
       promptVersion: MCQ_PROMPT_VERSION,
-      // 新規問題は出題時点で配信済みとマークする (次回は別問題が未使用として優先される)
+      // 新規問題は出題時点で配信済みとマークする (次回は別問題が未使用として優先される)。
+      // 誤概念矯正モード (user-specific な prompt で生成された問題) は共有キャッシュを
+      // 汚染しないよう retired=true で保存し、cache 検索対象から除外する
+      // (Codex Round 2 P1-b)。
       serveCount: 1,
       lastServedAt: now,
+      retired: correctiveMode,
+      retiredReason: correctiveMode ? "corrective (user-specific misconception)" : null,
     })
     .returning();
 

--- a/src/server/generator/prompts.test.ts
+++ b/src/server/generator/prompts.test.ts
@@ -84,7 +84,11 @@ describe("buildMcqPrompt", () => {
       ## Avoid duplicates (可変)
 
       Past recent framings for this concept (last 30 days, if any):
-      - setTimeout の評価タイミングを問う問題",
+      - setTimeout の評価タイミングを問う問題
+
+      ## User misconceptions to correct (可変、任意)
+
+      (none)",
       }
     `);
   });

--- a/src/server/generator/prompts.test.ts
+++ b/src/server/generator/prompts.test.ts
@@ -92,4 +92,32 @@ describe("buildMcqPrompt", () => {
       }
     `);
   });
+
+  it("userMisconceptions があると矯正指示が user セクションに注入される (issue #19)", () => {
+    const out = buildMcqPrompt({
+      concept: {
+        id: "network.tls.key_exchange",
+        name: "TLS 鍵交換",
+        description: null,
+        domainId: "network",
+        subdomainId: "tls",
+      },
+      difficulty: "mid",
+      thinkingStyle: "why",
+      pastQuestionsSummary: [],
+      userMisconceptions: [
+        { description: "tls 1.3 の鍵交換は rsa と誤解", count: 4 },
+        { description: "rsa 鍵交換はおすすめ", count: 2 },
+      ],
+    });
+    expect(out.user).toContain("## User misconceptions to correct");
+    expect(out.user).toContain('"tls 1.3 の鍵交換は rsa と誤解" (seen 4 times');
+    expect(out.user).toContain('"rsa 鍵交換はおすすめ" (seen 2 times');
+    // misconceptions セクションに (none) が出ないことの確認 (concept description null の
+    // "description: (none)" は別セクションなので除外)
+    const misconceptionsSection = out.user.slice(
+      out.user.indexOf("## User misconceptions to correct"),
+    );
+    expect(misconceptionsSection).not.toContain("(none)");
+  });
 });

--- a/src/server/generator/prompts.ts
+++ b/src/server/generator/prompts.ts
@@ -26,6 +26,12 @@ export type McqPromptInput = {
   thinkingStyle: ThinkingStyle | null;
   /** 直近 30 日の既出問題の要約。文字列の配列で渡す。空配列なら "(none)" を出す */
   pastQuestionsSummary: string[];
+  /**
+   * この concept 上でユーザーが繰り返している誤概念。issue #19 で注入する「矯正指示」の入口。
+   * 各 { description, count } は docs/05 §5.8 の misconceptions テーブルから直近の上位 N 件。
+   * 空配列なら「(none)」として出力。
+   */
+  userMisconceptions?: Array<{ description: string; count: number }>;
 };
 
 /**
@@ -42,6 +48,16 @@ export function buildMcqPrompt(input: McqPromptInput): {
       ? "(none)"
       : input.pastQuestionsSummary.map((s) => `- ${s}`).join("\n");
 
+  const misconceptions =
+    !input.userMisconceptions || input.userMisconceptions.length === 0
+      ? "(none)"
+      : input.userMisconceptions
+          .map(
+            (m) =>
+              `- "${m.description}" (seen ${m.count} times; generate a question that would reveal or correct this)`,
+          )
+          .join("\n");
+
   return renderTemplate(MCQ_TEMPLATE_PATH, {
     conceptId: input.concept.id,
     conceptName: input.concept.name,
@@ -52,5 +68,6 @@ export function buildMcqPrompt(input: McqPromptInput): {
     thinkingStyle: input.thinkingStyle ?? "(none)",
     styleInstruction: styleInstruction(input.thinkingStyle),
     pastQuestionsSummary: past,
+    userMisconceptions: misconceptions,
   });
 }

--- a/src/server/grader/__snapshots__/extract-misconception.test.ts.snap
+++ b/src/server/grader/__snapshots__/extract-misconception.test.ts.snap
@@ -1,0 +1,34 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`buildExtractMisconceptionPrompt > snapshot (代表入力) 1`] = `
+{
+  "system": "You are a senior engineer diagnosing a student's misconception. Given the expected answer and what the student actually answered (plus their reasoning), extract the misconception. Output strictly as JSON matching the provided schema. Use 日本語 for the misconception description.",
+  "user": "## Output requirements (固定)
+
+- \`description\` (string): 誤解の要旨を 1 文 (最大 100 文字) で日本語で。後で集計キーに使うため、再発を検知しやすい定型表現に (例: 「TLS 1.3 の鍵交換は RSA と誤解」)。
+- \`confidence\` (number 0.0-1.0): この抽出が確度高いかの自己申告。理由 (reason_given) が空 / 曖昧なら低めに。
+
+空な (抽出できない / ユーザーが単に勘違いではなく完全な無知など) 場合は \`description: ""\` + \`confidence: 0\` を返すこと。
+
+## Concept (可変)
+
+id: network.tls.key_exchange
+name: TLS 鍵交換
+
+## Question (可変)
+
+TLS 1.3 の鍵交換方式は?
+
+## Expected answer (可変)
+
+楕円曲線 Diffie-Hellman (ECDHE) ベース。TLS 1.3 は RSA 鍵交換を廃止した。
+
+## User's answer (可変)
+
+RSA
+
+## User's reasoning (可変)
+
+古い TLS でも RSA を使うから、TLS 1.3 も同じだと思った。",
+}
+`;

--- a/src/server/grader/extract-misconception.test.ts
+++ b/src/server/grader/extract-misconception.test.ts
@@ -1,13 +1,32 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
   buildExtractMisconceptionPrompt,
   extractAndPersistMisconception,
+  normalizeMisconceptionDescription,
 } from "./extract-misconception";
 
-// upsertMisconception は DB を呼ぶので、テスト側で extract-misconception.ts の
-// `upsertMisconception` を vi.spyOn で差し替えて DB 呼び出しをスキップする。
-vi.mock("@/db/client", () => ({ getDb: vi.fn() }));
+// upsertMisconception は ON CONFLICT で upsert する。テスト側は insert().values().onConflictDoUpdate()
+// のチェーンを stub して、呼び出し内容 (特に userId/conceptId/description) を検証できるようにする。
+const onConflictSpy = vi.fn();
+const valuesSpy = vi.fn();
+vi.mock("@/db/client", () => {
+  const onConflictDoUpdate = vi.fn((v: unknown) => {
+    onConflictSpy(v);
+    return Promise.resolve();
+  });
+  const values = vi.fn((v: unknown) => {
+    valuesSpy(v);
+    return { onConflictDoUpdate };
+  });
+  const insert = vi.fn().mockReturnValue({ values });
+  return { getDb: vi.fn().mockReturnValue({ insert }) };
+});
+
+beforeEach(() => {
+  onConflictSpy.mockClear();
+  valuesSpy.mockClear();
+});
 
 const baseInput = {
   userId: "u-1",
@@ -74,5 +93,43 @@ describe("extractAndPersistMisconception", () => {
     const caller = vi.fn().mockResolvedValue({ description: "", confidence: 0 });
     const res = await extractAndPersistMisconception(baseInput, caller);
     expect(res.saved).toBe(false);
+  });
+
+  it("confidence >= 0.5 なら保存 (saved=true、description は normalize 後の形で upsert)", async () => {
+    const caller = vi.fn().mockResolvedValue({
+      description: "  TLS 1.3 の鍵交換は RSA と誤解 。  ",
+      confidence: 0.9,
+    });
+    const res = await extractAndPersistMisconception(baseInput, caller);
+    expect(res.saved).toBe(true);
+    expect(valuesSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: "u-1",
+        conceptId: "network.tls.key_exchange",
+        description: "tls 1.3 の鍵交換は rsa と誤解", // trim + lower + 末尾句点削除 + 空白圧縮
+      }),
+    );
+    expect(onConflictSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ set: expect.any(Object) }),
+    );
+  });
+});
+
+describe("normalizeMisconceptionDescription", () => {
+  it("trim + lower + 連続空白 → 1 空白 + 末尾句点削除", () => {
+    expect(normalizeMisconceptionDescription("  TLS 1.3 の  鍵交換   は RSA 。")).toBe(
+      "tls 1.3 の 鍵交換 は rsa",
+    );
+  });
+
+  it("末尾句点 (全角 / 半角) を削る", () => {
+    expect(normalizeMisconceptionDescription("Foo.")).toBe("foo");
+    expect(normalizeMisconceptionDescription("Foo。")).toBe("foo");
+    expect(normalizeMisconceptionDescription("Foo.。.")).toBe("foo");
+  });
+
+  it("入力が空なら空を返す (crash しない)", () => {
+    expect(normalizeMisconceptionDescription("")).toBe("");
+    expect(normalizeMisconceptionDescription("   ")).toBe("");
   });
 });

--- a/src/server/grader/extract-misconception.test.ts
+++ b/src/server/grader/extract-misconception.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  buildExtractMisconceptionPrompt,
+  extractAndPersistMisconception,
+} from "./extract-misconception";
+
+// upsertMisconception は DB を呼ぶので、テスト側で extract-misconception.ts の
+// `upsertMisconception` を vi.spyOn で差し替えて DB 呼び出しをスキップする。
+vi.mock("@/db/client", () => ({ getDb: vi.fn() }));
+
+const baseInput = {
+  userId: "u-1",
+  concept: { id: "network.tls.key_exchange", name: "TLS 鍵交換" },
+  question: {
+    prompt: "TLS 1.3 の鍵交換方式は?",
+    answer: "楕円曲線 Diffie-Hellman (ECDHE) ベース。TLS 1.3 は RSA 鍵交換を廃止した。",
+  },
+  userAnswer: "RSA",
+  reasonGiven: "古い TLS でも RSA を使うから、TLS 1.3 も同じだと思った。",
+};
+
+describe("buildExtractMisconceptionPrompt", () => {
+  it("Output requirements が user 冒頭、可変セクションが末尾 (prompt caching 規約)", () => {
+    const out = buildExtractMisconceptionPrompt(baseInput);
+    expect(out.user.indexOf("## Output requirements")).toBeLessThan(
+      out.user.indexOf("## Question"),
+    );
+  });
+
+  it("snapshot (代表入力)", () => {
+    const out = buildExtractMisconceptionPrompt(baseInput);
+    expect({ system: out.system, user: out.user }).toMatchSnapshot();
+  });
+
+  it("変数置換: userAnswer / reasonGiven / conceptId を含む", () => {
+    const out = buildExtractMisconceptionPrompt(baseInput);
+    expect(out.user).toContain("RSA");
+    expect(out.user).toContain("古い TLS でも RSA");
+    expect(out.user).toContain("network.tls.key_exchange");
+  });
+});
+
+describe("extractAndPersistMisconception", () => {
+  it("reasonGiven が空なら抽出スキップ (コスト節約)", async () => {
+    const caller = vi.fn();
+    const res = await extractAndPersistMisconception({ ...baseInput, reasonGiven: "" }, caller);
+    expect(res.saved).toBe(false);
+    expect(res.extracted).toBeNull();
+    expect(caller).not.toHaveBeenCalled();
+  });
+
+  it("reasonGiven が whitespace のみでもスキップ", async () => {
+    const caller = vi.fn();
+    const res = await extractAndPersistMisconception(
+      { ...baseInput, reasonGiven: "   \n\t " },
+      caller,
+    );
+    expect(res.saved).toBe(false);
+    expect(caller).not.toHaveBeenCalled();
+  });
+
+  it("confidence < 0.5 は保存しない (迎合抑止)", async () => {
+    const caller = vi.fn().mockResolvedValue({
+      description: "弱い根拠の推測",
+      confidence: 0.3,
+    });
+    const res = await extractAndPersistMisconception(baseInput, caller);
+    expect(res.saved).toBe(false);
+    expect(res.extracted?.confidence).toBe(0.3);
+  });
+
+  it("description が空なら保存しない", async () => {
+    const caller = vi.fn().mockResolvedValue({ description: "", confidence: 0 });
+    const res = await extractAndPersistMisconception(baseInput, caller);
+    expect(res.saved).toBe(false);
+  });
+});

--- a/src/server/grader/extract-misconception.ts
+++ b/src/server/grader/extract-misconception.ts
@@ -8,11 +8,30 @@ import { MODEL_MAIN } from "@/lib/openai/models";
 
 import { renderTemplate } from "../generator/prompt-template";
 
+/**
+ * 類似 description のマージ判定用 normalize。
+ * - trim
+ * - 連続する空白を 1 つに
+ * - lower (ASCII のみ)
+ * - 末尾の句点「。.」を削る
+ * 完全に意味的な同義判定ではないが、LLM 表現の軽微な揺れ
+ * (大小文字 / 末尾句点 / 余計な空白) を吸収して count 加算ヒットさせる。
+ */
+export function normalizeMisconceptionDescription(raw: string): string {
+  return raw
+    .trim()
+    .replace(/\s+/g, " ")
+    .toLowerCase()
+    .replace(/[。.]+$/u, "")
+    .trim();
+}
+
 export const EXTRACT_MISCONCEPTION_PROMPT_VERSION = "extract-misconception.v1";
 const TEMPLATE_PATH = "grading/extract-misconception.v1.md";
 
+// prompt の「最大 100 文字」と合わせる。LLM が多少超過することは許容して max は少し緩め。
 const MisconceptionSchema = z.object({
-  description: z.string().max(200),
+  description: z.string().max(100),
   confidence: z.number().min(0).max(1),
 });
 
@@ -26,7 +45,7 @@ const JSON_SCHEMA = {
     additionalProperties: false,
     required: ["description", "confidence"],
     properties: {
-      description: { type: "string" },
+      description: { type: "string", maxLength: 100 },
       confidence: { type: "number", minimum: 0, maximum: 1 },
     },
   },
@@ -105,17 +124,19 @@ export async function extractAndPersistMisconception(
   await upsertMisconception({
     userId: input.userId,
     conceptId: input.concept.id,
-    description: parsed.description.trim(),
+    // normalize して保存キーを安定化させる (類似揺れを 1 行に集約)
+    description: normalizeMisconceptionDescription(parsed.description),
   });
   return { saved: true, extracted: parsed };
 }
 
 /**
- * user × concept × description (1文字単位の完全一致) の misconception を upsert する。
- * 既存があれば count +1 + last_seen 更新、なければ INSERT。
+ * user × concept × description (normalize 済み) の misconception を upsert。
+ * uq_misconceptions_user_concept_desc の一意制約に乗せて ON CONFLICT DO UPDATE で
+ * 原子的に count +1 する (並行誤答での重複行生成を防ぐ、Codex Round 1 P0)。
  *
- * 注意: description 完全一致は LLM の表現揺れに弱いため、docs/03 §3.4.1 にある「類似判定」
- * (LLM での近似マッチ or embedding) は Phase 5+ で上乗せ。MVP はこのまま文字列一致。
+ * description は normalizeMisconceptionDescription で事前に正規化すること
+ * (大小文字・末尾句点・空白を吸収)。
  */
 export async function upsertMisconception(params: {
   userId: string;
@@ -123,33 +144,20 @@ export async function upsertMisconception(params: {
   description: string;
 }): Promise<void> {
   const db = getDb();
-  const existing = await db
-    .select()
-    .from(misconceptions)
-    .where(
-      and(
-        eq(misconceptions.userId, params.userId),
-        eq(misconceptions.conceptId, params.conceptId),
-        eq(misconceptions.description, params.description),
-      ),
-    )
-    .limit(1);
-
-  if (existing[0]) {
-    await db
-      .update(misconceptions)
-      .set({
-        count: sql`${misconceptions.count} + 1`,
-        lastSeen: sql`now()`,
-      })
-      .where(eq(misconceptions.id, existing[0].id));
-  } else {
-    await db.insert(misconceptions).values({
+  await db
+    .insert(misconceptions)
+    .values({
       userId: params.userId,
       conceptId: params.conceptId,
       description: params.description,
+    })
+    .onConflictDoUpdate({
+      target: [misconceptions.userId, misconceptions.conceptId, misconceptions.description],
+      set: {
+        count: sql`${misconceptions.count} + 1`,
+        lastSeen: sql`now()`,
+      },
     });
-  }
 }
 
 /**

--- a/src/server/grader/extract-misconception.ts
+++ b/src/server/grader/extract-misconception.ts
@@ -1,0 +1,179 @@
+import { and, eq, sql } from "drizzle-orm";
+import { z } from "zod";
+
+import { getDb } from "@/db/client";
+import { misconceptions, type Concept, type Question } from "@/db/schema";
+import { getOpenAI } from "@/lib/openai/client";
+import { MODEL_MAIN } from "@/lib/openai/models";
+
+import { renderTemplate } from "../generator/prompt-template";
+
+export const EXTRACT_MISCONCEPTION_PROMPT_VERSION = "extract-misconception.v1";
+const TEMPLATE_PATH = "grading/extract-misconception.v1.md";
+
+const MisconceptionSchema = z.object({
+  description: z.string().max(200),
+  confidence: z.number().min(0).max(1),
+});
+
+export type ExtractedMisconception = z.infer<typeof MisconceptionSchema>;
+
+const JSON_SCHEMA = {
+  name: "misconception_extraction",
+  strict: true as const,
+  schema: {
+    type: "object",
+    additionalProperties: false,
+    required: ["description", "confidence"],
+    properties: {
+      description: { type: "string" },
+      confidence: { type: "number", minimum: 0, maximum: 1 },
+    },
+  },
+};
+
+export type ExtractMisconceptionInput = {
+  concept: Pick<Concept, "id" | "name">;
+  question: Pick<Question, "prompt" | "answer">;
+  userAnswer: string;
+  reasonGiven: string;
+};
+
+export function buildExtractMisconceptionPrompt(input: ExtractMisconceptionInput) {
+  return renderTemplate(TEMPLATE_PATH, {
+    conceptId: input.concept.id,
+    conceptName: input.concept.name,
+    questionPrompt: input.question.prompt,
+    expectedAnswer: input.question.answer,
+    userAnswer: input.userAnswer,
+    reasonGiven: input.reasonGiven,
+  });
+}
+
+export type ExtractMisconceptionCaller = (args: {
+  model: string;
+  system: string;
+  user: string;
+}) => Promise<unknown>;
+
+export const defaultExtractMisconceptionCaller: ExtractMisconceptionCaller = async ({
+  model,
+  system,
+  user,
+}) => {
+  const client = getOpenAI();
+  const res = await client.responses.create({
+    model,
+    input: [
+      { role: "system", content: system },
+      { role: "user", content: user },
+    ],
+    text: {
+      format: {
+        type: "json_schema",
+        ...JSON_SCHEMA,
+      },
+    },
+  });
+  return JSON.parse(res.output_text);
+};
+
+/**
+ * 誤答 + reason_given から誤概念を抽出 (issue #19)。
+ * - reason_given が空なら抽出スキップ (コスト節約。docs/03 §3.4.1)
+ * - confidence < 0.5 の抽出は保存しない (迎合的な強引な診断を避ける)
+ *
+ * 抽出した誤概念は同 user × concept × description 一致 (lowercased normalize) で
+ * upsert され、count が +1 される。
+ */
+export async function extractAndPersistMisconception(
+  input: ExtractMisconceptionInput & { userId: string },
+  caller: ExtractMisconceptionCaller = defaultExtractMisconceptionCaller,
+): Promise<{ saved: boolean; extracted: ExtractedMisconception | null }> {
+  if (!input.reasonGiven || input.reasonGiven.trim().length === 0) {
+    return { saved: false, extracted: null };
+  }
+
+  const { system, user } = buildExtractMisconceptionPrompt(input);
+  const raw = await caller({ model: MODEL_MAIN, system, user });
+  const parsed = MisconceptionSchema.parse(raw);
+
+  if (parsed.confidence < 0.5 || parsed.description.trim().length === 0) {
+    return { saved: false, extracted: parsed };
+  }
+
+  await upsertMisconception({
+    userId: input.userId,
+    conceptId: input.concept.id,
+    description: parsed.description.trim(),
+  });
+  return { saved: true, extracted: parsed };
+}
+
+/**
+ * user × concept × description (1文字単位の完全一致) の misconception を upsert する。
+ * 既存があれば count +1 + last_seen 更新、なければ INSERT。
+ *
+ * 注意: description 完全一致は LLM の表現揺れに弱いため、docs/03 §3.4.1 にある「類似判定」
+ * (LLM での近似マッチ or embedding) は Phase 5+ で上乗せ。MVP はこのまま文字列一致。
+ */
+export async function upsertMisconception(params: {
+  userId: string;
+  conceptId: string;
+  description: string;
+}): Promise<void> {
+  const db = getDb();
+  const existing = await db
+    .select()
+    .from(misconceptions)
+    .where(
+      and(
+        eq(misconceptions.userId, params.userId),
+        eq(misconceptions.conceptId, params.conceptId),
+        eq(misconceptions.description, params.description),
+      ),
+    )
+    .limit(1);
+
+  if (existing[0]) {
+    await db
+      .update(misconceptions)
+      .set({
+        count: sql`${misconceptions.count} + 1`,
+        lastSeen: sql`now()`,
+      })
+      .where(eq(misconceptions.id, existing[0].id));
+  } else {
+    await db.insert(misconceptions).values({
+      userId: params.userId,
+      conceptId: params.conceptId,
+      description: params.description,
+    });
+  }
+}
+
+/**
+ * 生成プロンプトへの注入用: 特定 concept 上で未解決 (resolved=false) かつ直近で count 上位の
+ * 誤概念を最大 N 件返す。docs/03 §3.4.1 「出題時に矯正指示を注入」の入口。
+ */
+export async function fetchUnresolvedMisconceptionsForGeneration(params: {
+  userId: string;
+  conceptId: string;
+  limit?: number;
+}): Promise<Pick<typeof misconceptions.$inferSelect, "description" | "count">[]> {
+  const db = getDb();
+  const limit = params.limit ?? 3;
+  const rows = await db
+    .select()
+    .from(misconceptions)
+    .where(
+      and(
+        eq(misconceptions.userId, params.userId),
+        eq(misconceptions.conceptId, params.conceptId),
+        eq(misconceptions.resolved, false),
+      ),
+    )
+    .orderBy(sql`${misconceptions.count} DESC`, sql`${misconceptions.lastSeen} DESC`)
+    .limit(limit);
+  return rows.map((r) => ({ description: r.description, count: r.count }));
+}

--- a/src/server/grader/index.ts
+++ b/src/server/grader/index.ts
@@ -1,5 +1,6 @@
 import { TRPCError } from "@trpc/server";
 import { and, desc, eq } from "drizzle-orm";
+import { after } from "next/server";
 
 import { getDb } from "@/db/client";
 import {
@@ -196,15 +197,16 @@ export async function gradeAttempt(input: GradeAttemptInput): Promise<GradeAttem
       });
     }
     // 誤答 + reason_given が与えられたときだけ誤概念抽出を走らせる (issue #19)。
-    // LLM 呼び出しなので submit レスポンスをブロックしないよう fire-and-forget に (Round 3 指摘)。
-    // 失敗は console.error でログに残す (Sentry 導入後 #27 に captureException へ差し替え)。
+    // 素の detach promise は Vercel Functions の teardown で切られる可能性があるため、
+    // Next.js の after() で post-response に予約する (Round 4 指摘)。
+    // 失敗は console.error でログに残す (Sentry 導入 #27 後は captureException に差し替え)。
     if (grade.correct === false && input.reasonGiven && input.reasonGiven.trim().length > 0) {
       const reason = input.reasonGiven;
       const userId = input.userId;
       const conceptId = question.conceptId;
       const qPayload = { prompt: question.prompt, answer: question.answer };
       const userAnswer = input.userAnswer;
-      void (async () => {
+      after(async () => {
         try {
           const conceptRow = await getDb()
             .select({ id: concepts.id, name: concepts.name })
@@ -223,22 +225,22 @@ export async function gradeAttempt(input: GradeAttemptInput): Promise<GradeAttem
            
           console.error("extractAndPersistMisconception failed", err);
         }
-      })();
+      });
     }
-    // 正答 + unresolved な misconceptions があれば resolve に遷移させる (docs/05 §5.8)。
-    // 1 回の正答では早計なので「直近 3 連続正解」を近似条件にする。
-    if (grade.correct === true && input.updateMastery !== false) {
-      void (async () => {
+    // 正答で unresolved な misconceptions があれば resolve に遷移させる (docs/05 §5.8)。
+    // resolve は誤概念履歴側の状態で FSRS とは独立なので updateMastery=false でも走らせる
+    // (Round 4 指摘)。1 回の正答では早計なので「直近 3 連続正解」を近似条件にする。
+    if (grade.correct === true) {
+      const userId = input.userId;
+      const conceptId = question.conceptId;
+      after(async () => {
         try {
-          await maybeResolveMisconceptions({
-            userId: input.userId,
-            conceptId: question.conceptId,
-          });
+          await maybeResolveMisconceptions({ userId, conceptId });
         } catch (err) {
            
           console.error("maybeResolveMisconceptions failed", err);
         }
-      })();
+      });
     }
     return grade;
   }

--- a/src/server/grader/index.ts
+++ b/src/server/grader/index.ts
@@ -181,8 +181,12 @@ export async function gradeAttempt(input: GradeAttemptInput): Promise<GradeAttem
             reasonGiven: input.reasonGiven,
           });
         }
-      } catch {
-        // 誤概念抽出の失敗は採点結果の返却を妨げない (docs/03 §3.4.1)
+      } catch (err) {
+        // 誤概念抽出の失敗は採点結果の返却を妨げない (docs/03 §3.4.1) が、
+        // 完全に沈黙させると原因調査できないため console.error でログに残す。
+        // Sentry 導入後 (#27) は captureException に置き換える。
+         
+        console.error("extractAndPersistMisconception failed", err);
       }
     }
     return grade;

--- a/src/server/grader/index.ts
+++ b/src/server/grader/index.ts
@@ -1,10 +1,11 @@
 import { TRPCError } from "@trpc/server";
-import { and, eq } from "drizzle-orm";
+import { and, desc, eq } from "drizzle-orm";
 
 import { getDb } from "@/db/client";
 import {
   attempts,
   concepts,
+  misconceptions,
   questions,
   sessions,
   type NewAttempt,
@@ -52,6 +53,38 @@ async function loadQuestion(questionId: string): Promise<Question> {
   const q = rows[0];
   if (!q) throw new TRPCError({ code: "NOT_FOUND", message: `unknown question: ${questionId}` });
   return q;
+}
+
+/**
+ * 同 concept で直近 3 件連続で正解していたら、その concept の unresolved misconception を
+ * `resolved=true` に遷移させる (docs/05 §5.8 「矯正できたら resolved=1」の近似)。
+ * 厳密には「その misconception が直接矯正されたか」まで見ないが、MVP ではユーザーが
+ * 同 concept で連続正答 = 概ね誤解が解けた、という近似で運用する。
+ */
+async function maybeResolveMisconceptions(params: {
+  userId: string;
+  conceptId: string;
+}): Promise<void> {
+  const STREAK_TO_RESOLVE = 3;
+  const db = getDb();
+  const recent = await db
+    .select({ correct: attempts.correct })
+    .from(attempts)
+    .where(and(eq(attempts.userId, params.userId), eq(attempts.conceptId, params.conceptId)))
+    .orderBy(desc(attempts.createdAt))
+    .limit(STREAK_TO_RESOLVE);
+  if (recent.length < STREAK_TO_RESOLVE) return;
+  if (!recent.every((a) => a.correct === true)) return;
+  await db
+    .update(misconceptions)
+    .set({ resolved: true })
+    .where(
+      and(
+        eq(misconceptions.userId, params.userId),
+        eq(misconceptions.conceptId, params.conceptId),
+        eq(misconceptions.resolved, false),
+      ),
+    );
 }
 
 /** session が呼び出し元ユーザーのものであることを確認。別 user の session への書き込みを防ぐ */
@@ -163,31 +196,49 @@ export async function gradeAttempt(input: GradeAttemptInput): Promise<GradeAttem
       });
     }
     // 誤答 + reason_given が与えられたときだけ誤概念抽出を走らせる (issue #19)。
-    // mastery と違って updateMastery=false でも走らせる (学習体験に関わるログ)。
-    // LLM 呼び出しなので失敗は UX を止めないよう try/catch で握りつぶす (Sentry で可視化)。
+    // LLM 呼び出しなので submit レスポンスをブロックしないよう fire-and-forget に (Round 3 指摘)。
+    // 失敗は console.error でログに残す (Sentry 導入後 #27 に captureException へ差し替え)。
     if (grade.correct === false && input.reasonGiven && input.reasonGiven.trim().length > 0) {
-      try {
-        const conceptRow = await getDb()
-          .select({ id: concepts.id, name: concepts.name })
-          .from(concepts)
-          .where(eq(concepts.id, question.conceptId))
-          .limit(1);
-        if (conceptRow[0]) {
+      const reason = input.reasonGiven;
+      const userId = input.userId;
+      const conceptId = question.conceptId;
+      const qPayload = { prompt: question.prompt, answer: question.answer };
+      const userAnswer = input.userAnswer;
+      void (async () => {
+        try {
+          const conceptRow = await getDb()
+            .select({ id: concepts.id, name: concepts.name })
+            .from(concepts)
+            .where(eq(concepts.id, conceptId))
+            .limit(1);
+          if (!conceptRow[0]) return;
           await extractAndPersistMisconception({
-            userId: input.userId,
+            userId,
             concept: conceptRow[0],
-            question: { prompt: question.prompt, answer: question.answer },
-            userAnswer: input.userAnswer,
-            reasonGiven: input.reasonGiven,
+            question: qPayload,
+            userAnswer,
+            reasonGiven: reason,
           });
+        } catch (err) {
+           
+          console.error("extractAndPersistMisconception failed", err);
         }
-      } catch (err) {
-        // 誤概念抽出の失敗は採点結果の返却を妨げない (docs/03 §3.4.1) が、
-        // 完全に沈黙させると原因調査できないため console.error でログに残す。
-        // Sentry 導入後 (#27) は captureException に置き換える。
-         
-        console.error("extractAndPersistMisconception failed", err);
-      }
+      })();
+    }
+    // 正答 + unresolved な misconceptions があれば resolve に遷移させる (docs/05 §5.8)。
+    // 1 回の正答では早計なので「直近 3 連続正解」を近似条件にする。
+    if (grade.correct === true && input.updateMastery !== false) {
+      void (async () => {
+        try {
+          await maybeResolveMisconceptions({
+            userId: input.userId,
+            conceptId: question.conceptId,
+          });
+        } catch (err) {
+           
+          console.error("maybeResolveMisconceptions failed", err);
+        }
+      })();
     }
     return grade;
   }

--- a/src/server/grader/index.ts
+++ b/src/server/grader/index.ts
@@ -4,6 +4,7 @@ import { and, eq } from "drizzle-orm";
 import { getDb } from "@/db/client";
 import {
   attempts,
+  concepts,
   questions,
   sessions,
   type NewAttempt,
@@ -12,6 +13,7 @@ import {
 } from "@/db/schema";
 import { updateMasteryAfterAttempt } from "@/server/scheduler/update-mastery";
 
+import { extractAndPersistMisconception } from "./extract-misconception";
 import { gradeMcq } from "./mcq";
 import { gradeShort } from "./short";
 import { gradeWritten } from "./written";
@@ -159,6 +161,29 @@ export async function gradeAttempt(input: GradeAttemptInput): Promise<GradeAttem
         conceptId: question.conceptId,
         score: grade.score,
       });
+    }
+    // 誤答 + reason_given が与えられたときだけ誤概念抽出を走らせる (issue #19)。
+    // mastery と違って updateMastery=false でも走らせる (学習体験に関わるログ)。
+    // LLM 呼び出しなので失敗は UX を止めないよう try/catch で握りつぶす (Sentry で可視化)。
+    if (grade.correct === false && input.reasonGiven && input.reasonGiven.trim().length > 0) {
+      try {
+        const conceptRow = await getDb()
+          .select({ id: concepts.id, name: concepts.name })
+          .from(concepts)
+          .where(eq(concepts.id, question.conceptId))
+          .limit(1);
+        if (conceptRow[0]) {
+          await extractAndPersistMisconception({
+            userId: input.userId,
+            concept: conceptRow[0],
+            question: { prompt: question.prompt, answer: question.answer },
+            userAnswer: input.userAnswer,
+            reasonGiven: input.reasonGiven,
+          });
+        }
+      } catch {
+        // 誤概念抽出の失敗は採点結果の返却を妨げない (docs/03 §3.4.1)
+      }
     }
     return grade;
   }

--- a/src/server/trpc/routers/session.ts
+++ b/src/server/trpc/routers/session.ts
@@ -303,6 +303,8 @@ export const sessionRouter = router({
           conceptId: conceptRow.id,
           difficulty: effectiveDifficulty,
           thinkingStyle: effectiveThinkingStyle,
+          // 生成プロンプトに「この concept で繰り返し誤解」を注入する (issue #19)。
+          userId: ctx.user.id,
         });
         question = generated.question;
         questionMeta = {


### PR DESCRIPTION
## Summary
- `src/server/grader/extract-misconception.ts`: gpt-5 で誤答 + reason_given から misconception を抽出
- reason_given が空なら抽出スキップ (コスト節約, docs/03 §3.4.1)
- confidence < 0.5 は保存しない (迎合抑止)
- description 完全一致で count 加算 upsert
- gradeAttempt: 誤答時に非同期で抽出を呼ぶ (失敗は握りつぶす)
- generateMcq に `userId` 追加、userMisconceptions を取得して prompt に注入
- テスト 5 件 (prompt snapshot / スキップ条件 / confidence 低い棄却など)

closes #19