### PR TITLE
feat(search): 簡易全文検索 (LIKE) (#22)

### DIFF
--- a/docs/05-insights.md
+++ b/docs/05-insights.md
@@ -150,13 +150,19 @@
 
 ### 実装
 
-- **PostgreSQL `tsvector` + GIN index** + `pg_trgm` を併用 (日本語対応)
-- `attempts.search_tsv` は `STORED` generated column として自動更新
-- インデックス対象:
-  - `questions.prompt` (attempts JOIN 経由)
-  - `attempts.user_answer`
-  - `questions.explanation`
-  - `misconceptions.description`
+**MVP (issue #22)**: `ILIKE '%q%'` ベースで attempts (user_answer / feedback) /
+questions.prompt / misconceptions.description を横断検索。
+`src/server/insights/search.ts` に集約。SQL injection 対策は drizzle の
+`ilike()` / `eq()` による prepared statement bind で担保 (unit test あり)。
+
+**Phase 5+ (issue #30)**: `tsvector` + GIN index + `pg_trgm` を併用した本格チューニング。
+`attempts.search_tsv` (STORED generated column) は MVP では index として未使用だが
+将来移行時の枝として残してある。将来のインデックス対象:
+
+- `questions.prompt` (attempts JOIN 経由)
+- `attempts.user_answer`
+- `questions.explanation`
+- `misconceptions.description`
 
 ### UX
 

--- a/src/app/insights/search/page.tsx
+++ b/src/app/insights/search/page.tsx
@@ -1,0 +1,18 @@
+import { redirect } from "next/navigation";
+
+import { SearchScreen } from "@/features/insights/search-screen";
+import { getCurrentUser } from "@/server/auth/session";
+
+export const dynamic = "force-dynamic";
+
+export default async function InsightsSearchPage() {
+  const user = await getCurrentUser();
+  if (!user) {
+    redirect("/login");
+  }
+  return (
+    <main className="flex min-h-screen flex-col items-center gap-6 p-8">
+      <SearchScreen />
+    </main>
+  );
+}

--- a/src/features/insights/search-screen.tsx
+++ b/src/features/insights/search-screen.tsx
@@ -1,0 +1,158 @@
+"use client";
+
+import type { inferRouterOutputs } from "@trpc/server";
+import { Search as SearchIcon } from "lucide-react";
+import { parseAsString, useQueryState } from "nuqs";
+import { useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { trpc } from "@/lib/trpc/react";
+
+import type { AppRouter } from "@/server/trpc/routers";
+
+type Hit = inferRouterOutputs<AppRouter>["insights"]["search"]["hits"][number];
+
+const HIT_SOURCE_LABEL: Record<Hit["hitSource"], string> = {
+  question: "問題文",
+  userAnswer: "あなたの回答",
+  feedback: "フィードバック",
+  misconception: "誤概念",
+};
+
+/**
+ * 簡易全文検索 (issue #22, docs/05 §5.6)。
+ * nuqs で ?q=... を URL 同期。送信ボタンで初めて検索を走らせる (onChange 都度は重いので)。
+ */
+export function SearchScreen() {
+  const [q, setQ] = useQueryState("q", parseAsString.withDefault(""));
+  const [input, setInput] = useState(q ?? "");
+
+  const query = trpc.insights.search.useQuery(
+    { q: q ?? "", limit: 50 },
+    { enabled: (q ?? "").trim().length > 0 },
+  );
+
+  const onSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    void setQ(input.trim() || null);
+  };
+
+  return (
+    <div className="w-full max-w-2xl space-y-4">
+      <Card>
+        <CardHeader>
+          <CardTitle>検索</CardTitle>
+          <CardDescription>
+            過去の問題文 / 自分の回答 / フィードバック / 誤概念から部分一致検索。
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={onSubmit} className="flex flex-wrap gap-2">
+            <input
+              value={input}
+              onChange={(e) => setInput(e.target.value)}
+              placeholder="例: race condition"
+              className="border-input bg-background min-w-0 flex-1 rounded-md border px-2 py-1 text-sm"
+              maxLength={200}
+            />
+            <Button type="submit" size="sm">
+              <SearchIcon className="mr-1 h-3.5 w-3.5" />
+              検索
+            </Button>
+          </form>
+        </CardContent>
+      </Card>
+
+      {(q ?? "").trim().length === 0 ? (
+        <Card>
+          <CardContent className="text-muted-foreground p-6 text-sm">
+            検索語を入力してください。
+          </CardContent>
+        </Card>
+      ) : query.isLoading ? (
+        <Card>
+          <CardContent className="text-muted-foreground p-6 text-sm">検索中...</CardContent>
+        </Card>
+      ) : query.error ? (
+        <Card>
+          <CardContent className="text-destructive p-6 text-sm">{query.error.message}</CardContent>
+        </Card>
+      ) : query.data ? (
+        <>
+          <Card>
+            <CardHeader>
+              <CardTitle>Hit 集計 ({query.data.hits.length} 件)</CardTitle>
+            </CardHeader>
+            <CardContent>
+              {query.data.domainHits.length === 0 ? (
+                <div className="text-muted-foreground text-sm">該当なし。</div>
+              ) : (
+                <ul className="space-y-1 text-sm">
+                  {query.data.domainHits.map((d) => (
+                    <li key={d.domainId}>
+                      {d.domainId}: <span className="font-mono">{d.count}</span> 件
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </CardContent>
+          </Card>
+
+          {query.data.hits.length === 0 ? null : (
+            <ul className="space-y-2">
+              {query.data.hits.map((hit) => (
+                <HitRow key={hit.attemptId} hit={hit} q={q ?? ""} />
+              ))}
+            </ul>
+          )}
+        </>
+      ) : null}
+    </div>
+  );
+}
+
+function HitRow({ hit, q }: { hit: Hit; q: string }) {
+  const created = new Date(hit.createdAt);
+  return (
+    <li className="border-border rounded-md border p-3 text-sm">
+      <div className="flex items-baseline justify-between gap-2">
+        <span className="text-muted-foreground font-mono text-xs">
+          {created.toLocaleString("ja-JP")}
+        </span>
+        <span className="text-muted-foreground text-xs">{HIT_SOURCE_LABEL[hit.hitSource]}</span>
+      </div>
+      <div className="mt-1 whitespace-pre-wrap">
+        <Highlight text={hit.questionPrompt} q={q} />
+      </div>
+      <div className="text-muted-foreground mt-1 text-xs">
+        {hit.domainId} / {hit.subdomainId} ・ {hit.conceptName}
+      </div>
+      {hit.userAnswer && hit.hitSource === "userAnswer" && (
+        <div className="bg-muted/40 mt-2 rounded p-2 text-xs">
+          <Highlight text={hit.userAnswer} q={q} />
+        </div>
+      )}
+      {hit.feedback && hit.hitSource === "feedback" && (
+        <div className="bg-muted/40 mt-2 rounded p-2 text-xs">
+          <Highlight text={hit.feedback} q={q} />
+        </div>
+      )}
+    </li>
+  );
+}
+
+function Highlight({ text, q }: { text: string; q: string }) {
+  if (!q || !text) return <>{text}</>;
+  const lower = text.toLowerCase();
+  const qLower = q.toLowerCase();
+  const idx = lower.indexOf(qLower);
+  if (idx < 0) return <>{text}</>;
+  return (
+    <>
+      {text.slice(0, idx)}
+      <mark className="bg-yellow-200 dark:bg-yellow-900">{text.slice(idx, idx + q.length)}</mark>
+      {text.slice(idx + q.length)}
+    </>
+  );
+}

--- a/src/server/insights/search.bind.test.ts
+++ b/src/server/insights/search.bind.test.ts
@@ -1,0 +1,54 @@
+import { and, eq, ilike, or } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/neon-http";
+import { describe, expect, it } from "vitest";
+
+import { attempts, questions } from "@/db/schema";
+
+/**
+ * SQL injection 防御の「本物」テスト (Round 2 指摘 #2)。
+ *
+ * 実 DB には接続せず、drizzle builder の toSQL() を呼んで生成される SQL 文字列と
+ * params を検査する。ユーザー入力 (injection ペイロード) が SQL 文字列本体ではなく
+ * params 側 (bind parameter) に入ることを確認する。
+ *
+ * search.ts が `ilike(column, pattern)` / `eq(column, value)` を使っている限り、
+ * drizzle は値を bind し、SQL 文字列には `$1`, `$2` プレースホルダしか入らない。
+ */
+describe("search SQL bind 検証 (drizzle toSQL)", () => {
+  const db = drizzle.mock();
+
+  const INJECTION_PAYLOADS = [
+    "' OR 1=1 --",
+    "; DROP TABLE attempts --",
+    "admin' --",
+    "' UNION SELECT * FROM users --",
+    "%_\\injection",
+  ];
+
+  for (const payload of INJECTION_PAYLOADS) {
+    it(`payload=${JSON.stringify(payload)} は params 側に入り、SQL 本体には含まれない`, () => {
+      const escaped = payload.replace(/[\\%_]/g, (c) => `\\${c}`);
+      const pattern = `%${escaped}%`;
+      const built = db
+        .select()
+        .from(attempts)
+        .where(
+          and(
+            eq(attempts.userId, "u-1"),
+            or(
+              ilike(attempts.userAnswer, pattern),
+              ilike(attempts.feedback, pattern),
+              ilike(questions.prompt, pattern),
+            ),
+          ),
+        );
+      const { sql, params } = built.toSQL();
+
+      // SQL 本体はプレースホルダ (e.g. $1) で、payload 自体は含まれない
+      expect(sql).not.toContain(payload);
+      // payload は escape された形で params 側に含まれる
+      const paramAsStrings = params.map(String);
+      expect(paramAsStrings.some((p) => p.includes(escaped))).toBe(true);
+    });
+  }
+});

--- a/src/server/insights/search.test.ts
+++ b/src/server/insights/search.test.ts
@@ -47,9 +47,6 @@ function mkAttemptHit(over: Partial<Record<string, unknown>> = {}) {
     conceptName: "並行性",
     domainId: "os",
     subdomainId: "concurrency",
-    ua: "race condition を発見した",
-    fb: null,
-    qp: "並行性とは?",
     ...over,
   };
 }
@@ -89,26 +86,60 @@ describe("fetchSearch", () => {
 
   it("hitSource は userAnswer > feedback > question の優先順で判定", async () => {
     queue.push(() => [
-      mkAttemptHit({ ua: "race!!!", fb: null }), // userAnswer マッチ → "userAnswer"
-      mkAttemptHit({
-        attemptId: "a-2",
-        ua: null,
-        userAnswer: null,
-        fb: "race!!!",
-        feedback: "race!!!",
-      }), // feedback マッチ
-      mkAttemptHit({
-        attemptId: "a-3",
-        ua: null,
-        userAnswer: null,
-        fb: null,
-        feedback: null,
-      }), // question だけマッチ (fallback)
+      mkAttemptHit({ userAnswer: "race!!!", feedback: null }), // userAnswer マッチ
+      mkAttemptHit({ attemptId: "a-2", userAnswer: null, feedback: "race!!!" }), // feedback
+      mkAttemptHit({ attemptId: "a-3", userAnswer: null, feedback: null }), // question fallback
     ]);
     queue.push(() => []);
 
     const out = await fetchSearch({ userId: "u-1", q: "race" });
     expect(out.hits.map((h) => h.hitSource)).toEqual(["userAnswer", "feedback", "question"]);
+  });
+
+  it("SQL injection: ' OR 1=1 -- / ; DROP TABLE / -- コメントを含む q でも通常検索として処理 (受け入れ基準)", async () => {
+    const payloads = [
+      "' OR 1=1 --",
+      "; DROP TABLE attempts --",
+      "admin' --",
+      "\\'%\\_",
+      "' UNION SELECT * FROM users --",
+    ];
+    for (const payload of payloads) {
+      queue.length = 0;
+      queue.push(() => []); // attempts
+      queue.push(() => []); // misconceptions
+      // SQL injection が成功していたら DB がエラーを投げるか全件返るかだが、
+      // drizzle の ilike/eq は prepared statement で bind するため、q は常に値として扱われ、
+      // 文字列としてそのままパターンに組み込まれる。エラーなく完走することを確認する。
+      await expect(fetchSearch({ userId: "u-1", q: payload })).resolves.toBeDefined();
+    }
+  });
+
+  it("SQL injection: whereSpy に渡る式は literal 結合ではなく drizzle SQL オブジェクト", async () => {
+    queue.push(() => []);
+    queue.push(() => []);
+    await fetchSearch({ userId: "u-1", q: "' OR 1=1 --" });
+    // attempts と misconceptions で whereSpy が呼ばれ、引数はオブジェクト (非 string)
+    expect(whereSpy).toHaveBeenCalledTimes(2);
+    for (const call of whereSpy.mock.calls) {
+      const arg = call[0];
+      expect(arg).toBeDefined();
+      expect(typeof arg).not.toBe("string"); // literal SQL 文字列ではない = bind 済み drizzle 式
+    }
+  });
+
+  it("limit=50 のとき attempts+misconceptions マージ後も最大 50 件 (Round 1 指摘 #2)", async () => {
+    const attemptsRows = Array.from({ length: 50 }).map((_, i) =>
+      mkAttemptHit({ attemptId: `a-${i}`, createdAt: new Date(Date.UTC(2026, 3, 18, 0, i)) }),
+    );
+    const miscRows = Array.from({ length: 50 }).map((_, i) =>
+      mkMiscHit({ id: `m-${i}`, lastSeen: new Date(Date.UTC(2026, 3, 17, 0, i)) }),
+    );
+    queue.push(() => attemptsRows);
+    queue.push(() => miscRows);
+
+    const out = await fetchSearch({ userId: "u-1", q: "race", limit: 50 });
+    expect(out.hits.length).toBe(50);
   });
 
   it("domainHits: ドメインごとの件数を降順で集約", async () => {

--- a/src/server/insights/search.test.ts
+++ b/src/server/insights/search.test.ts
@@ -1,0 +1,128 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { fetchSearch } from "./search";
+
+// 2 クエリ (attempts 側 / misconceptions 側) 順に結果を返す stub。
+const queue: Array<() => unknown> = [];
+const whereSpy = vi.fn();
+vi.mock("@/db/client", () => {
+  function makeBuilder(): unknown {
+    const b: Record<string, unknown> = {
+      from: () => b,
+      where: (...args: unknown[]) => {
+        whereSpy(...args);
+        return b;
+      },
+      orderBy: () => b,
+      limit: () => b,
+      innerJoin: () => b,
+      then: (onFulfilled: (v: unknown) => unknown) => {
+        const handler = queue.shift();
+        const result = handler ? handler() : [];
+        return Promise.resolve(result).then(onFulfilled);
+      },
+    };
+    return b;
+  }
+  return {
+    getDb: () => ({ select: () => makeBuilder() }),
+  };
+});
+
+beforeEach(() => {
+  queue.length = 0;
+  whereSpy.mockClear();
+});
+
+function mkAttemptHit(over: Partial<Record<string, unknown>> = {}) {
+  return {
+    attemptId: "a-1",
+    createdAt: new Date("2026-04-18T00:00:00Z"),
+    userAnswer: "race condition を発見した",
+    feedback: null,
+    correct: true,
+    score: 1,
+    questionPrompt: "並行性とは?",
+    conceptId: "c-1",
+    conceptName: "並行性",
+    domainId: "os",
+    subdomainId: "concurrency",
+    ua: "race condition を発見した",
+    fb: null,
+    qp: "並行性とは?",
+    ...over,
+  };
+}
+
+function mkMiscHit(over: Partial<Record<string, unknown>> = {}) {
+  return {
+    id: "m-1",
+    description: "race condition は常に lock で解決できる",
+    conceptId: "c-1",
+    conceptName: "並行性",
+    domainId: "os",
+    subdomainId: "concurrency",
+    lastSeen: new Date("2026-04-17T00:00:00Z"),
+    ...over,
+  };
+}
+
+describe("fetchSearch", () => {
+  it("空クエリは即空配列 (DB 呼び出しなし)", async () => {
+    const out = await fetchSearch({ userId: "u-1", q: "   " });
+    expect(out.hits).toEqual([]);
+    expect(out.domainHits).toEqual([]);
+    expect(whereSpy).not.toHaveBeenCalled();
+  });
+
+  it("attempts と misconceptions の両方から hit を取得して時系列で集約", async () => {
+    queue.push(() => [mkAttemptHit()]); // attempts
+    queue.push(() => [mkMiscHit()]); // misconceptions
+
+    const out = await fetchSearch({ userId: "u-1", q: "race" });
+    expect(out.hits).toHaveLength(2);
+    // createdAt 降順: a-1 (2026-04-18) → m-1 (2026-04-17)
+    expect(out.hits[0]!.attemptId).toBe("a-1");
+    expect(out.hits[1]!.attemptId).toBe("misc-m-1");
+    expect(out.hits[1]!.hitSource).toBe("misconception");
+  });
+
+  it("hitSource は userAnswer > feedback > question の優先順で判定", async () => {
+    queue.push(() => [
+      mkAttemptHit({ ua: "race!!!", fb: null }), // userAnswer マッチ → "userAnswer"
+      mkAttemptHit({
+        attemptId: "a-2",
+        ua: null,
+        userAnswer: null,
+        fb: "race!!!",
+        feedback: "race!!!",
+      }), // feedback マッチ
+      mkAttemptHit({
+        attemptId: "a-3",
+        ua: null,
+        userAnswer: null,
+        fb: null,
+        feedback: null,
+      }), // question だけマッチ (fallback)
+    ]);
+    queue.push(() => []);
+
+    const out = await fetchSearch({ userId: "u-1", q: "race" });
+    expect(out.hits.map((h) => h.hitSource)).toEqual(["userAnswer", "feedback", "question"]);
+  });
+
+  it("domainHits: ドメインごとの件数を降順で集約", async () => {
+    queue.push(() => [
+      mkAttemptHit({ attemptId: "a-1", domainId: "os" }),
+      mkAttemptHit({ attemptId: "a-2", domainId: "os" }),
+      mkAttemptHit({ attemptId: "a-3", domainId: "network" }),
+    ]);
+    queue.push(() => []);
+
+    const out = await fetchSearch({ userId: "u-1", q: "race" });
+    expect(out.domainHits).toEqual([
+      { domainId: "os", count: 2 },
+      { domainId: "network", count: 1 },
+    ]);
+  });
+});

--- a/src/server/insights/search.ts
+++ b/src/server/insights/search.ts
@@ -43,7 +43,9 @@ export async function fetchSearch(params: {
   const pattern = `%${q}%`;
   const db = getDb();
 
-  // attempts.user_answer / attempts.feedback に部分一致したもの
+  // attempts と misconceptions の両方から最大 limit 件ずつ引き、マージ後にもう一度 limit で
+  // トリムする。片側 DB クエリに半分ずつ割り付けると「一方がほぼ空のときにもう一方を
+  // 活かしきれない」ため、取得段階では各 limit、最終段階で合算 limit。
   const attemptHits = await db
     .select({
       attemptId: attempts.id,
@@ -57,9 +59,6 @@ export async function fetchSearch(params: {
       conceptName: concepts.name,
       domainId: concepts.domainId,
       subdomainId: concepts.subdomainId,
-      ua: attempts.userAnswer,
-      fb: attempts.feedback,
-      qp: questions.prompt,
     })
     .from(attempts)
     .innerJoin(questions, eq(attempts.questionId, questions.id))
@@ -96,16 +95,16 @@ export async function fetchSearch(params: {
     .orderBy(desc(misconceptions.lastSeen))
     .limit(limit);
 
-  const hits: SearchResult["hits"] = [];
+  const merged: SearchResult["hits"] = [];
   for (const r of attemptHits) {
-    const matchedInUserAnswer = r.ua !== null && containsIgnoreCase(r.ua, q);
-    const matchedInFeedback = r.fb !== null && containsIgnoreCase(r.fb, q);
+    const matchedInUserAnswer = r.userAnswer !== null && containsIgnoreCase(r.userAnswer, q);
+    const matchedInFeedback = r.feedback !== null && containsIgnoreCase(r.feedback, q);
     const hitSource: SearchResult["hits"][number]["hitSource"] = matchedInUserAnswer
       ? "userAnswer"
       : matchedInFeedback
         ? "feedback"
         : "question";
-    hits.push({
+    merged.push({
       attemptId: r.attemptId,
       createdAt: r.createdAt,
       questionPrompt: r.questionPrompt,
@@ -122,7 +121,7 @@ export async function fetchSearch(params: {
   }
   for (const m of miscHits) {
     // misconception 由来の hit は attempt id を持たないため、疑似 id を "misc-{id}" で返す。
-    hits.push({
+    merged.push({
       attemptId: `misc-${m.id}`,
       createdAt: m.lastSeen,
       questionPrompt: m.description,
@@ -137,9 +136,12 @@ export async function fetchSearch(params: {
       hitSource: "misconception",
     });
   }
-  hits.sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
+  merged.sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
 
-  // ドメインごとの hit 集計
+  // 両側サブクエリに limit ずつ割り当てたので、マージ後に合算 limit で再トリム (Round 1 指摘 #2)。
+  const hits = merged.slice(0, limit);
+
+  // ドメインごとの hit 集計はトリム後の hits から計算 (UI 表示件数と一致させる)
   const byDomain = new Map<string, number>();
   for (const h of hits) {
     byDomain.set(h.domainId, (byDomain.get(h.domainId) ?? 0) + 1);

--- a/src/server/insights/search.ts
+++ b/src/server/insights/search.ts
@@ -40,7 +40,11 @@ export async function fetchSearch(params: {
   const q = params.q.trim();
   if (q.length === 0) return { hits: [], domainHits: [] };
   const limit = Math.min(Math.max(params.limit ?? 50, 1), 200);
-  const pattern = `%${q}%`;
+  // LIKE ワイルドカード文字 (% _ \\) を escape して「ユーザーの意図通りの部分一致」に揃える。
+  // hitSource 判定 (containsIgnoreCase) は literal includes なので、この escape により
+  // SQL 側 ILIKE と JS 判定の挙動が一致する (Round 2 指摘 #1 解消)。
+  const escaped = q.replace(/[\\%_]/g, (c) => `\\${c}`);
+  const pattern = `%${escaped}%`;
   const db = getDb();
 
   // attempts と misconceptions の両方から最大 limit 件ずつ引き、マージ後にもう一度 limit で

--- a/src/server/insights/search.ts
+++ b/src/server/insights/search.ts
@@ -1,0 +1,159 @@
+import { and, desc, eq, ilike, or, sql, type SQL } from "drizzle-orm";
+
+import { getDb } from "@/db/client";
+import { attempts, concepts, misconceptions, questions } from "@/db/schema";
+
+export type SearchResult = {
+  hits: Array<{
+    attemptId: string;
+    createdAt: Date;
+    questionPrompt: string;
+    userAnswer: string | null;
+    feedback: string | null;
+    correct: boolean | null;
+    score: number | null;
+    conceptId: string;
+    conceptName: string;
+    domainId: string;
+    subdomainId: string;
+    /** この行に実際に q がヒットした source。questions/attempts/misconceptions のどれか */
+    hitSource: "question" | "userAnswer" | "feedback" | "misconception";
+  }>;
+  /** ドメインごとの hit 集計 (受け入れ基準「検索結果にドメインごとの hit 集計」) */
+  domainHits: Array<{ domainId: string; count: number }>;
+};
+
+/**
+ * 簡易全文検索 (issue #22, docs/05 §5.6)。
+ * MVP では ILIKE '%q%' を attempts / questions / misconceptions に投げ、concept で集約する。
+ * pg_trgm / tsvector 本格チューニングは Phase 5+ (issue #30)。
+ *
+ * SQL injection 対策: drizzle の ilike() / eq() は prepared statement で bind されるため、
+ * 外部文字列 (q) はプレースホルダ経由で安全。`%` `_` などの LIKE ワイルドカード文字は
+ * エスケープしない (ユーザーの意図した部分一致を優先)。
+ */
+export async function fetchSearch(params: {
+  userId: string;
+  q: string;
+  limit?: number;
+}): Promise<SearchResult> {
+  const q = params.q.trim();
+  if (q.length === 0) return { hits: [], domainHits: [] };
+  const limit = Math.min(Math.max(params.limit ?? 50, 1), 200);
+  const pattern = `%${q}%`;
+  const db = getDb();
+
+  // attempts.user_answer / attempts.feedback に部分一致したもの
+  const attemptHits = await db
+    .select({
+      attemptId: attempts.id,
+      createdAt: attempts.createdAt,
+      userAnswer: attempts.userAnswer,
+      feedback: attempts.feedback,
+      correct: attempts.correct,
+      score: attempts.score,
+      questionPrompt: questions.prompt,
+      conceptId: concepts.id,
+      conceptName: concepts.name,
+      domainId: concepts.domainId,
+      subdomainId: concepts.subdomainId,
+      ua: attempts.userAnswer,
+      fb: attempts.feedback,
+      qp: questions.prompt,
+    })
+    .from(attempts)
+    .innerJoin(questions, eq(attempts.questionId, questions.id))
+    .innerJoin(concepts, eq(attempts.conceptId, concepts.id))
+    .where(
+      and(
+        eq(attempts.userId, params.userId),
+        or(
+          ilike(attempts.userAnswer, pattern),
+          ilike(attempts.feedback, pattern),
+          ilike(questions.prompt, pattern),
+        ) as SQL,
+      ),
+    )
+    .orderBy(desc(attempts.createdAt))
+    .limit(limit);
+
+  // misconceptions.description に部分一致したもの (attempt は未紐付け)
+  const miscHits = await db
+    .select({
+      id: misconceptions.id,
+      description: misconceptions.description,
+      conceptId: concepts.id,
+      conceptName: concepts.name,
+      domainId: concepts.domainId,
+      subdomainId: concepts.subdomainId,
+      lastSeen: misconceptions.lastSeen,
+    })
+    .from(misconceptions)
+    .innerJoin(concepts, eq(misconceptions.conceptId, concepts.id))
+    .where(
+      and(eq(misconceptions.userId, params.userId), ilike(misconceptions.description, pattern)),
+    )
+    .orderBy(desc(misconceptions.lastSeen))
+    .limit(limit);
+
+  const hits: SearchResult["hits"] = [];
+  for (const r of attemptHits) {
+    const matchedInUserAnswer = r.ua !== null && containsIgnoreCase(r.ua, q);
+    const matchedInFeedback = r.fb !== null && containsIgnoreCase(r.fb, q);
+    const hitSource: SearchResult["hits"][number]["hitSource"] = matchedInUserAnswer
+      ? "userAnswer"
+      : matchedInFeedback
+        ? "feedback"
+        : "question";
+    hits.push({
+      attemptId: r.attemptId,
+      createdAt: r.createdAt,
+      questionPrompt: r.questionPrompt,
+      userAnswer: r.userAnswer,
+      feedback: r.feedback,
+      correct: r.correct,
+      score: r.score,
+      conceptId: r.conceptId,
+      conceptName: r.conceptName,
+      domainId: r.domainId,
+      subdomainId: r.subdomainId,
+      hitSource,
+    });
+  }
+  for (const m of miscHits) {
+    // misconception 由来の hit は attempt id を持たないため、疑似 id を "misc-{id}" で返す。
+    hits.push({
+      attemptId: `misc-${m.id}`,
+      createdAt: m.lastSeen,
+      questionPrompt: m.description,
+      userAnswer: null,
+      feedback: null,
+      correct: null,
+      score: null,
+      conceptId: m.conceptId,
+      conceptName: m.conceptName,
+      domainId: m.domainId,
+      subdomainId: m.subdomainId,
+      hitSource: "misconception",
+    });
+  }
+  hits.sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
+
+  // ドメインごとの hit 集計
+  const byDomain = new Map<string, number>();
+  for (const h of hits) {
+    byDomain.set(h.domainId, (byDomain.get(h.domainId) ?? 0) + 1);
+  }
+  const domainHits = Array.from(byDomain.entries())
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+    .map(([domainId, count]) => ({ domainId, count }));
+
+  return { hits, domainHits };
+}
+
+function containsIgnoreCase(text: string, q: string): boolean {
+  return text.toLowerCase().includes(q.toLowerCase());
+}
+
+/** 関連 SQL: `sql` は現在使っていないが将来 tsvector 移行 (#30) 時に再利用する想定で保持 */
+void sql;

--- a/src/server/trpc/routers/insights.ts
+++ b/src/server/trpc/routers/insights.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { DOMAIN_IDS } from "@/db/schema/_constants";
 import { fetchHistory } from "@/server/insights/history";
 import { fetchInsightsOverview } from "@/server/insights/overview";
+import { fetchSearch } from "@/server/insights/search";
 
 import { protectedProcedure, router } from "../init";
 
@@ -28,4 +29,22 @@ export const insightsRouter = router({
       }),
     )
     .query(({ ctx, input }) => fetchHistory({ userId: ctx.user.id, filter: input })),
+
+  /**
+   * 簡易全文検索 (issue #22, docs/05 §5.6)。
+   * ILIKE '%q%' ベース。tsvector 本格チューニングは Phase 5+ (issue #30)。
+   */
+  search: protectedProcedure
+    .input(
+      z.object({
+        q: z
+          .string()
+          .transform((s) => s.trim())
+          .pipe(z.string().min(1, "検索語を入力してください").max(200)),
+        limit: z.number().int().min(1).max(200).optional(),
+      }),
+    )
+    .query(({ ctx, input }) =>
+      fetchSearch({ userId: ctx.user.id, q: input.q, limit: input.limit }),
+    ),
 });


### PR DESCRIPTION
## Summary
- `insights.search` tRPC (ILIKE '%q%')
- attempts / questions / misconceptions に対する横断部分一致検索
- `/insights/search` + `SearchScreen` (nuqs で URL 同期、ハイライト、domainHits)
- unit test 4 ケース

pg_trgm / tsvector 本格チューニングは Phase 5+ (#30)。

closes #22