### PR TITLE
feat(insights): History 画面 + 基本フィルタ (#21)

### DIFF
--- a/src/app/insights/history/page.tsx
+++ b/src/app/insights/history/page.tsx
@@ -1,0 +1,18 @@
+import { redirect } from "next/navigation";
+
+import { HistoryScreen } from "@/features/insights/history-screen";
+import { getCurrentUser } from "@/server/auth/session";
+
+export const dynamic = "force-dynamic";
+
+export default async function InsightsHistoryPage() {
+  const user = await getCurrentUser();
+  if (!user) {
+    redirect("/login");
+  }
+  return (
+    <main className="flex min-h-screen flex-col items-center gap-6 p-8">
+      <HistoryScreen />
+    </main>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
+import { NuqsAdapter } from "nuqs/adapters/next/app";
 
 import { TrpcProvider } from "@/lib/trpc/react";
 
@@ -28,7 +29,9 @@ export default function RootLayout({
   return (
     <html lang="ja" className={`${geistSans.variable} ${geistMono.variable} h-full antialiased`}>
       <body className="flex min-h-full flex-col">
-        <TrpcProvider>{children}</TrpcProvider>
+        <NuqsAdapter>
+          <TrpcProvider>{children}</TrpcProvider>
+        </NuqsAdapter>
       </body>
     </html>
   );

--- a/src/features/insights/history-screen.tsx
+++ b/src/features/insights/history-screen.tsx
@@ -1,8 +1,10 @@
 "use client";
 
 import type { inferRouterOutputs } from "@trpc/server";
+import { ChevronDown, ChevronUp } from "lucide-react";
 import Link from "next/link";
 import { parseAsString, parseAsStringLiteral, useQueryState } from "nuqs";
+import { useState } from "react";
 
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
@@ -130,6 +132,7 @@ export function HistoryScreen() {
 }
 
 function HistoryRow({ item }: { item: HistoryItem }) {
+  const [expanded, setExpanded] = useState(false);
   const correctLabel =
     item.correct === true ? "○ 正解" : item.correct === false ? "× 不正解" : "判定なし";
   const correctClass =
@@ -139,8 +142,29 @@ function HistoryRow({ item }: { item: HistoryItem }) {
         ? "text-destructive"
         : "text-muted-foreground";
   const created = new Date(item.createdAt);
-  // 「類題を出す」は concept を絞った Custom Session へ
   const customHref = `/custom?conceptId=${encodeURIComponent(item.conceptId)}`;
+
+  async function copy() {
+    const text = [
+      `# 問題`,
+      item.questionPrompt,
+      "",
+      `# 模範解答`,
+      item.questionAnswer,
+      "",
+      `# あなたの回答`,
+      item.userAnswer ?? "(未回答)",
+      "",
+      `# 採点: ${correctLabel}${item.score !== null ? ` / ${item.score.toFixed(2)}` : ""}`,
+      item.feedback ?? "",
+    ].join("\n");
+    try {
+      await navigator.clipboard.writeText(text);
+    } catch {
+      // コピー失敗は無通知で
+    }
+  }
+
   return (
     <li className="border-border rounded-md border p-3 text-sm">
       <div className="flex items-baseline justify-between gap-2">
@@ -154,21 +178,50 @@ function HistoryRow({ item }: { item: HistoryItem }) {
         {item.domainId} / {item.subdomainId} ・ {item.conceptName} ・ {item.questionType} ・{" "}
         {item.difficulty}
       </div>
-      {item.userAnswer && (
-        <div className="bg-muted/40 mt-2 rounded p-2 text-xs">
-          <span className="text-muted-foreground">あなたの回答: </span>
-          <span>{item.userAnswer}</span>
+      {expanded && (
+        <div className="mt-2 space-y-2">
+          {item.userAnswer && (
+            <div className="bg-muted/40 rounded p-2 text-xs">
+              <div className="text-muted-foreground">あなたの回答:</div>
+              <div className="whitespace-pre-wrap">{item.userAnswer}</div>
+            </div>
+          )}
+          <div className="bg-muted/40 rounded p-2 text-xs">
+            <div className="text-muted-foreground">模範解答:</div>
+            <div className="whitespace-pre-wrap">{item.questionAnswer}</div>
+          </div>
+          {item.feedback && (
+            <div className="text-xs">
+              <span className="text-muted-foreground">フィードバック: </span>
+              <span>{item.feedback}</span>
+            </div>
+          )}
+          {item.score !== null && (
+            <div className="text-muted-foreground text-xs">
+              スコア: {item.score.toFixed(2)} / 1.00
+            </div>
+          )}
         </div>
       )}
-      {item.feedback && (
-        <div className="mt-1 text-xs">
-          <span className="text-muted-foreground">フィードバック: </span>
-          <span>{item.feedback}</span>
-        </div>
-      )}
-      <div className="mt-2">
+      <div className="mt-2 flex flex-wrap gap-2">
+        <Button
+          size="sm"
+          variant="outline"
+          onClick={() => setExpanded((v) => !v)}
+          aria-expanded={expanded}
+        >
+          {expanded ? (
+            <ChevronUp className="mr-1 h-3.5 w-3.5" />
+          ) : (
+            <ChevronDown className="mr-1 h-3.5 w-3.5" />
+          )}
+          {expanded ? "閉じる" : "詳細"}
+        </Button>
         <Button asChild variant="outline" size="sm">
           <Link href={customHref}>🎯 類題を出す</Link>
+        </Button>
+        <Button size="sm" variant="outline" onClick={() => void copy()}>
+          📋 コピー
         </Button>
       </div>
     </li>

--- a/src/features/insights/history-screen.tsx
+++ b/src/features/insights/history-screen.tsx
@@ -9,6 +9,7 @@ import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { DOMAIN_IDS, type DomainId } from "@/db/schema/_constants";
+import { buildCopyForLlm } from "@/lib/share/copy-for-llm";
 import { trpc } from "@/lib/trpc/react";
 
 import type { AppRouter } from "@/server/trpc/routers";
@@ -144,22 +145,35 @@ function HistoryRow({ item }: { item: HistoryItem }) {
   const created = new Date(item.createdAt);
   const customHref = `/custom?conceptId=${encodeURIComponent(item.conceptId)}`;
 
+  // drill 画面と同じ buildCopyForLlm を再利用して整形 (Codex Round 2 指摘: copy 重複)
   async function copy() {
-    const text = [
-      `# 問題`,
-      item.questionPrompt,
-      "",
-      `# 模範解答`,
-      item.questionAnswer,
-      "",
-      `# あなたの回答`,
-      item.userAnswer ?? "(未回答)",
-      "",
-      `# 採点: ${correctLabel}${item.score !== null ? ` / ${item.score.toFixed(2)}` : ""}`,
-      item.feedback ?? "",
-    ].join("\n");
+    const text = buildCopyForLlm({
+      question: {
+        prompt: item.questionPrompt,
+        answer: item.questionAnswer,
+        tags: [],
+        hint: null,
+        meta: {
+          domain: item.domainId,
+          subdomain: item.subdomainId,
+          conceptId: item.conceptId,
+          conceptName: item.conceptName,
+          difficulty: item.difficulty,
+        },
+      },
+      userAnswer: item.userAnswer ?? "",
+      grading: {
+        correct: item.correct,
+        score: item.score,
+        feedback: item.feedback,
+      },
+    });
     try {
-      await navigator.clipboard.writeText(text);
+      if (typeof navigator !== "undefined" && navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(text);
+      } else if (typeof navigator !== "undefined" && navigator.share) {
+        await navigator.share({ text });
+      }
     } catch {
       // コピー失敗は無通知で
     }

--- a/src/features/insights/history-screen.tsx
+++ b/src/features/insights/history-screen.tsx
@@ -1,0 +1,176 @@
+"use client";
+
+import type { inferRouterOutputs } from "@trpc/server";
+import Link from "next/link";
+import { parseAsString, parseAsStringLiteral, useQueryState } from "nuqs";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { DOMAIN_IDS, type DomainId } from "@/db/schema/_constants";
+import { trpc } from "@/lib/trpc/react";
+
+import type { AppRouter } from "@/server/trpc/routers";
+
+type HistoryItem = inferRouterOutputs<AppRouter>["insights"]["history"]["items"][number];
+
+const PERIOD_VALUES = ["all", "today", "week"] as const;
+const CORRECTNESS_VALUES = ["all", "correct", "wrong"] as const;
+
+/**
+ * History 画面 (issue #21, docs/05 §5.5)。
+ * nuqs で URL クエリと state を同期 (`?period=week&correctness=wrong&domain=network` 等)。
+ * 「もっと読み込む」で cursor pagination。
+ */
+export function HistoryScreen() {
+  const [period, setPeriod] = useQueryState(
+    "period",
+    parseAsStringLiteral(PERIOD_VALUES).withDefault("all"),
+  );
+  const [correctness, setCorrectness] = useQueryState(
+    "correctness",
+    parseAsStringLiteral(CORRECTNESS_VALUES).withDefault("all"),
+  );
+  const [domainRaw, setDomainRaw] = useQueryState("domain", parseAsString.withDefault(""));
+  const domain = DOMAIN_IDS.includes(domainRaw as DomainId) ? (domainRaw as DomainId) : "";
+
+  const query = trpc.insights.history.useInfiniteQuery(
+    {
+      period,
+      correctness,
+      domains: domain ? [domain] : undefined,
+      limit: 20,
+    },
+    {
+      getNextPageParam: (last) => last.nextCursor ?? undefined,
+    },
+  );
+
+  const items: HistoryItem[] = (query.data?.pages ?? []).flatMap((p) => p.items);
+
+  return (
+    <div className="w-full max-w-2xl space-y-4">
+      <Card>
+        <CardHeader>
+          <CardTitle>解答履歴</CardTitle>
+          <CardDescription>過去の attempt を時系列で閲覧。URL に状態が反映される。</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <div className="flex flex-wrap gap-2 text-sm">
+            <select
+              value={period}
+              onChange={(e) => void setPeriod(e.target.value as (typeof PERIOD_VALUES)[number])}
+              className="border-input bg-background rounded-md border px-2 py-1"
+            >
+              <option value="all">全期間</option>
+              <option value="today">今日</option>
+              <option value="week">今週</option>
+            </select>
+            <select
+              value={correctness}
+              onChange={(e) =>
+                void setCorrectness(e.target.value as (typeof CORRECTNESS_VALUES)[number])
+              }
+              className="border-input bg-background rounded-md border px-2 py-1"
+            >
+              <option value="all">正誤すべて</option>
+              <option value="correct">正解のみ</option>
+              <option value="wrong">誤答のみ</option>
+            </select>
+            <select
+              value={domain}
+              onChange={(e) => void setDomainRaw(e.target.value)}
+              className="border-input bg-background rounded-md border px-2 py-1"
+            >
+              <option value="">分野すべて</option>
+              {DOMAIN_IDS.map((d) => (
+                <option key={d} value={d}>
+                  {d}
+                </option>
+              ))}
+            </select>
+          </div>
+        </CardContent>
+      </Card>
+
+      {query.isLoading ? (
+        <Card>
+          <CardContent className="text-muted-foreground p-6 text-sm">読み込み中...</CardContent>
+        </Card>
+      ) : query.error ? (
+        <Card>
+          <CardContent className="text-destructive p-6 text-sm">{query.error.message}</CardContent>
+        </Card>
+      ) : items.length === 0 ? (
+        <Card>
+          <CardContent className="text-muted-foreground p-6 text-sm">
+            該当する履歴がありません。
+          </CardContent>
+        </Card>
+      ) : (
+        <ul className="space-y-2">
+          {items.map((item) => (
+            <HistoryRow key={item.attemptId} item={item} />
+          ))}
+        </ul>
+      )}
+
+      {query.hasNextPage && (
+        <div className="flex justify-center">
+          <Button
+            variant="outline"
+            onClick={() => void query.fetchNextPage()}
+            disabled={query.isFetchingNextPage}
+          >
+            {query.isFetchingNextPage ? "読み込み中..." : "もっと読み込む"}
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function HistoryRow({ item }: { item: HistoryItem }) {
+  const correctLabel =
+    item.correct === true ? "○ 正解" : item.correct === false ? "× 不正解" : "判定なし";
+  const correctClass =
+    item.correct === true
+      ? "text-emerald-600"
+      : item.correct === false
+        ? "text-destructive"
+        : "text-muted-foreground";
+  const created = new Date(item.createdAt);
+  // 「類題を出す」は concept を絞った Custom Session へ
+  const customHref = `/custom?conceptId=${encodeURIComponent(item.conceptId)}`;
+  return (
+    <li className="border-border rounded-md border p-3 text-sm">
+      <div className="flex items-baseline justify-between gap-2">
+        <span className="text-muted-foreground font-mono text-xs">
+          {created.toLocaleString("ja-JP")}
+        </span>
+        <span className={`font-medium ${correctClass}`}>{correctLabel}</span>
+      </div>
+      <div className="mt-1 whitespace-pre-wrap">{item.questionPrompt}</div>
+      <div className="text-muted-foreground mt-1 text-xs">
+        {item.domainId} / {item.subdomainId} ・ {item.conceptName} ・ {item.questionType} ・{" "}
+        {item.difficulty}
+      </div>
+      {item.userAnswer && (
+        <div className="bg-muted/40 mt-2 rounded p-2 text-xs">
+          <span className="text-muted-foreground">あなたの回答: </span>
+          <span>{item.userAnswer}</span>
+        </div>
+      )}
+      {item.feedback && (
+        <div className="mt-1 text-xs">
+          <span className="text-muted-foreground">フィードバック: </span>
+          <span>{item.feedback}</span>
+        </div>
+      )}
+      <div className="mt-2">
+        <Button asChild variant="outline" size="sm">
+          <Link href={customHref}>🎯 類題を出す</Link>
+        </Button>
+      </div>
+    </li>
+  );
+}

--- a/src/features/insights/history-screen.tsx
+++ b/src/features/insights/history-screen.tsx
@@ -17,7 +17,27 @@ import type { AppRouter } from "@/server/trpc/routers";
 type HistoryItem = inferRouterOutputs<AppRouter>["insights"]["history"]["items"][number];
 
 const PERIOD_VALUES = ["all", "today", "week"] as const;
-const CORRECTNESS_VALUES = ["all", "correct", "wrong"] as const;
+const CORRECTNESS_VALUES = ["all", "correct", "partial", "wrong"] as const;
+
+// 部分正解判定の閾値は server 側 history.ts と一致させる (docs/05 部分正解表示)
+const PARTIAL_MIN_SCORE = 0.3;
+const FULL_MIN_SCORE = 0.9;
+
+/** correct boolean と score から表示ラベルと色を決定 */
+function deriveStatus(
+  correct: boolean | null,
+  score: number | null,
+): { label: string; className: string } {
+  if (correct === null) return { label: "判定なし", className: "text-muted-foreground" };
+  if (correct === true && score !== null && score >= FULL_MIN_SCORE) {
+    return { label: "○ 正解", className: "text-emerald-600" };
+  }
+  if (correct === true) return { label: "◐ 合格", className: "text-emerald-600/80" };
+  if (score !== null && score >= PARTIAL_MIN_SCORE) {
+    return { label: "◐ 部分正解", className: "text-amber-600" };
+  }
+  return { label: "× 不正解", className: "text-destructive" };
+}
 
 /**
  * History 画面 (issue #21, docs/05 §5.5)。
@@ -76,7 +96,8 @@ export function HistoryScreen() {
               className="border-input bg-background rounded-md border px-2 py-1"
             >
               <option value="all">正誤すべて</option>
-              <option value="correct">正解のみ</option>
+              <option value="correct">正解のみ (score ≥ 0.9)</option>
+              <option value="partial">部分正解のみ</option>
               <option value="wrong">誤答のみ</option>
             </select>
             <select
@@ -134,14 +155,7 @@ export function HistoryScreen() {
 
 function HistoryRow({ item }: { item: HistoryItem }) {
   const [expanded, setExpanded] = useState(false);
-  const correctLabel =
-    item.correct === true ? "○ 正解" : item.correct === false ? "× 不正解" : "判定なし";
-  const correctClass =
-    item.correct === true
-      ? "text-emerald-600"
-      : item.correct === false
-        ? "text-destructive"
-        : "text-muted-foreground";
+  const { label: correctLabel, className: correctClass } = deriveStatus(item.correct, item.score);
   const created = new Date(item.createdAt);
   const customHref = `/custom?conceptId=${encodeURIComponent(item.conceptId)}`;
 

--- a/src/server/insights/history.test.ts
+++ b/src/server/insights/history.test.ts
@@ -1,0 +1,113 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { fetchHistory } from "./history";
+
+// DB クライアントをクエリ順序で stub する。history.ts の呼び出し順序:
+//   1. (domains 指定時) select({id}).from(concepts).where(inArray) → conceptIds
+//   2. select(...).from(attempts).innerJoin.innerJoin.where.orderBy.limit → attempts rows
+// drizzle chain を簡略化した promise-then stub。
+const queue: Array<() => unknown> = [];
+vi.mock("@/db/client", () => {
+  function makeBuilder(): unknown {
+    const b: Record<string, unknown> = {
+      from: () => b,
+      where: () => b,
+      orderBy: () => b,
+      limit: () => b,
+      innerJoin: () => b,
+      then: (onFulfilled: (v: unknown) => unknown) => {
+        const handler = queue.shift();
+        const result = handler ? handler() : [];
+        return Promise.resolve(result).then(onFulfilled);
+      },
+    };
+    return b;
+  }
+  return {
+    getDb: () => ({ select: () => makeBuilder() }),
+  };
+});
+
+beforeEach(() => {
+  queue.length = 0;
+});
+
+function mkRow(over: Partial<Record<string, unknown>> = {}) {
+  return {
+    attemptId: "a-1",
+    createdAt: new Date("2026-04-18T00:00:00Z"),
+    correct: true,
+    score: 1,
+    feedback: null,
+    userAnswer: "ans",
+    questionId: "q-1",
+    questionPrompt: "Q?",
+    questionAnswer: "A",
+    questionType: "mcq",
+    difficulty: "junior",
+    conceptId: "c-1",
+    conceptName: "C1",
+    domainId: "network",
+    subdomainId: "http",
+    ...over,
+  };
+}
+
+describe("fetchHistory", () => {
+  it("空結果: nextCursor=null, items=[]", async () => {
+    queue.push(() => []); // attempts 行
+    const out = await fetchHistory({ userId: "u-1" });
+    expect(out.items).toEqual([]);
+    expect(out.nextCursor).toBeNull();
+  });
+
+  it("limit+1 件返ったら nextCursor を設定", async () => {
+    const rows = Array.from({ length: 21 }).map((_, i) =>
+      mkRow({
+        attemptId: `a-${i}`,
+        createdAt: new Date(Date.UTC(2026, 3, 20 - Math.floor(i / 5), 0, 0, 0)),
+      }),
+    );
+    queue.push(() => rows);
+    const out = await fetchHistory({ userId: "u-1", filter: { limit: 20 } });
+    expect(out.items).toHaveLength(20);
+    expect(out.nextCursor).toBe(out.items[out.items.length - 1]!.createdAt.toISOString());
+  });
+
+  it("limit に満たなければ nextCursor=null", async () => {
+    queue.push(() => [mkRow()]);
+    const out = await fetchHistory({ userId: "u-1", filter: { limit: 20 } });
+    expect(out.items).toHaveLength(1);
+    expect(out.nextCursor).toBeNull();
+  });
+
+  it("domains フィルタ: 対象 concept が 0 件ならすぐ空配列 (早期 return)", async () => {
+    queue.push(() => []); // concepts where inArray 結果
+    const out = await fetchHistory({
+      userId: "u-1",
+      filter: { domains: ["network"] },
+    });
+    expect(out.items).toEqual([]);
+    expect(out.nextCursor).toBeNull();
+  });
+
+  it("domains フィルタ: concepts が返れば attempts を引く", async () => {
+    queue.push(() => [{ id: "c-1" }]); // conceptIds
+    queue.push(() => [mkRow()]); // attempts
+    const out = await fetchHistory({
+      userId: "u-1",
+      filter: { domains: ["network"] },
+    });
+    expect(out.items).toHaveLength(1);
+    expect(out.items[0]!.domainId).toBe("network");
+  });
+
+  it("不正な cursor は無視 (例外にせず結果を返す)", async () => {
+    queue.push(() => [mkRow()]);
+    const out = await fetchHistory({
+      userId: "u-1",
+      filter: { cursor: "not-a-date" },
+    });
+    expect(out.items).toHaveLength(1);
+  });
+});

--- a/src/server/insights/history.test.ts
+++ b/src/server/insights/history.test.ts
@@ -91,6 +91,35 @@ describe("fetchHistory", () => {
     expect(out2.items).toHaveLength(1);
   });
 
+  it("同一 createdAt が limit 境界をまたいでも取りこぼさない (Round 2 指摘)", async () => {
+    // 3 件が同時刻 + 1 件が古い時刻。limit=2 で 1 ページ目 2 件、2 ページ目 2 件。
+    const sameTime = new Date("2026-04-18T10:00:00Z");
+    const older = new Date("2026-04-18T09:00:00Z");
+    // 1 ページ目: (sameTime, a-3) / (sameTime, a-2) の 2 件 + 余剰 1 件 (sameTime, a-1)
+    // limit=2 の場合 select は limit+1=3 件を返す
+    queue.push(() => [
+      mkRow({ attemptId: "a-3", createdAt: sameTime }),
+      mkRow({ attemptId: "a-2", createdAt: sameTime }),
+      mkRow({ attemptId: "a-1", createdAt: sameTime }),
+    ]);
+    const p1 = await fetchHistory({ userId: "u-1", filter: { limit: 2 } });
+    expect(p1.items.map((i) => i.attemptId)).toEqual(["a-3", "a-2"]);
+    expect(p1.nextCursor).toBe(`${sameTime.toISOString()}|a-2`);
+
+    // 2 ページ目: cursor=(sameTime, a-2) 以降。a-1 が同秒残存、後は older の a-0
+    queue.push(() => [
+      mkRow({ attemptId: "a-1", createdAt: sameTime }),
+      mkRow({ attemptId: "a-0", createdAt: older }),
+    ]);
+    const p2 = await fetchHistory({
+      userId: "u-1",
+      filter: { limit: 2, cursor: p1.nextCursor! },
+    });
+    // limit=2 で 2 件返るがそれが全件なので nextCursor=null
+    expect(p2.items.map((i) => i.attemptId)).toEqual(["a-1", "a-0"]);
+    expect(p2.nextCursor).toBeNull();
+  });
+
   it("limit に満たなければ nextCursor=null", async () => {
     queue.push(() => [mkRow()]);
     const out = await fetchHistory({ userId: "u-1", filter: { limit: 20 } });

--- a/src/server/insights/history.test.ts
+++ b/src/server/insights/history.test.ts
@@ -61,7 +61,7 @@ describe("fetchHistory", () => {
     expect(out.nextCursor).toBeNull();
   });
 
-  it("limit+1 件返ったら nextCursor を設定", async () => {
+  it("limit+1 件返ったら nextCursor を複合キー形式で設定 (createdAt ISO | attemptId)", async () => {
     const rows = Array.from({ length: 21 }).map((_, i) =>
       mkRow({
         attemptId: `a-${i}`,
@@ -71,7 +71,24 @@ describe("fetchHistory", () => {
     queue.push(() => rows);
     const out = await fetchHistory({ userId: "u-1", filter: { limit: 20 } });
     expect(out.items).toHaveLength(20);
-    expect(out.nextCursor).toBe(out.items[out.items.length - 1]!.createdAt.toISOString());
+    const last = out.items[out.items.length - 1]!;
+    expect(out.nextCursor).toBe(`${last.createdAt.toISOString()}|${last.attemptId}`);
+  });
+
+  it("cursor 複合キー形式を受け付け、ISO 単独の旧形式との後方互換も保つ", async () => {
+    queue.push(() => [mkRow()]);
+    const out1 = await fetchHistory({
+      userId: "u-1",
+      filter: { cursor: "2026-04-18T00:00:00.000Z|a-99" },
+    });
+    expect(out1.items).toHaveLength(1);
+
+    queue.push(() => [mkRow()]);
+    const out2 = await fetchHistory({
+      userId: "u-1",
+      filter: { cursor: "2026-04-18T00:00:00.000Z" },
+    });
+    expect(out2.items).toHaveLength(1);
   });
 
   it("limit に満たなければ nextCursor=null", async () => {

--- a/src/server/insights/history.test.ts
+++ b/src/server/insights/history.test.ts
@@ -6,13 +6,22 @@ import { fetchHistory } from "./history";
 //   1. (domains 指定時) select({id}).from(concepts).where(inArray) → conceptIds
 //   2. select(...).from(attempts).innerJoin.innerJoin.where.orderBy.limit → attempts rows
 // drizzle chain を簡略化した promise-then stub。
+// spy: where / orderBy に渡された式を capture して後段 assert できるようにする。
 const queue: Array<() => unknown> = [];
+const whereSpy = vi.fn();
+const orderBySpy = vi.fn();
 vi.mock("@/db/client", () => {
   function makeBuilder(): unknown {
     const b: Record<string, unknown> = {
       from: () => b,
-      where: () => b,
-      orderBy: () => b,
+      where: (...args: unknown[]) => {
+        whereSpy(...args);
+        return b;
+      },
+      orderBy: (...args: unknown[]) => {
+        orderBySpy(...args);
+        return b;
+      },
       limit: () => b,
       innerJoin: () => b,
       then: (onFulfilled: (v: unknown) => unknown) => {
@@ -30,6 +39,8 @@ vi.mock("@/db/client", () => {
 
 beforeEach(() => {
   queue.length = 0;
+  whereSpy.mockClear();
+  orderBySpy.mockClear();
 });
 
 function mkRow(over: Partial<Record<string, unknown>> = {}) {
@@ -89,6 +100,21 @@ describe("fetchHistory", () => {
       filter: { cursor: "2026-04-18T00:00:00.000Z" },
     });
     expect(out2.items).toHaveLength(1);
+  });
+
+  it("orderBy は (createdAt DESC, attemptId DESC) の 2 引数で呼ばれる (Round 3 spy 検証)", async () => {
+    queue.push(() => []);
+    await fetchHistory({ userId: "u-1" });
+    expect(orderBySpy).toHaveBeenCalledTimes(1);
+    expect(orderBySpy.mock.calls[0]).toHaveLength(2);
+  });
+
+  it("where は必ず呼ばれて predicate が注入されている (user_id フィルタの回帰防止)", async () => {
+    queue.push(() => []);
+    await fetchHistory({ userId: "u-1" });
+    expect(whereSpy).toHaveBeenCalled();
+    const arg = whereSpy.mock.calls[0]?.[0];
+    expect(arg).toBeDefined();
   });
 
   it("同一 createdAt が limit 境界をまたいでも取りこぼさない (Round 2 指摘)", async () => {

--- a/src/server/insights/history.ts
+++ b/src/server/insights/history.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, gte, inArray, lt, or, type SQL } from "drizzle-orm";
+import { and, desc, eq, gte, inArray, isNull, lt, or, type SQL } from "drizzle-orm";
 
 import { getDb } from "@/db/client";
 import { attempts, concepts, questions } from "@/db/schema";
@@ -7,14 +7,30 @@ import type { DomainId } from "@/db/schema/_constants";
 export type HistoryFilter = {
   /** 'all' | 'today' | 'week' */
   period?: "all" | "today" | "week";
-  /** 'all' | 'correct' | 'wrong' */
-  correctness?: "all" | "correct" | "wrong";
+  /** 'all' | 'correct' | 'partial' | 'wrong' */
+  correctness?: "all" | "correct" | "partial" | "wrong";
   /** 分野 (domain ID) でフィルタ */
   domains?: string[];
   /** カーソル (createdAt ISO 文字列)。この時刻より古い attempt を取得 */
   cursor?: string;
   limit?: number;
 };
+
+/** 部分正解の閾値: score >= PARTIAL_MIN & < FULL_MIN を「部分正解」とする */
+const PARTIAL_MIN_SCORE = 0.3;
+const FULL_MIN_SCORE = 0.9;
+
+/** Asia/Tokyo (JST, UTC+9) 固定で今日の 00:00 と直近 7 日境界を返す (MVP: 個人用 / 日本語 UI) */
+function jstPeriodBounds(now: Date = new Date()): { today: Date; weekAgo: Date } {
+  const nowJstMs = now.getTime() + 9 * 60 * 60 * 1000;
+  const dayMs = 24 * 60 * 60 * 1000;
+  const jstStartOfTodayMs = Math.floor(nowJstMs / dayMs) * dayMs;
+  const todayUtcMs = jstStartOfTodayMs - 9 * 60 * 60 * 1000;
+  return {
+    today: new Date(todayUtcMs),
+    weekAgo: new Date(todayUtcMs - 6 * dayMs),
+  };
+}
 
 export type HistoryItem = {
   attemptId: string;
@@ -59,22 +75,36 @@ export async function fetchHistory(params: {
 
   const preds: SQL[] = [eq(attempts.userId, params.userId)];
 
-  // 期間
+  // 期間は JST (Asia/Tokyo) 基準で「今日」と「今週 (直近 7 日 JST の 00:00 境界)」を算出
+  // (Round 3 指摘: サーバがローカルタイムで判定していた)。
   if (filter.period === "today") {
-    const startOfToday = new Date();
-    startOfToday.setHours(0, 0, 0, 0);
-    preds.push(gte(attempts.createdAt, startOfToday));
+    preds.push(gte(attempts.createdAt, jstPeriodBounds().today));
   } else if (filter.period === "week") {
-    const weekAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
-    preds.push(gte(attempts.createdAt, weekAgo));
+    preds.push(gte(attempts.createdAt, jstPeriodBounds().weekAgo));
   }
 
-  // 正誤
+  // 正誤: correct と score を組み合わせて correct / partial / wrong を判定 (Round 3 指摘)。
+  // - correct: score >= FULL_MIN_SCORE (= 0.9) かつ correct=true
+  // - partial: correct=true で score < FULL_MIN_SCORE、または correct=false で score >= PARTIAL_MIN_SCORE
+  // - wrong:   上記以外 (correct=false かつ score < PARTIAL_MIN_SCORE、または correct=false & score=null)
   if (filter.correctness === "correct") {
-    preds.push(eq(attempts.correct, true));
+    preds.push(and(eq(attempts.correct, true), gte(attempts.score, FULL_MIN_SCORE)) as SQL);
+  } else if (filter.correctness === "partial") {
+    preds.push(
+      or(
+        and(eq(attempts.correct, true), lt(attempts.score, FULL_MIN_SCORE)) as SQL,
+        and(eq(attempts.correct, false), gte(attempts.score, PARTIAL_MIN_SCORE)) as SQL,
+      ) as SQL,
+    );
   } else if (filter.correctness === "wrong") {
-    preds.push(eq(attempts.correct, false));
+    preds.push(
+      and(
+        eq(attempts.correct, false),
+        or(lt(attempts.score, PARTIAL_MIN_SCORE), isNull(attempts.score)) as SQL,
+      ) as SQL,
+    );
   }
+  // "all" および undefined は追加 predicate なし
 
   // 分野 (domain) は concepts.domainId で絞る。conceptId で attempts を絞り込むため、
   // 対象 domain の concept id を先に取得し、attempts.conceptId IN (...) で渡す。

--- a/src/server/insights/history.ts
+++ b/src/server/insights/history.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, gte, inArray, lt, type SQL } from "drizzle-orm";
+import { and, desc, eq, gte, inArray, lt, or, type SQL } from "drizzle-orm";
 
 import { getDb } from "@/db/client";
 import { attempts, concepts, questions } from "@/db/schema";
@@ -90,11 +90,23 @@ export async function fetchHistory(params: {
     preds.push(inArray(attempts.conceptId, ids));
   }
 
-  // cursor (createdAt)
+  // cursor: "{ISO}|{attemptId}" の複合キーで同秒 tie-break まで安定。
+  // 後方互換のため "{ISO}" 単独入力は従来通り (createdAt 未満) として扱う。
   if (filter.cursor) {
-    const cursorDate = new Date(filter.cursor);
-    if (!Number.isNaN(cursorDate.getTime())) {
-      preds.push(lt(attempts.createdAt, cursorDate));
+    const [cursorIso, cursorId] = filter.cursor.split("|");
+    const cursorDate = cursorIso ? new Date(cursorIso) : null;
+    if (cursorDate && !Number.isNaN(cursorDate.getTime())) {
+      if (cursorId) {
+        // createdAt < c OR (createdAt = c AND id < cursorId)
+        preds.push(
+          or(
+            lt(attempts.createdAt, cursorDate),
+            and(eq(attempts.createdAt, cursorDate), lt(attempts.id, cursorId)) as SQL,
+          ) as SQL,
+        );
+      } else {
+        preds.push(lt(attempts.createdAt, cursorDate));
+      }
     }
   }
 
@@ -120,12 +132,15 @@ export async function fetchHistory(params: {
     .innerJoin(questions, eq(attempts.questionId, questions.id))
     .innerJoin(concepts, eq(attempts.conceptId, concepts.id))
     .where(and(...preds))
-    .orderBy(desc(attempts.createdAt))
+    // createdAt 降順 + attemptId 降順の複合 sort で同秒 tie-break まで安定化。
+    .orderBy(desc(attempts.createdAt), desc(attempts.id))
     .limit(limit + 1);
 
   const hasMore = rows.length > limit;
   const items = rows.slice(0, limit);
-  const nextCursor = hasMore ? items[items.length - 1]!.createdAt.toISOString() : null;
+  // nextCursor は複合キー形式 "{ISO}|{attemptId}" で返し、次ページで正確に続きが取れるように。
+  const last = items[items.length - 1];
+  const nextCursor = hasMore && last ? `${last.createdAt.toISOString()}|${last.attemptId}` : null;
 
   return { items, nextCursor };
 }

--- a/src/server/insights/history.ts
+++ b/src/server/insights/history.ts
@@ -1,0 +1,131 @@
+import { and, desc, eq, gte, inArray, lt, type SQL } from "drizzle-orm";
+
+import { getDb } from "@/db/client";
+import { attempts, concepts, questions } from "@/db/schema";
+import type { DomainId } from "@/db/schema/_constants";
+
+export type HistoryFilter = {
+  /** 'all' | 'today' | 'week' */
+  period?: "all" | "today" | "week";
+  /** 'all' | 'correct' | 'wrong' */
+  correctness?: "all" | "correct" | "wrong";
+  /** 分野 (domain ID) でフィルタ */
+  domains?: string[];
+  /** カーソル (createdAt ISO 文字列)。この時刻より古い attempt を取得 */
+  cursor?: string;
+  limit?: number;
+};
+
+export type HistoryItem = {
+  attemptId: string;
+  createdAt: Date;
+  correct: boolean | null;
+  score: number | null;
+  feedback: string | null;
+  questionId: string;
+  questionPrompt: string;
+  questionAnswer: string;
+  userAnswer: string | null;
+  questionType: string;
+  difficulty: string;
+  conceptId: string;
+  conceptName: string;
+  domainId: string;
+  subdomainId: string;
+};
+
+export type HistoryResult = {
+  items: HistoryItem[];
+  /** 次ページがある場合、最後の attempt.createdAt ISO 文字列 */
+  nextCursor: string | null;
+};
+
+const DEFAULT_LIMIT = 20;
+const MAX_LIMIT = 100;
+
+/**
+ * History 画面 (issue #21, docs/05 §5.5) のデータ取得。
+ * attempt を時系列降順で取得し、cursor (createdAt) ベースで pagination。
+ * フィルタ: 期間 / 正誤 / 分野 (domain ID)。
+ *
+ * SQL injection 対策: 外部文字列は全て parametrized で投入 (drizzle の eq/gte/inArray は bind)。
+ */
+export async function fetchHistory(params: {
+  userId: string;
+  filter?: HistoryFilter;
+}): Promise<HistoryResult> {
+  const filter = params.filter ?? {};
+  const limit = Math.min(Math.max(filter.limit ?? DEFAULT_LIMIT, 1), MAX_LIMIT);
+
+  const preds: SQL[] = [eq(attempts.userId, params.userId)];
+
+  // 期間
+  if (filter.period === "today") {
+    const startOfToday = new Date();
+    startOfToday.setHours(0, 0, 0, 0);
+    preds.push(gte(attempts.createdAt, startOfToday));
+  } else if (filter.period === "week") {
+    const weekAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
+    preds.push(gte(attempts.createdAt, weekAgo));
+  }
+
+  // 正誤
+  if (filter.correctness === "correct") {
+    preds.push(eq(attempts.correct, true));
+  } else if (filter.correctness === "wrong") {
+    preds.push(eq(attempts.correct, false));
+  }
+
+  // 分野 (domain) は concepts.domainId で絞る。conceptId で attempts を絞り込むため、
+  // 対象 domain の concept id を先に取得し、attempts.conceptId IN (...) で渡す。
+  if (filter.domains && filter.domains.length > 0) {
+    const conceptIds = await getDb()
+      .select({ id: concepts.id })
+      .from(concepts)
+      .where(inArray(concepts.domainId, filter.domains as DomainId[]));
+    const ids = conceptIds.map((r) => r.id);
+    if (ids.length === 0) {
+      return { items: [], nextCursor: null };
+    }
+    preds.push(inArray(attempts.conceptId, ids));
+  }
+
+  // cursor (createdAt)
+  if (filter.cursor) {
+    const cursorDate = new Date(filter.cursor);
+    if (!Number.isNaN(cursorDate.getTime())) {
+      preds.push(lt(attempts.createdAt, cursorDate));
+    }
+  }
+
+  const rows = await getDb()
+    .select({
+      attemptId: attempts.id,
+      createdAt: attempts.createdAt,
+      correct: attempts.correct,
+      score: attempts.score,
+      feedback: attempts.feedback,
+      userAnswer: attempts.userAnswer,
+      questionId: questions.id,
+      questionPrompt: questions.prompt,
+      questionAnswer: questions.answer,
+      questionType: questions.type,
+      difficulty: questions.difficulty,
+      conceptId: concepts.id,
+      conceptName: concepts.name,
+      domainId: concepts.domainId,
+      subdomainId: concepts.subdomainId,
+    })
+    .from(attempts)
+    .innerJoin(questions, eq(attempts.questionId, questions.id))
+    .innerJoin(concepts, eq(attempts.conceptId, concepts.id))
+    .where(and(...preds))
+    .orderBy(desc(attempts.createdAt))
+    .limit(limit + 1);
+
+  const hasMore = rows.length > limit;
+  const items = rows.slice(0, limit);
+  const nextCursor = hasMore ? items[items.length - 1]!.createdAt.toISOString() : null;
+
+  return { items, nextCursor };
+}

--- a/src/server/trpc/routers/insights.ts
+++ b/src/server/trpc/routers/insights.ts
@@ -1,3 +1,7 @@
+import { z } from "zod";
+
+import { DOMAIN_IDS } from "@/db/schema/_constants";
+import { fetchHistory } from "@/server/insights/history";
 import { fetchInsightsOverview } from "@/server/insights/overview";
 
 import { protectedProcedure, router } from "../init";
@@ -8,4 +12,20 @@ export const insightsRouter = router({
    * mastery 全体、top3 strongest / weakest / blindSpots / decaying を返す。
    */
   overview: protectedProcedure.query(({ ctx }) => fetchInsightsOverview(ctx.user.id)),
+
+  /**
+   * History 画面 (issue #21, docs/05 §5.5)。
+   * cursor ベース pagination。フィルタは分野 / 正誤 / 期間。
+   */
+  history: protectedProcedure
+    .input(
+      z.object({
+        period: z.enum(["all", "today", "week"]).optional(),
+        correctness: z.enum(["all", "correct", "wrong"]).optional(),
+        domains: z.array(z.enum(DOMAIN_IDS)).optional(),
+        cursor: z.string().optional(),
+        limit: z.number().int().min(1).max(100).optional(),
+      }),
+    )
+    .query(({ ctx, input }) => fetchHistory({ userId: ctx.user.id, filter: input })),
 });

--- a/src/server/trpc/routers/insights.ts
+++ b/src/server/trpc/routers/insights.ts
@@ -21,7 +21,7 @@ export const insightsRouter = router({
     .input(
       z.object({
         period: z.enum(["all", "today", "week"]).optional(),
-        correctness: z.enum(["all", "correct", "wrong"]).optional(),
+        correctness: z.enum(["all", "correct", "partial", "wrong"]).optional(),
         domains: z.array(z.enum(DOMAIN_IDS)).optional(),
         cursor: z.string().optional(),
         limit: z.number().int().min(1).max(100).optional(),


### PR DESCRIPTION
## Summary
- `insights.history` tRPC: cursor pagination、filter (period/correctness/domains)
- `/insights/history` + `HistoryScreen`
- nuqs で URL クエリ同期 (NuqsAdapter を layout に追加)
- 各 attempt に「類題を出す」(`/custom?conceptId=...`) ボタン
- unit test: 6 ケース

closes #21