### PR TITLE
feat(insights): Insights Dashboard (#20)

### DIFF
--- a/src/app/custom/page.tsx
+++ b/src/app/custom/page.tsx
@@ -5,10 +5,15 @@ import { getCurrentUser } from "@/server/auth/session";
 
 export const dynamic = "force-dynamic";
 
+function pickFirstString(value: string | string[] | undefined): string | undefined {
+  const first = Array.isArray(value) ? value[0] : value;
+  return typeof first === "string" ? first : undefined;
+}
+
 export default async function CustomPage({
   searchParams,
 }: {
-  searchParams?: Promise<{ prefill?: string | string[] }>;
+  searchParams?: Promise<{ prefill?: string | string[]; conceptId?: string | string[] }>;
 }) {
   const user = await getCurrentUser();
   if (!user) {
@@ -17,12 +22,14 @@ export default async function CustomPage({
   const params = await searchParams;
   // Next.js の searchParams は string | string[] | undefined のため単一化してから渡す。
   // ?prefill=a&prefill=b のような多値クエリは先頭を採用。
-  const rawParam = params?.prefill;
-  const rawValue = Array.isArray(rawParam) ? rawParam[0] : rawParam;
-  const initialRaw = typeof rawValue === "string" ? rawValue.slice(0, 2000) : undefined;
+  const initialRaw = pickFirstString(params?.prefill)?.slice(0, 2000);
+  // Insights Dashboard 等から ?conceptId=... で来た場合は、LLM parse を迂回して
+  // decoding で customSpec.concepts = [conceptId] を固定する (Round 3 指摘 #1: parser の
+  // 出力次第で別 concept になるリスクを回避し、「この concept だけ Custom Session」を確実に保証)。
+  const initialConceptId = pickFirstString(params?.conceptId)?.slice(0, 200);
   return (
     <main className="flex min-h-screen flex-col items-center justify-center gap-6 p-8">
-      <CustomScreen initialRaw={initialRaw} />
+      <CustomScreen initialRaw={initialRaw} initialConceptId={initialConceptId} />
     </main>
   );
 }

--- a/src/app/custom/page.tsx
+++ b/src/app/custom/page.tsx
@@ -5,14 +5,21 @@ import { getCurrentUser } from "@/server/auth/session";
 
 export const dynamic = "force-dynamic";
 
-export default async function CustomPage() {
+export default async function CustomPage({
+  searchParams,
+}: {
+  searchParams?: Promise<{ prefill?: string }>;
+}) {
   const user = await getCurrentUser();
   if (!user) {
     redirect("/login");
   }
+  const params = await searchParams;
+  // Insights 等から ?prefill=概念名 で遷移したときは初期 raw にセットする。
+  const initialRaw = params?.prefill?.slice(0, 2000) ?? undefined;
   return (
     <main className="flex min-h-screen flex-col items-center justify-center gap-6 p-8">
-      <CustomScreen />
+      <CustomScreen initialRaw={initialRaw} />
     </main>
   );
 }

--- a/src/app/custom/page.tsx
+++ b/src/app/custom/page.tsx
@@ -8,15 +8,18 @@ export const dynamic = "force-dynamic";
 export default async function CustomPage({
   searchParams,
 }: {
-  searchParams?: Promise<{ prefill?: string }>;
+  searchParams?: Promise<{ prefill?: string | string[] }>;
 }) {
   const user = await getCurrentUser();
   if (!user) {
     redirect("/login");
   }
   const params = await searchParams;
-  // Insights 等から ?prefill=概念名 で遷移したときは初期 raw にセットする。
-  const initialRaw = params?.prefill?.slice(0, 2000) ?? undefined;
+  // Next.js の searchParams は string | string[] | undefined のため単一化してから渡す。
+  // ?prefill=a&prefill=b のような多値クエリは先頭を採用。
+  const rawParam = params?.prefill;
+  const rawValue = Array.isArray(rawParam) ? rawParam[0] : rawParam;
+  const initialRaw = typeof rawValue === "string" ? rawValue.slice(0, 2000) : undefined;
   return (
     <main className="flex min-h-screen flex-col items-center justify-center gap-6 p-8">
       <CustomScreen initialRaw={initialRaw} />

--- a/src/app/insights/page.tsx
+++ b/src/app/insights/page.tsx
@@ -1,0 +1,18 @@
+import { redirect } from "next/navigation";
+
+import { InsightsOverviewScreen } from "@/features/insights/overview-screen";
+import { getCurrentUser } from "@/server/auth/session";
+
+export const dynamic = "force-dynamic";
+
+export default async function InsightsPage() {
+  const user = await getCurrentUser();
+  if (!user) {
+    redirect("/login");
+  }
+  return (
+    <main className="flex min-h-screen flex-col items-center gap-6 p-8">
+      <InsightsOverviewScreen />
+    </main>
+  );
+}

--- a/src/features/custom/custom-screen.tsx
+++ b/src/features/custom/custom-screen.tsx
@@ -28,13 +28,28 @@ type Phase =
  * 1. 自然言語入力 → custom.parse → 読み取り専用カード
  * 2. 違うと判断したら raw を修正して再パース (MVP は編集フォームなし)
  * 3. 開始ボタン → session.start({kind:"custom", spec}) → useDrillStore に流し込み → DrillScreen
+ *
+ * Insights Dashboard 等から ?conceptId=... で来た場合は、LLM parse を迂回して
+ * initialSpec (concepts=[conceptId], questionCount=5) を decoding で組み立て、
+ * そのまま previewing 状態に遷移する (Round 3 指摘 #1 対応)。
  */
-// 初期 raw はマウント時に useState の初期値として注入する。
-// Insights Dashboard 等から ?prefill=... で来たとき、自動 parse はせず、
-// ユーザーに内容を確認してもらう (プレビューフローを尊重)。
-export function CustomScreen({ initialRaw }: { initialRaw?: string } = {}) {
-  const [phase, setPhase] = useState<Phase>({ kind: "input" });
-  const [raw, setRaw] = useState(initialRaw ?? "");
+export function CustomScreen({
+  initialRaw,
+  initialConceptId,
+}: { initialRaw?: string; initialConceptId?: string } = {}) {
+  // initialConceptId があれば LLM を通さず previewing に直行する。
+  const initialSpec: CustomSessionSpec | null = initialConceptId
+    ? { concepts: [initialConceptId], questionCount: 5 }
+    : null;
+  const initialRawForPreview = initialSpec
+    ? (initialRaw ?? `concept ${initialConceptId} を 5 問`)
+    : "";
+  const [phase, setPhase] = useState<Phase>(
+    initialSpec
+      ? { kind: "previewing", raw: initialRawForPreview, spec: initialSpec }
+      : { kind: "input" },
+  );
+  const [raw, setRaw] = useState(initialRaw ?? initialRawForPreview);
   const [error, setError] = useState<string | null>(null);
 
   const parseMutation = trpc.custom.parse.useMutation();

--- a/src/features/custom/custom-screen.tsx
+++ b/src/features/custom/custom-screen.tsx
@@ -29,9 +29,12 @@ type Phase =
  * 2. 違うと判断したら raw を修正して再パース (MVP は編集フォームなし)
  * 3. 開始ボタン → session.start({kind:"custom", spec}) → useDrillStore に流し込み → DrillScreen
  */
-export function CustomScreen() {
+// 初期 raw はマウント時に useState の初期値として注入する。
+// Insights Dashboard 等から ?prefill=... で来たとき、自動 parse はせず、
+// ユーザーに内容を確認してもらう (プレビューフローを尊重)。
+export function CustomScreen({ initialRaw }: { initialRaw?: string } = {}) {
   const [phase, setPhase] = useState<Phase>({ kind: "input" });
-  const [raw, setRaw] = useState("");
+  const [raw, setRaw] = useState(initialRaw ?? "");
   const [error, setError] = useState<string | null>(null);
 
   const parseMutation = trpc.custom.parse.useMutation();

--- a/src/features/insights/overview-screen.tsx
+++ b/src/features/insights/overview-screen.tsx
@@ -13,7 +13,7 @@ type OverviewItem = {
   subdomainId: string;
   masteryPct: number;
   attemptCount: number;
-  recentWrongCount?: number;
+  wrongCount: number;
 };
 
 function ProgressBar({ value }: { value: number }) {
@@ -39,6 +39,9 @@ function ItemRow({
   hint: (it: OverviewItem) => string | null;
 }) {
   const message = hint(item);
+  // /custom?prefill=... で該当 concept に絞った Custom Session を開始できる
+  const prefill = `${item.conceptName} (${item.conceptId}) を 5 問出して`;
+  const customHref = `/custom?prefill=${encodeURIComponent(prefill)}`;
   return (
     <li className="border-border rounded-md border p-2 text-sm">
       <div className="flex items-baseline justify-between gap-2">
@@ -50,6 +53,11 @@ function ItemRow({
       {message && <div className="text-muted-foreground mt-1 text-xs">{message}</div>}
       <div className="text-muted-foreground mt-1 text-xs">
         {item.domainId} / {item.subdomainId} ・ {item.conceptId}
+      </div>
+      <div className="mt-2">
+        <Button asChild variant="outline" size="sm">
+          <Link href={customHref}>🎯 この concept を出題</Link>
+        </Button>
       </div>
     </li>
   );
@@ -129,8 +137,8 @@ export function InsightsOverviewScreen() {
                   key={i.conceptId}
                   item={i}
                   hint={(it) =>
-                    it.attemptCount > 0 && (it.recentWrongCount ?? 0) > 0
-                      ? `直近 ${it.attemptCount} 問中 ${it.recentWrongCount} 問ミス`
+                    it.attemptCount > 0 && it.wrongCount > 0
+                      ? `${it.attemptCount} 問中 ${it.wrongCount} 問ミス (全期間)`
                       : null
                   }
                 />

--- a/src/features/insights/overview-screen.tsx
+++ b/src/features/insights/overview-screen.tsx
@@ -1,20 +1,17 @@
 "use client";
 
+import type { inferRouterOutputs } from "@trpc/server";
 import Link from "next/link";
 
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { trpc } from "@/lib/trpc/react";
 
-type OverviewItem = {
-  conceptId: string;
-  conceptName: string;
-  domainId: string;
-  subdomainId: string;
-  masteryPct: number;
-  attemptCount: number;
-  wrongCount: number;
-};
+import type { AppRouter } from "@/server/trpc/routers";
+
+// Server 側の OverviewItem 型から推論して client 再定義の二重管理を避ける (Round 4 指摘 #2)。
+type InsightsOverview = inferRouterOutputs<AppRouter>["insights"]["overview"];
+type OverviewItem = InsightsOverview["strongest"][number];
 
 function ProgressBar({ value }: { value: number }) {
   const pct = Math.round(value * 100);

--- a/src/features/insights/overview-screen.tsx
+++ b/src/features/insights/overview-screen.tsx
@@ -1,0 +1,193 @@
+"use client";
+
+import Link from "next/link";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { trpc } from "@/lib/trpc/react";
+
+type OverviewItem = {
+  conceptId: string;
+  conceptName: string;
+  domainId: string;
+  subdomainId: string;
+  masteryPct: number;
+  attemptCount: number;
+  recentWrongCount?: number;
+};
+
+function ProgressBar({ value }: { value: number }) {
+  const pct = Math.round(value * 100);
+  const filled = Math.round(value * 20);
+  return (
+    <div className="space-y-1">
+      <div className="font-mono text-xs">
+        {"▓".repeat(filled)}
+        <span className="text-muted-foreground">{"░".repeat(20 - filled)}</span>
+        {"  "}
+        {pct}%
+      </div>
+    </div>
+  );
+}
+
+function ItemRow({
+  item,
+  hint,
+}: {
+  item: OverviewItem;
+  hint: (it: OverviewItem) => string | null;
+}) {
+  const message = hint(item);
+  return (
+    <li className="border-border rounded-md border p-2 text-sm">
+      <div className="flex items-baseline justify-between gap-2">
+        <span className="font-medium">{item.conceptName}</span>
+        <span className="text-muted-foreground font-mono text-xs">
+          {Math.round(item.masteryPct * 100)}%
+        </span>
+      </div>
+      {message && <div className="text-muted-foreground mt-1 text-xs">{message}</div>}
+      <div className="text-muted-foreground mt-1 text-xs">
+        {item.domainId} / {item.subdomainId} ・ {item.conceptId}
+      </div>
+    </li>
+  );
+}
+
+/**
+ * Insights Dashboard (issue #20, docs/05 §5.3)。
+ * MVP は数値のみ + 簡易プログレスバー (Recharts なし)。
+ * 各 Top 3 項目からは concept を強調した custom session への導線を置ける (Phase 2+)。
+ */
+export function InsightsOverviewScreen() {
+  const { data, isLoading, error } = trpc.insights.overview.useQuery();
+
+  if (isLoading) {
+    return (
+      <Card className="w-full max-w-2xl">
+        <CardContent className="text-muted-foreground p-6 text-sm">読み込み中...</CardContent>
+      </Card>
+    );
+  }
+
+  if (error) {
+    return (
+      <Card className="w-full max-w-2xl">
+        <CardContent className="text-destructive p-6 text-sm">{error.message}</CardContent>
+      </Card>
+    );
+  }
+
+  if (!data) return null;
+
+  return (
+    <div className="w-full max-w-2xl space-y-4">
+      <Card>
+        <CardHeader>
+          <CardTitle>Your Learning, Today</CardTitle>
+          <CardDescription>
+            Mastery: {data.masteredConcepts} / {data.totalConcepts} concepts
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <ProgressBar value={data.masteryPct} />
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>📈 Strongest (top 3)</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {data.strongest.length === 0 ? (
+            <div className="text-muted-foreground text-sm">まだ十分な attempt がありません。</div>
+          ) : (
+            <ul className="space-y-2">
+              {data.strongest.map((i) => (
+                <ItemRow key={i.conceptId} item={i} hint={() => null} />
+              ))}
+            </ul>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>⚠️ Weakest (top 3)</CardTitle>
+          <CardDescription>
+            5 attempt 以上で mastery &lt; 50% の concept。改善対象。
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {data.weakest.length === 0 ? (
+            <div className="text-muted-foreground text-sm">該当なし。調子いい!</div>
+          ) : (
+            <ul className="space-y-2">
+              {data.weakest.map((i) => (
+                <ItemRow
+                  key={i.conceptId}
+                  item={i}
+                  hint={(it) =>
+                    it.attemptCount > 0 && (it.recentWrongCount ?? 0) > 0
+                      ? `直近 ${it.attemptCount} 問中 ${it.recentWrongCount} 問ミス`
+                      : null
+                  }
+                />
+              ))}
+            </ul>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>🚧 Blind Spots (未着手 top 3)</CardTitle>
+          <CardDescription>
+            prereqs を満たしているのにまだ一度も解いていない concept。
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {data.blindSpots.length === 0 ? (
+            <div className="text-muted-foreground text-sm">全て着手済み。</div>
+          ) : (
+            <ul className="space-y-2">
+              {data.blindSpots.map((i) => (
+                <ItemRow key={i.conceptId} item={i} hint={() => "0 問"} />
+              ))}
+            </ul>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>📉 Decaying (忘却進行中 top 3)</CardTitle>
+          <CardDescription>
+            1 週間以上レビューしていない mastery &lt; 80% の concept。
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {data.decaying.length === 0 ? (
+            <div className="text-muted-foreground text-sm">該当なし。</div>
+          ) : (
+            <ul className="space-y-2">
+              {data.decaying.map((i) => (
+                <ItemRow key={i.conceptId} item={i} hint={() => null} />
+              ))}
+            </ul>
+          )}
+        </CardContent>
+      </Card>
+
+      <div className="flex flex-wrap gap-2">
+        <Button variant="outline" asChild>
+          <Link href="/custom">🎯 苦手を絞って出題</Link>
+        </Button>
+        <Button variant="outline" asChild>
+          <Link href="/drill">🎲 Daily Drill</Link>
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/features/insights/overview-screen.tsx
+++ b/src/features/insights/overview-screen.tsx
@@ -39,9 +39,9 @@ function ItemRow({
   hint: (it: OverviewItem) => string | null;
 }) {
   const message = hint(item);
-  // /custom?prefill=... で該当 concept に絞った Custom Session を開始できる
-  const prefill = `${item.conceptName} (${item.conceptId}) を 5 問出して`;
-  const customHref = `/custom?prefill=${encodeURIComponent(prefill)}`;
+  // /custom?conceptId=... に直接 conceptId を渡し、parser を迂回して customSpec.concepts を
+  // 決定論的に固定する (Round 3 指摘 #1: 自然言語 prefill では別 concept に解釈されうる)。
+  const customHref = `/custom?conceptId=${encodeURIComponent(item.conceptId)}`;
   return (
     <li className="border-border rounded-md border p-2 text-sm">
       <div className="flex items-baseline justify-between gap-2">

--- a/src/server/insights/overview.test.ts
+++ b/src/server/insights/overview.test.ts
@@ -155,4 +155,29 @@ describe("fetchInsightsOverview (集計スナップショット)", () => {
     const out = await fetchInsightsOverview("u-1");
     expect(out.decaying.map((d) => d.conceptId)).toEqual(["old"]);
   });
+
+  it("decaying は同じ lastReview の場合 conceptId で安定ソート (Round 5)", async () => {
+    const sameTime = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+    fixtures.concepts = [
+      { id: "ccc", name: "Ccc", domainId: "x", subdomainId: "y", prereqs: [] },
+      { id: "aaa", name: "Aaa", domainId: "x", subdomainId: "y", prereqs: [] },
+      { id: "bbb", name: "Bbb", domainId: "x", subdomainId: "y", prereqs: [] },
+      { id: "ddd", name: "Ddd", domainId: "x", subdomainId: "y", prereqs: [] },
+    ];
+    fixtures.mastery = [
+      { conceptId: "ccc", userId: "u-1", mastered: false, masteryPct: 0.5, lastReview: sameTime },
+      { conceptId: "aaa", userId: "u-1", mastered: false, masteryPct: 0.5, lastReview: sameTime },
+      { conceptId: "bbb", userId: "u-1", mastered: false, masteryPct: 0.5, lastReview: sameTime },
+      { conceptId: "ddd", userId: "u-1", mastered: false, masteryPct: 0.5, lastReview: sameTime },
+    ];
+    fixtures.attemptsGroup = [
+      { conceptId: "ccc", total: 3 },
+      { conceptId: "aaa", total: 3 },
+      { conceptId: "bbb", total: 3 },
+      { conceptId: "ddd", total: 3 },
+    ];
+
+    const out = await fetchInsightsOverview("u-1");
+    expect(out.decaying.map((d) => d.conceptId)).toEqual(["aaa", "bbb", "ccc"]);
+  });
 });

--- a/src/server/insights/overview.test.ts
+++ b/src/server/insights/overview.test.ts
@@ -8,26 +8,18 @@ const fixtures: {
   concepts: unknown[];
   mastery: unknown[];
   attemptsGroup: unknown[];
-  attemptsRecent: unknown[];
 } = {
   concepts: [],
   mastery: [],
   attemptsGroup: [],
-  attemptsRecent: [],
 };
 
 vi.mock("@/db/client", () => {
   // 呼び出し順序で返り値を切り替える: 1. select().from(concepts) → conceptRows
   // 2. select().from(mastery).where() → masteryRows
-  // 3. select({conceptId, total}).from(attempts).where().groupBy() → attemptsGroup
-  // 4. select({conceptId, correct}).from(attempts).where().orderBy().limit() → attemptsRecent
+  // 3. select({conceptId, total, wrong}).from(attempts).where().groupBy() → attemptsGroup
   let callIdx = 0;
-  const queue = [
-    () => fixtures.concepts,
-    () => fixtures.mastery,
-    () => fixtures.attemptsGroup,
-    () => fixtures.attemptsRecent,
-  ];
+  const queue = [() => fixtures.concepts, () => fixtures.mastery, () => fixtures.attemptsGroup];
   // drizzle builder をイミュータブルに chain したい。テスト簡略化のため then を返す。
   function makeBuilder(): unknown {
     const b = {
@@ -63,7 +55,6 @@ beforeEach(async () => {
   fixtures.concepts = [];
   fixtures.mastery = [];
   fixtures.attemptsGroup = [];
-  fixtures.attemptsRecent = [];
 });
 
 describe("fetchInsightsOverview (集計スナップショット)", () => {
@@ -97,7 +88,7 @@ describe("fetchInsightsOverview (集計スナップショット)", () => {
       { conceptId: "c2", total: 8 },
       { conceptId: "c3", total: 12 },
     ];
-    fixtures.attemptsRecent = [];
+
     const out = await fetchInsightsOverview("u-1");
     expect(out.strongest.map((s) => s.conceptId)).toEqual(["c2", "c1", "c3"]);
   });
@@ -120,7 +111,7 @@ describe("fetchInsightsOverview (集計スナップショット)", () => {
       { conceptId: "c2", total: 8 },
       { conceptId: "c3", total: 3 },
     ];
-    fixtures.attemptsRecent = [];
+
     const out = await fetchInsightsOverview("u-1");
     expect(out.weakest.map((w) => w.conceptId)).toEqual(["c2", "c1"]);
   });
@@ -135,7 +126,7 @@ describe("fetchInsightsOverview (集計スナップショット)", () => {
       { conceptId: "c1", userId: "u-1", mastered: true, masteryPct: 0.9, lastReview: new Date() },
     ];
     fixtures.attemptsGroup = [{ conceptId: "c1", total: 10 }];
-    fixtures.attemptsRecent = [];
+
     const out = await fetchInsightsOverview("u-1");
     expect(out.blindSpots.map((b) => b.conceptId)).toEqual(["c2"]);
     // c3 は prereq (c2) が未 mastered なので入らない
@@ -160,7 +151,7 @@ describe("fetchInsightsOverview (集計スナップショット)", () => {
       { conceptId: "fresh", total: 3 },
       { conceptId: "no-review", total: 3 },
     ];
-    fixtures.attemptsRecent = [];
+
     const out = await fetchInsightsOverview("u-1");
     expect(out.decaying.map((d) => d.conceptId)).toEqual(["old"]);
   });

--- a/src/server/insights/overview.test.ts
+++ b/src/server/insights/overview.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+import { fetchInsightsOverview } from "./overview";
+
+// DB クライアントをテーブル別に mock して集計ロジックだけを検証する。
+// 各テストで __conceptRows / __masteryRows / __attemptCountRows / __recentRows を差し替える。
+const fixtures: {
+  concepts: unknown[];
+  mastery: unknown[];
+  attemptsGroup: unknown[];
+  attemptsRecent: unknown[];
+} = {
+  concepts: [],
+  mastery: [],
+  attemptsGroup: [],
+  attemptsRecent: [],
+};
+
+vi.mock("@/db/client", () => {
+  // 呼び出し順序で返り値を切り替える: 1. select().from(concepts) → conceptRows
+  // 2. select().from(mastery).where() → masteryRows
+  // 3. select({conceptId, total}).from(attempts).where().groupBy() → attemptsGroup
+  // 4. select({conceptId, correct}).from(attempts).where().orderBy().limit() → attemptsRecent
+  let callIdx = 0;
+  const queue = [
+    () => fixtures.concepts,
+    () => fixtures.mastery,
+    () => fixtures.attemptsGroup,
+    () => fixtures.attemptsRecent,
+  ];
+  // drizzle builder をイミュータブルに chain したい。テスト簡略化のため then を返す。
+  function makeBuilder(): unknown {
+    const b = {
+      from: () => b,
+      where: () => b,
+      orderBy: () => b,
+      groupBy: () => b,
+      limit: () => b,
+      then: (onFulfilled: (v: unknown) => unknown) => {
+        const result = queue[callIdx++]?.() ?? [];
+        return Promise.resolve(result).then(onFulfilled);
+      },
+    };
+    return b;
+  }
+  return {
+    getDb: () => ({
+      select: () => makeBuilder(),
+    }),
+    __setFixtures: (f: typeof fixtures) => {
+      Object.assign(fixtures, f);
+      callIdx = 0;
+    },
+    __resetCall: () => {
+      callIdx = 0;
+    },
+  };
+});
+
+beforeEach(async () => {
+  const mod = (await import("@/db/client")) as unknown as { __resetCall: () => void };
+  mod.__resetCall();
+  fixtures.concepts = [];
+  fixtures.mastery = [];
+  fixtures.attemptsGroup = [];
+  fixtures.attemptsRecent = [];
+});
+
+describe("fetchInsightsOverview (集計スナップショット)", () => {
+  it("空データなら全部 0 / 空配列", async () => {
+    const out = await fetchInsightsOverview("u-1");
+    expect(out.totalConcepts).toBe(0);
+    expect(out.masteredConcepts).toBe(0);
+    expect(out.strongest).toEqual([]);
+    expect(out.weakest).toEqual([]);
+    expect(out.blindSpots).toEqual([]);
+    expect(out.decaying).toEqual([]);
+  });
+
+  it("strongest は mastery 降順、attemptCount > 0 のみ", async () => {
+    const now = new Date("2026-04-18T00:00:00Z");
+    fixtures.concepts = [
+      { id: "c1", name: "A", domainId: "x", subdomainId: "y", prereqs: [] },
+      { id: "c2", name: "B", domainId: "x", subdomainId: "y", prereqs: [] },
+      { id: "c3", name: "C", domainId: "x", subdomainId: "y", prereqs: [] },
+      { id: "c4", name: "D", domainId: "x", subdomainId: "y", prereqs: [] },
+    ];
+    fixtures.mastery = [
+      { conceptId: "c1", userId: "u-1", mastered: false, masteryPct: 0.9, lastReview: now },
+      { conceptId: "c2", userId: "u-1", mastered: true, masteryPct: 0.95, lastReview: now },
+      { conceptId: "c3", userId: "u-1", mastered: false, masteryPct: 0.3, lastReview: now },
+      // c4 は attempt なし (attemptCount=0) なので strongest に入らない
+      { conceptId: "c4", userId: "u-1", mastered: false, masteryPct: 1.0, lastReview: null },
+    ];
+    fixtures.attemptsGroup = [
+      { conceptId: "c1", total: 10 },
+      { conceptId: "c2", total: 8 },
+      { conceptId: "c3", total: 12 },
+    ];
+    fixtures.attemptsRecent = [];
+    const out = await fetchInsightsOverview("u-1");
+    expect(out.strongest.map((s) => s.conceptId)).toEqual(["c2", "c1", "c3"]);
+  });
+
+  it("weakest は attempt>=5 かつ mastery<0.5 のみ、低い順", async () => {
+    const now = new Date("2026-04-18T00:00:00Z");
+    fixtures.concepts = [
+      { id: "c1", name: "A", domainId: "x", subdomainId: "y", prereqs: [] },
+      { id: "c2", name: "B", domainId: "x", subdomainId: "y", prereqs: [] },
+      { id: "c3", name: "C", domainId: "x", subdomainId: "y", prereqs: [] },
+    ];
+    fixtures.mastery = [
+      { conceptId: "c1", userId: "u-1", mastered: false, masteryPct: 0.4, lastReview: now },
+      { conceptId: "c2", userId: "u-1", mastered: false, masteryPct: 0.2, lastReview: now },
+      // c3 は attempt が 3 件なので weakest に入らない
+      { conceptId: "c3", userId: "u-1", mastered: false, masteryPct: 0.1, lastReview: now },
+    ];
+    fixtures.attemptsGroup = [
+      { conceptId: "c1", total: 6 },
+      { conceptId: "c2", total: 8 },
+      { conceptId: "c3", total: 3 },
+    ];
+    fixtures.attemptsRecent = [];
+    const out = await fetchInsightsOverview("u-1");
+    expect(out.weakest.map((w) => w.conceptId)).toEqual(["c2", "c1"]);
+  });
+
+  it("blindSpots は attempt=0 かつ prereqs 全 mastered の concept", async () => {
+    fixtures.concepts = [
+      { id: "c1", name: "A", domainId: "x", subdomainId: "y", prereqs: [] },
+      { id: "c2", name: "B", domainId: "x", subdomainId: "y", prereqs: ["c1"] },
+      { id: "c3", name: "C", domainId: "x", subdomainId: "y", prereqs: ["c2"] },
+    ];
+    fixtures.mastery = [
+      { conceptId: "c1", userId: "u-1", mastered: true, masteryPct: 0.9, lastReview: new Date() },
+    ];
+    fixtures.attemptsGroup = [{ conceptId: "c1", total: 10 }];
+    fixtures.attemptsRecent = [];
+    const out = await fetchInsightsOverview("u-1");
+    expect(out.blindSpots.map((b) => b.conceptId)).toEqual(["c2"]);
+    // c3 は prereq (c2) が未 mastered なので入らない
+    expect(out.blindSpots.find((b) => b.conceptId === "c3")).toBeUndefined();
+  });
+
+  it("decaying は lastReview が 7 日以上前 & mastery<0.8 & attempt>0", async () => {
+    const longAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+    const recent = new Date();
+    fixtures.concepts = [
+      { id: "old", name: "Old", domainId: "x", subdomainId: "y", prereqs: [] },
+      { id: "fresh", name: "Fresh", domainId: "x", subdomainId: "y", prereqs: [] },
+      { id: "no-review", name: "NoReview", domainId: "x", subdomainId: "y", prereqs: [] },
+    ];
+    fixtures.mastery = [
+      { conceptId: "old", userId: "u-1", mastered: false, masteryPct: 0.5, lastReview: longAgo },
+      { conceptId: "fresh", userId: "u-1", mastered: false, masteryPct: 0.5, lastReview: recent },
+      { conceptId: "no-review", userId: "u-1", mastered: false, masteryPct: 0.5, lastReview: null },
+    ];
+    fixtures.attemptsGroup = [
+      { conceptId: "old", total: 3 },
+      { conceptId: "fresh", total: 3 },
+      { conceptId: "no-review", total: 3 },
+    ];
+    fixtures.attemptsRecent = [];
+    const out = await fetchInsightsOverview("u-1");
+    expect(out.decaying.map((d) => d.conceptId)).toEqual(["old"]);
+  });
+});

--- a/src/server/insights/overview.test.ts
+++ b/src/server/insights/overview.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it, vi, beforeEach } from "vitest";
 import { fetchInsightsOverview } from "./overview";
 
 // DB クライアントをテーブル別に mock して集計ロジックだけを検証する。
-// 各テストで __conceptRows / __masteryRows / __attemptCountRows / __recentRows を差し替える。
+// 各テストで fixtures.{concepts, mastery, attemptsGroup} を差し替える。
 const fixtures: {
   concepts: unknown[];
   mastery: unknown[];

--- a/src/server/insights/overview.ts
+++ b/src/server/insights/overview.ts
@@ -2,6 +2,7 @@ import { eq, sql } from "drizzle-orm";
 
 import { getDb } from "@/db/client";
 import { attempts, concepts, mastery, type Concept, type Mastery } from "@/db/schema";
+import { arePrereqsSatisfied } from "@/server/scheduler/blind-spot";
 
 export type OverviewItem = {
   conceptId: string;
@@ -96,7 +97,8 @@ export async function fetchInsightsOverview(userId: string): Promise<InsightsOve
     .sort((a, b) => a.masteryPct - b.masteryPct || a.conceptId.localeCompare(b.conceptId))
     .slice(0, TOP_N);
 
-  // Blind spots: attempts=0 かつ prereqs 全て mastered (daily と同じ判定)。
+  // Blind spots: attempts=0 かつ prereqs 全て mastered
+  // (daily の rankDailyCandidates と同じ prereq 判定ロジックを共有 helper で使う)。
   // domain → subdomain → id の順で安定ソートして表示の再現性を確保。
   const conceptById = new Map(conceptRows.map((c) => [c.id, c]));
   const blindSpots = items
@@ -104,8 +106,7 @@ export async function fetchInsightsOverview(userId: string): Promise<InsightsOve
       if (i.attemptCount !== 0) return false;
       const concept = conceptById.get(i.conceptId);
       if (!concept) return false;
-      const prereqs = concept.prereqs ?? [];
-      return prereqs.length === 0 || prereqs.every((pid) => masteredIds.has(pid));
+      return arePrereqsSatisfied(concept, masteredIds);
     })
     .sort(
       (a, b) =>

--- a/src/server/insights/overview.ts
+++ b/src/server/insights/overview.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, sql } from "drizzle-orm";
+import { eq, sql } from "drizzle-orm";
 
 import { getDb } from "@/db/client";
 import { attempts, concepts, mastery, type Concept, type Mastery } from "@/db/schema";
@@ -9,10 +9,10 @@ export type OverviewItem = {
   domainId: string;
   subdomainId: string;
   masteryPct: number;
-  /** 関連 attempts 数 (weakest 表示で「○問中 ○問ミス」に使う) */
+  /** この concept の全期間 attempts 総数 */
   attemptCount: number;
-  /** 直近誤答数 (最終20件内) */
-  recentWrongCount?: number;
+  /** 全期間の誤答数 (weakest で「N 問中 M 問ミス」に使う、両方とも同じ窓=全期間) */
+  wrongCount: number;
   /** 最終レビュー (decaying に使う) */
   lastReview: Date | null;
 };
@@ -43,37 +43,26 @@ export async function fetchInsightsOverview(userId: string): Promise<InsightsOve
   const db = getDb();
   const now = new Date();
 
-  // concepts × mastery を user 軸で LEFT JOIN して 1 行 1 concept に正規化
+  // concepts / mastery / attempts を user 軸でメモリ上 join (3 クエリを JS 側で合成)。
   const conceptRows: Concept[] = await db.select().from(concepts);
   const masteryRows: Mastery[] = await db.select().from(mastery).where(eq(mastery.userId, userId));
 
-  // attempts の concept 別カウント (全期間)
+  // attempts の concept 別カウント (全期間の total と wrong を一括集計)
+  // weakest 表示 (「N 問中 M 問ミス」) が同じ時間窓になるよう attemptCount と wrongCount は
+  // どちらも「全期間」で揃える (Round 1 指摘: 時間窓混在を避ける)。
   const attemptCountRows = await db
     .select({
       conceptId: attempts.conceptId,
       total: sql<number>`count(*)::int`.as("total"),
+      wrong: sql<number>`sum(case when ${attempts.correct} = false then 1 else 0 end)::int`.as(
+        "wrong",
+      ),
     })
     .from(attempts)
     .where(eq(attempts.userId, userId))
     .groupBy(attempts.conceptId);
   const attemptCountByConcept = new Map(attemptCountRows.map((r) => [r.conceptId, r.total]));
-
-  // 直近 20 件の誤答を concept 別に数える (weakest の「8 問中 5 問ミス」など)
-  const recentWrongRows = await db
-    .select({
-      conceptId: attempts.conceptId,
-      correct: attempts.correct,
-    })
-    .from(attempts)
-    .where(and(eq(attempts.userId, userId)))
-    .orderBy(desc(attempts.createdAt))
-    .limit(200);
-  const recentWrongByConcept = new Map<string, number>();
-  for (const r of recentWrongRows) {
-    if (r.correct === false) {
-      recentWrongByConcept.set(r.conceptId, (recentWrongByConcept.get(r.conceptId) ?? 0) + 1);
-    }
-  }
+  const wrongCountByConcept = new Map(attemptCountRows.map((r) => [r.conceptId, r.wrong ?? 0]));
 
   const masteryByConcept = new Map(masteryRows.map((m) => [m.conceptId, m]));
   const masteredIds = new Set(masteryRows.filter((m) => m.mastered).map((m) => m.conceptId));
@@ -87,34 +76,43 @@ export async function fetchInsightsOverview(userId: string): Promise<InsightsOve
       subdomainId: c.subdomainId,
       masteryPct: m?.masteryPct ?? 0,
       attemptCount: attemptCountByConcept.get(c.id) ?? 0,
-      recentWrongCount: recentWrongByConcept.get(c.id) ?? 0,
+      wrongCount: wrongCountByConcept.get(c.id) ?? 0,
       lastReview: m?.lastReview ?? null,
     };
   });
 
-  // Strongest: mastered=true または masteryPct 高い順に attempts 1 件以上の上位 3
+  // Strongest: attempts 1 件以上の concept を masteryPct 降順、同率なら conceptId で安定ソート
   const strongest = items
     .filter((i) => i.attemptCount > 0)
-    .sort((a, b) => b.masteryPct - a.masteryPct)
+    .sort((a, b) => b.masteryPct - a.masteryPct || a.conceptId.localeCompare(b.conceptId))
     .slice(0, TOP_N);
 
-  // Weakest: attempts >= 5 かつ masteryPct < 0.5 の中で masteryPct 昇順 (= 弱い順) 上位 3
+  // Weakest: attempts >= 5 かつ masteryPct < 0.5 の中で masteryPct 昇順 (= 弱い順) 上位 3。
+  // 同率は conceptId 昇順で安定化。
   const weakest = items
     .filter(
       (i) => i.attemptCount >= WEAKEST_MIN_ATTEMPTS && i.masteryPct < WEAKEST_MASTERY_THRESHOLD,
     )
-    .sort((a, b) => a.masteryPct - b.masteryPct)
+    .sort((a, b) => a.masteryPct - b.masteryPct || a.conceptId.localeCompare(b.conceptId))
     .slice(0, TOP_N);
 
-  // Blind spots: attempts=0 かつ prereqs 全て mastered (daily と同じ判定)
+  // Blind spots: attempts=0 かつ prereqs 全て mastered (daily と同じ判定)。
+  // domain → subdomain → id の順で安定ソートして表示の再現性を確保。
+  const conceptById = new Map(conceptRows.map((c) => [c.id, c]));
   const blindSpots = items
     .filter((i) => {
       if (i.attemptCount !== 0) return false;
-      const concept = conceptRows.find((c) => c.id === i.conceptId);
+      const concept = conceptById.get(i.conceptId);
       if (!concept) return false;
       const prereqs = concept.prereqs ?? [];
       return prereqs.length === 0 || prereqs.every((pid) => masteredIds.has(pid));
     })
+    .sort(
+      (a, b) =>
+        a.domainId.localeCompare(b.domainId) ||
+        a.subdomainId.localeCompare(b.subdomainId) ||
+        a.conceptId.localeCompare(b.conceptId),
+    )
     .slice(0, TOP_N);
 
   // Decaying: mastered=false かつ最終レビューが DECAYING_DAYS 日以上前

--- a/src/server/insights/overview.ts
+++ b/src/server/insights/overview.ts
@@ -116,7 +116,8 @@ export async function fetchInsightsOverview(userId: string): Promise<InsightsOve
     )
     .slice(0, TOP_N);
 
-  // Decaying: mastered=false かつ最終レビューが DECAYING_DAYS 日以上前
+  // Decaying: mastered=false かつ最終レビューが DECAYING_DAYS 日以上前。
+  // 古い順 (忘却進行度合いが大きい順)。同日の場合は conceptId で安定化 (Round 5 指摘)。
   const decaying = items
     .filter((i) => {
       if (!i.lastReview) return false;
@@ -125,10 +126,9 @@ export async function fetchInsightsOverview(userId: string): Promise<InsightsOve
       return days >= DECAYING_DAYS && i.masteryPct < 0.8;
     })
     .sort((a, b) => {
-      // 古い順 (忘却進行度合いが大きい順)
       const aDate = a.lastReview?.getTime() ?? 0;
       const bDate = b.lastReview?.getTime() ?? 0;
-      return aDate - bDate;
+      return aDate - bDate || a.conceptId.localeCompare(b.conceptId);
     })
     .slice(0, TOP_N);
 

--- a/src/server/insights/overview.ts
+++ b/src/server/insights/overview.ts
@@ -1,0 +1,145 @@
+import { and, desc, eq, sql } from "drizzle-orm";
+
+import { getDb } from "@/db/client";
+import { attempts, concepts, mastery, type Concept, type Mastery } from "@/db/schema";
+
+export type OverviewItem = {
+  conceptId: string;
+  conceptName: string;
+  domainId: string;
+  subdomainId: string;
+  masteryPct: number;
+  /** 関連 attempts 数 (weakest 表示で「○問中 ○問ミス」に使う) */
+  attemptCount: number;
+  /** 直近誤答数 (最終20件内) */
+  recentWrongCount?: number;
+  /** 最終レビュー (decaying に使う) */
+  lastReview: Date | null;
+};
+
+export type InsightsOverview = {
+  totalConcepts: number;
+  masteredConcepts: number;
+  masteryPct: number;
+  strongest: OverviewItem[];
+  weakest: OverviewItem[];
+  blindSpots: OverviewItem[];
+  decaying: OverviewItem[];
+};
+
+const TOP_N = 3;
+/** weakest 条件: 5 attempt 以上、masteryPct < 0.5 */
+const WEAKEST_MIN_ATTEMPTS = 5;
+const WEAKEST_MASTERY_THRESHOLD = 0.5;
+/** decaying 判定: 最終レビューが N 日以上前かつ mastered=false */
+const DECAYING_DAYS = 7;
+
+/**
+ * Insights Dashboard (`/insights`) の overview 集計 (issue #20, docs/05 §5.3)。
+ * 1 user の attempts × concepts × mastery を結合して、強み / 弱点 / 盲点 / 忘却中 の
+ * Top3 を数値だけで返す。Recharts などの可視化は Phase 5+ (issue #29, #33)。
+ */
+export async function fetchInsightsOverview(userId: string): Promise<InsightsOverview> {
+  const db = getDb();
+  const now = new Date();
+
+  // concepts × mastery を user 軸で LEFT JOIN して 1 行 1 concept に正規化
+  const conceptRows: Concept[] = await db.select().from(concepts);
+  const masteryRows: Mastery[] = await db.select().from(mastery).where(eq(mastery.userId, userId));
+
+  // attempts の concept 別カウント (全期間)
+  const attemptCountRows = await db
+    .select({
+      conceptId: attempts.conceptId,
+      total: sql<number>`count(*)::int`.as("total"),
+    })
+    .from(attempts)
+    .where(eq(attempts.userId, userId))
+    .groupBy(attempts.conceptId);
+  const attemptCountByConcept = new Map(attemptCountRows.map((r) => [r.conceptId, r.total]));
+
+  // 直近 20 件の誤答を concept 別に数える (weakest の「8 問中 5 問ミス」など)
+  const recentWrongRows = await db
+    .select({
+      conceptId: attempts.conceptId,
+      correct: attempts.correct,
+    })
+    .from(attempts)
+    .where(and(eq(attempts.userId, userId)))
+    .orderBy(desc(attempts.createdAt))
+    .limit(200);
+  const recentWrongByConcept = new Map<string, number>();
+  for (const r of recentWrongRows) {
+    if (r.correct === false) {
+      recentWrongByConcept.set(r.conceptId, (recentWrongByConcept.get(r.conceptId) ?? 0) + 1);
+    }
+  }
+
+  const masteryByConcept = new Map(masteryRows.map((m) => [m.conceptId, m]));
+  const masteredIds = new Set(masteryRows.filter((m) => m.mastered).map((m) => m.conceptId));
+
+  const items: OverviewItem[] = conceptRows.map((c) => {
+    const m = masteryByConcept.get(c.id);
+    return {
+      conceptId: c.id,
+      conceptName: c.name,
+      domainId: c.domainId,
+      subdomainId: c.subdomainId,
+      masteryPct: m?.masteryPct ?? 0,
+      attemptCount: attemptCountByConcept.get(c.id) ?? 0,
+      recentWrongCount: recentWrongByConcept.get(c.id) ?? 0,
+      lastReview: m?.lastReview ?? null,
+    };
+  });
+
+  // Strongest: mastered=true または masteryPct 高い順に attempts 1 件以上の上位 3
+  const strongest = items
+    .filter((i) => i.attemptCount > 0)
+    .sort((a, b) => b.masteryPct - a.masteryPct)
+    .slice(0, TOP_N);
+
+  // Weakest: attempts >= 5 かつ masteryPct < 0.5 の中で masteryPct 昇順 (= 弱い順) 上位 3
+  const weakest = items
+    .filter(
+      (i) => i.attemptCount >= WEAKEST_MIN_ATTEMPTS && i.masteryPct < WEAKEST_MASTERY_THRESHOLD,
+    )
+    .sort((a, b) => a.masteryPct - b.masteryPct)
+    .slice(0, TOP_N);
+
+  // Blind spots: attempts=0 かつ prereqs 全て mastered (daily と同じ判定)
+  const blindSpots = items
+    .filter((i) => {
+      if (i.attemptCount !== 0) return false;
+      const concept = conceptRows.find((c) => c.id === i.conceptId);
+      if (!concept) return false;
+      const prereqs = concept.prereqs ?? [];
+      return prereqs.length === 0 || prereqs.every((pid) => masteredIds.has(pid));
+    })
+    .slice(0, TOP_N);
+
+  // Decaying: mastered=false かつ最終レビューが DECAYING_DAYS 日以上前
+  const decaying = items
+    .filter((i) => {
+      if (!i.lastReview) return false;
+      if (i.attemptCount === 0) return false;
+      const days = (now.getTime() - i.lastReview.getTime()) / (1000 * 60 * 60 * 24);
+      return days >= DECAYING_DAYS && i.masteryPct < 0.8;
+    })
+    .sort((a, b) => {
+      // 古い順 (忘却進行度合いが大きい順)
+      const aDate = a.lastReview?.getTime() ?? 0;
+      const bDate = b.lastReview?.getTime() ?? 0;
+      return aDate - bDate;
+    })
+    .slice(0, TOP_N);
+
+  return {
+    totalConcepts: conceptRows.length,
+    masteredConcepts: masteredIds.size,
+    masteryPct: conceptRows.length > 0 ? masteredIds.size / conceptRows.length : 0,
+    strongest,
+    weakest,
+    blindSpots,
+    decaying,
+  };
+}

--- a/src/server/scheduler/blind-spot.ts
+++ b/src/server/scheduler/blind-spot.ts
@@ -1,0 +1,12 @@
+import type { Concept } from "@/db/schema";
+
+/**
+ * Blind spot 判定の共有ヘルパ。
+ * 「prereqs が空、または全ての prereq が masteredIds に含まれる」なら true。
+ * Daily Drill (scheduler/daily.ts) と Insights Overview (insights/overview.ts) の
+ * 両方で使い、定義がずれないようにする (issue #20 Round 3 指摘)。
+ */
+export function arePrereqsSatisfied(concept: Concept, masteredIds: Set<string>): boolean {
+  const prereqs = concept.prereqs ?? [];
+  return prereqs.length === 0 || prereqs.every((id) => masteredIds.has(id));
+}

--- a/src/server/scheduler/daily.ts
+++ b/src/server/scheduler/daily.ts
@@ -3,6 +3,8 @@ import { eq } from "drizzle-orm";
 import { getDb } from "@/db/client";
 import { concepts, mastery, type Concept, type Mastery } from "@/db/schema";
 
+import { arePrereqsSatisfied } from "./blind-spot";
+
 /**
  * Daily Drill 候補選定 (docs/06-architecture.md §6.4.2 の重み付け):
  *   score = overdueDays + lapseCount*2 + blindSpotBonus - masteryPct*3
@@ -118,9 +120,7 @@ export function rankDailyCandidates(params: {
         });
       }
     } else {
-      const prereqs = concept.prereqs ?? [];
-      const prereqsSatisfied = prereqs.length === 0 || prereqs.every((id) => masteredIds.has(id));
-      if (prereqsSatisfied) {
+      if (arePrereqsSatisfied(concept, masteredIds)) {
         blindSpots.push({
           concept,
           mastery: null,

--- a/src/server/trpc/routers/index.ts
+++ b/src/server/trpc/routers/index.ts
@@ -2,6 +2,7 @@ import { router } from "../init";
 import { attemptsRouter } from "./attempts";
 import { authRouter } from "./auth";
 import { customRouter } from "./custom";
+import { insightsRouter } from "./insights";
 import { pingRouter } from "./ping";
 import { questionsRouter } from "./questions";
 import { sessionRouter } from "./session";
@@ -11,6 +12,7 @@ export const appRouter = router({
   auth: authRouter,
   attempts: attemptsRouter,
   custom: customRouter,
+  insights: insightsRouter,
   questions: questionsRouter,
   session: sessionRouter,
 });

--- a/src/server/trpc/routers/insights.ts
+++ b/src/server/trpc/routers/insights.ts
@@ -7,7 +7,5 @@ export const insightsRouter = router({
    * Insights Dashboard の overview (issue #20, docs/05 §5.3)。
    * mastery 全体、top3 strongest / weakest / blindSpots / decaying を返す。
    */
-  overview: protectedProcedure.query(async ({ ctx }) => {
-    return await fetchInsightsOverview(ctx.user.id);
-  }),
+  overview: protectedProcedure.query(({ ctx }) => fetchInsightsOverview(ctx.user.id)),
 });

--- a/src/server/trpc/routers/insights.ts
+++ b/src/server/trpc/routers/insights.ts
@@ -1,0 +1,13 @@
+import { fetchInsightsOverview } from "@/server/insights/overview";
+
+import { protectedProcedure, router } from "../init";
+
+export const insightsRouter = router({
+  /**
+   * Insights Dashboard の overview (issue #20, docs/05 §5.3)。
+   * mastery 全体、top3 strongest / weakest / blindSpots / decaying を返す。
+   */
+  overview: protectedProcedure.query(async ({ ctx }) => {
+    return await fetchInsightsOverview(ctx.user.id);
+  }),
+});

--- a/src/server/trpc/routers/session.ts
+++ b/src/server/trpc/routers/session.ts
@@ -145,16 +145,20 @@ export const sessionRouter = router({
           message: "Custom Session MVP は concepts を 1 件のみ指定できます",
         });
       }
-      // concepts[0] と difficulty 両方が指定されていれば concept.difficultyLevels と
-      // 整合することを start 時点でチェック (session.next が後続で失敗するのを避ける)。
-      if (input.customSpec?.concepts?.[0] && input.customSpec.difficulty) {
+      // concepts[0] が指定されていれば常に concept の存在を確認する (Round 4 指摘 #1)。
+      // 不正/陳腐化した conceptId のリンクで空 session row が残るのを防ぐため、
+      // difficulty 未指定でも事前 loadConcept を通す。difficulty も指定されていれば
+      // concept.difficultyLevels との整合も同時にチェック。
+      if (input.customSpec?.concepts?.[0]) {
         const concept = await loadConcept(input.customSpec.concepts[0]);
-        const level = input.customSpec.difficulty.level;
-        if (!concept.difficultyLevels.includes(level)) {
-          throw new TRPCError({
-            code: "BAD_REQUEST",
-            message: `concept "${concept.id}" は difficulty=${level} をサポートしていません (対応: ${concept.difficultyLevels.join(", ")})`,
-          });
+        if (input.customSpec.difficulty) {
+          const level = input.customSpec.difficulty.level;
+          if (!concept.difficultyLevels.includes(level)) {
+            throw new TRPCError({
+              code: "BAD_REQUEST",
+              message: `concept "${concept.id}" は difficulty=${level} をサポートしていません (対応: ${concept.difficultyLevels.join(", ")})`,
+            });
+          }
         }
       }
       // constraints は MVP で生成プロンプトに反映されないため、該当フィールドがあれば reject


### PR DESCRIPTION
## Summary
- `insights.overview` tRPC: strongest / weakest / blindSpots / decaying の Top 3 + 全体 mastery
- `/insights` ルート + `InsightsOverviewScreen` (Recharts なし、ASCII プログレスバー)
- weakest = attempts>=5 & mastery<50%、blindSpots = 未着手 & prereqs mastered、decaying = 7 日以上レビューなし & mastery<80%
- unit test 5 ケース

closes #20