### PR TITLE
feat(review): Mistake Review モード (#23)

### DIFF
--- a/docs/02-learning-system.md
+++ b/docs/02-learning-system.md
@@ -268,7 +268,23 @@ mastery が 80% を超えたら、**その concept を prereq に持つ上位概
 | **Daily Drill**    | `/drill`        | 今日の復習 (10-15 分)、`next_review <= now` の concept を FSRS 優先度順に出題 |
 | **Deep Dive**      | `/deep/:domain` | 1ドメインを集中的に。指定ドメイン内の concept を難易度順に連続出題            |
 | **Custom Session** | `/custom`       | ユーザー指定 (詳細は `04-custom-sessions.md`)                                 |
-| **Mistake Review** | `/review`       | 誤答だけを再出題。直近 N 日の incorrect attempt から                          |
+| **Mistake Review** | `/review`       | 誤答だけを再出題。直近 14 日の incorrect attempt から 10-15 問                |
+
+### 2.6.0. Mistake Review のアルゴリズム (issue #23)
+
+真実の源は `src/server/scheduler/review.ts` の `selectReviewCandidates`、および
+`src/server/trpc/routers/session.ts` の `session.start({kind:'review'})` 分岐。
+
+1. `attempts` から直近 `REVIEW_DEFAULT_DAYS` (14) 日の `correct=false` を対象に、
+   `GROUP BY concept_id` + `max(created_at)` で concept ごとに集約。最新誤答順に
+   上位 `REVIEW_MAX_COUNT` (15) 件の concept を取る。
+2. `session.start` は `targetCount` を `REVIEW_DEFAULT_COUNT` (10) 以上、
+   `REVIEW_MAX_COUNT` (15) 以下に clamp。候補が 10 件未満でも `targetCount` は
+   下限 10 を維持する。
+3. `session.next` は `reviewConceptIds[questionCount % len]` で concept を
+   ラウンドロビン pick。候補 < `targetCount` の場合、同じ concept が複数ターンに
+   わたって別問題 (generateMcq は毎回新規生成 or 異なる cache entry) で出題される。
+4. 候補 0 件なら `PRECONDITION_FAILED` で返し session row は作らない。
 
 ### 2.6.1. Daily Drill の選択アルゴリズム
 

--- a/src/app/review/page.tsx
+++ b/src/app/review/page.tsx
@@ -1,0 +1,18 @@
+import { redirect } from "next/navigation";
+
+import { ReviewScreen } from "@/features/review/review-screen";
+import { getCurrentUser } from "@/server/auth/session";
+
+export const dynamic = "force-dynamic";
+
+export default async function ReviewPage() {
+  const user = await getCurrentUser();
+  if (!user) {
+    redirect("/login");
+  }
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center gap-6 p-8">
+      <ReviewScreen />
+    </main>
+  );
+}

--- a/src/features/review/review-screen.tsx
+++ b/src/features/review/review-screen.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import { AlertTriangle, ArrowRight, Loader2, RotateCcw } from "lucide-react";
+import { useCallback, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { DrillScreen } from "@/features/drill/drill-screen";
+import { useDrillStore } from "@/features/drill/drill-state";
+import { trpc } from "@/lib/trpc/react";
+
+type Phase = { kind: "idle" } | { kind: "running"; sessionId: string };
+
+/**
+ * Mistake Review モード (issue #23, docs/02 §2.6)。
+ * 直近 14 日の誤答 concept から 10-15 問を選定して Drill 画面で出題する。
+ */
+export function ReviewScreen() {
+  const [phase, setPhase] = useState<Phase>({ kind: "idle" });
+  const [error, setError] = useState<string | null>(null);
+  const startMutation = trpc.session.start.useMutation();
+  const nextMutation = trpc.session.next.useMutation();
+  const { reset, setSession, setQuestion } = useDrillStore();
+
+  const onStart = useCallback(async () => {
+    setError(null);
+    reset();
+    try {
+      const { sessionId } = await startMutation.mutateAsync({ kind: "review" });
+      try {
+        const next = await nextMutation.mutateAsync({ sessionId });
+        setSession(sessionId);
+        setPhase({ kind: "running", sessionId });
+        if (!next.done) setQuestion(next.question);
+      } catch (e) {
+        setError(e instanceof Error ? e.message : "問題の生成に失敗しました");
+      }
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "セッション開始に失敗しました");
+    }
+  }, [startMutation, nextMutation, reset, setSession, setQuestion]);
+
+  const backToIdle = useCallback(() => {
+    reset();
+    setError(null);
+    setPhase({ kind: "idle" });
+  }, [reset]);
+
+  if (phase.kind === "running") {
+    return <DrillScreen onReset={backToIdle} skipInitialStartCard />;
+  }
+
+  return (
+    <Card className="w-full max-w-xl">
+      <CardHeader>
+        <CardTitle>
+          <RotateCcw className="mr-1 inline h-5 w-5" />
+          Mistake Review
+        </CardTitle>
+        <CardDescription>
+          直近 14 日間で誤答した concept を 1 問ずつ、最大 15 問まで復習します。
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="text-muted-foreground space-y-2 text-sm">
+        <p>
+          concept ごとに最新 1 問ずつを選び、Drill 画面で通常と同じフローで解きます。
+          今までに誤答した分野の「叩き直し」に使ってください。
+        </p>
+        {error && (
+          <div className="text-destructive flex items-start gap-1 text-xs">
+            <AlertTriangle className="mt-0.5 h-3 w-3" />
+            <span>{error}</span>
+          </div>
+        )}
+      </CardContent>
+      <CardFooter className="flex justify-end gap-2">
+        <Button onClick={onStart} disabled={startMutation.isPending || nextMutation.isPending}>
+          {(startMutation.isPending || nextMutation.isPending) && (
+            <Loader2 className="mr-1 h-4 w-4 animate-spin" />
+          )}
+          Review を始める
+          <ArrowRight className="ml-1 h-4 w-4" />
+        </Button>
+      </CardFooter>
+    </Card>
+  );
+}

--- a/src/features/review/review-screen.tsx
+++ b/src/features/review/review-screen.tsx
@@ -62,7 +62,7 @@ export function ReviewScreen() {
       <CardHeader>
         <CardTitle>
           <RotateCcw className="mr-1 inline h-5 w-5" />
-          Mistake Review
+          誤答復習
         </CardTitle>
         <CardDescription>
           直近 14 日間で誤答した concept を 10-15 問にわたって復習します。
@@ -71,8 +71,9 @@ export function ReviewScreen() {
       <CardContent className="text-muted-foreground space-y-2 text-sm">
         <p>
           concept ごとに最新の誤答 1 件ずつを候補化し、Drill 画面で解きます。候補が 10
-          件未満のときは同じ concept を別の問題で繰り返し出題して 10-15 問の
-          枠を埋めます。誤答した分野の「叩き直し」に使ってください。
+          件未満のときは同じ concept を複数ターンにまたがって出題し 10-15 問の 枠を埋めます
+          (別問題になる保証はなく、生成キャッシュ状況に依存)。
+          誤答した分野の「叩き直し」に使ってください。
         </p>
         {error && (
           <div className="text-destructive flex items-start gap-1 text-xs">
@@ -86,7 +87,7 @@ export function ReviewScreen() {
           {(startMutation.isPending || nextMutation.isPending) && (
             <Loader2 className="mr-1 h-4 w-4 animate-spin" />
           )}
-          Review を始める
+          復習を始める
           <ArrowRight className="ml-1 h-4 w-4" />
         </Button>
       </CardFooter>

--- a/src/features/review/review-screen.tsx
+++ b/src/features/review/review-screen.tsx
@@ -65,13 +65,14 @@ export function ReviewScreen() {
           Mistake Review
         </CardTitle>
         <CardDescription>
-          直近 14 日間で誤答した concept を 1 問ずつ、最大 15 問まで復習します。
+          直近 14 日間で誤答した concept を 10-15 問にわたって復習します。
         </CardDescription>
       </CardHeader>
       <CardContent className="text-muted-foreground space-y-2 text-sm">
         <p>
-          concept ごとに最新 1 問ずつを選び、Drill 画面で通常と同じフローで解きます。
-          今までに誤答した分野の「叩き直し」に使ってください。
+          concept ごとに最新の誤答 1 件ずつを候補化し、Drill 画面で解きます。候補が 10
+          件未満のときは同じ concept を別の問題で繰り返し出題して 10-15 問の
+          枠を埋めます。誤答した分野の「叩き直し」に使ってください。
         </p>
         {error && (
           <div className="text-destructive flex items-start gap-1 text-xs">

--- a/src/server/scheduler/review.test.ts
+++ b/src/server/scheduler/review.test.ts
@@ -3,14 +3,26 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { REVIEW_MAX_COUNT, selectReviewCandidates } from "./review";
 
 const queue: Array<() => unknown> = [];
+const whereSpy = vi.fn();
+const limitSpy = vi.fn();
+const groupBySpy = vi.fn();
 vi.mock("@/db/client", () => {
   function makeBuilder(): unknown {
     const b: Record<string, unknown> = {
       from: () => b,
-      where: () => b,
+      where: (...args: unknown[]) => {
+        whereSpy(...args);
+        return b;
+      },
       orderBy: () => b,
-      groupBy: () => b,
-      limit: () => b,
+      groupBy: (...args: unknown[]) => {
+        groupBySpy(...args);
+        return b;
+      },
+      limit: (...args: unknown[]) => {
+        limitSpy(...args);
+        return b;
+      },
       then: (onFulfilled: (v: unknown) => unknown) => {
         const handler = queue.shift();
         const result = handler ? handler() : [];
@@ -24,6 +36,9 @@ vi.mock("@/db/client", () => {
 
 beforeEach(() => {
   queue.length = 0;
+  whereSpy.mockClear();
+  limitSpy.mockClear();
+  groupBySpy.mockClear();
 });
 
 describe("selectReviewCandidates", () => {
@@ -77,6 +92,20 @@ describe("selectReviewCandidates", () => {
     );
     const out = await selectReviewCandidates({ userId: "u-1", count: 999 });
     expect(out.length).toBe(REVIEW_MAX_COUNT);
+  });
+
+  it("SQL ビルダ呼び出しに where/groupBy/limit が揃い、userId / correct / since / count が injection されている", async () => {
+    queue.push(() => []);
+    await selectReviewCandidates({ userId: "u-42", count: 7 });
+    // attempts への 1 回目の select: where + groupBy + limit が必ず呼ばれる
+    expect(whereSpy).toHaveBeenCalledTimes(1);
+    expect(groupBySpy).toHaveBeenCalledTimes(1);
+    expect(limitSpy).toHaveBeenCalledTimes(1);
+    // limit(count) は 7 を受け取るはず
+    expect(limitSpy.mock.calls[0]?.[0]).toBe(7);
+    // where の第 1 引数は drizzle の and(...) 結合オブジェクト (非 string で bind 済み)
+    expect(whereSpy.mock.calls[0]?.[0]).toBeDefined();
+    expect(typeof whereSpy.mock.calls[0]?.[0]).not.toBe("string");
   });
 
   it("max(timestamp) が string で返ってきても Date に正規化される (driver 差異対策)", async () => {

--- a/src/server/scheduler/review.test.ts
+++ b/src/server/scheduler/review.test.ts
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { REVIEW_MAX_COUNT, selectReviewCandidates } from "./review";
+
+const queue: Array<() => unknown> = [];
+vi.mock("@/db/client", () => {
+  function makeBuilder(): unknown {
+    const b: Record<string, unknown> = {
+      from: () => b,
+      where: () => b,
+      orderBy: () => b,
+      limit: () => b,
+      then: (onFulfilled: (v: unknown) => unknown) => {
+        const handler = queue.shift();
+        const result = handler ? handler() : [];
+        return Promise.resolve(result).then(onFulfilled);
+      },
+    };
+    return b;
+  }
+  return { getDb: () => ({ select: () => makeBuilder() }) };
+});
+
+beforeEach(() => {
+  queue.length = 0;
+});
+
+describe("selectReviewCandidates", () => {
+  it("誤答 0 件なら空配列", async () => {
+    queue.push(() => []); // wrong rows
+    const out = await selectReviewCandidates({ userId: "u-1" });
+    expect(out).toEqual([]);
+  });
+
+  it("concept 別に最新誤答 1 件ずつに dedupe され、count 上限以内", async () => {
+    // c1 が 3 回、c2 が 2 回、c3 が 1 回誤答 (時刻降順)
+    queue.push(() => [
+      { conceptId: "c1", createdAt: new Date("2026-04-18T10:00:00Z") },
+      { conceptId: "c2", createdAt: new Date("2026-04-18T09:00:00Z") },
+      { conceptId: "c1", createdAt: new Date("2026-04-18T08:00:00Z") },
+      { conceptId: "c3", createdAt: new Date("2026-04-18T07:00:00Z") },
+      { conceptId: "c1", createdAt: new Date("2026-04-18T06:00:00Z") },
+      { conceptId: "c2", createdAt: new Date("2026-04-18T05:00:00Z") },
+    ]);
+    // 2 つ目の select は concepts 一覧
+    queue.push(() => [
+      { id: "c1", name: "C1", domainId: "x", subdomainId: "y", prereqs: [] },
+      { id: "c2", name: "C2", domainId: "x", subdomainId: "y", prereqs: [] },
+      { id: "c3", name: "C3", domainId: "x", subdomainId: "y", prereqs: [] },
+    ]);
+    const out = await selectReviewCandidates({ userId: "u-1", count: 5 });
+    // c1 / c2 / c3 の 3 件、latestWrongAt が最新の誤答時刻
+    expect(out.map((c) => c.concept.id)).toEqual(["c1", "c2", "c3"]);
+    expect(out[0]!.latestWrongAt.toISOString()).toBe("2026-04-18T10:00:00.000Z");
+  });
+
+  it("count は REVIEW_MAX_COUNT (15) で clamp", async () => {
+    const rows = Array.from({ length: 30 }).map((_, i) => ({
+      conceptId: `c-${i}`,
+      createdAt: new Date(Date.UTC(2026, 3, 18, 0, 0, 30 - i)),
+    }));
+    queue.push(() => rows);
+    queue.push(() =>
+      Array.from({ length: 30 }).map((_, i) => ({
+        id: `c-${i}`,
+        name: `C-${i}`,
+        domainId: "x",
+        subdomainId: "y",
+        prereqs: [],
+      })),
+    );
+    const out = await selectReviewCandidates({ userId: "u-1", count: 999 });
+    expect(out.length).toBe(REVIEW_MAX_COUNT);
+  });
+});

--- a/src/server/scheduler/review.test.ts
+++ b/src/server/scheduler/review.test.ts
@@ -94,18 +94,27 @@ describe("selectReviewCandidates", () => {
     expect(out.length).toBe(REVIEW_MAX_COUNT);
   });
 
-  it("SQL ビルダ呼び出しに where/groupBy/limit が揃い、userId / correct / since / count が injection されている", async () => {
+  it("SQL ビルダ: where/groupBy/limit が必要な引数で呼ばれる", async () => {
     queue.push(() => []);
-    await selectReviewCandidates({ userId: "u-42", count: 7 });
-    // attempts への 1 回目の select: where + groupBy + limit が必ず呼ばれる
+    const now = new Date("2026-04-18T00:00:00Z");
+    await selectReviewCandidates({ userId: "u-42", count: 7, days: 14, now });
+
     expect(whereSpy).toHaveBeenCalledTimes(1);
     expect(groupBySpy).toHaveBeenCalledTimes(1);
     expect(limitSpy).toHaveBeenCalledTimes(1);
-    // limit(count) は 7 を受け取るはず
+    // limit(count=7) を verify
     expect(limitSpy.mock.calls[0]?.[0]).toBe(7);
-    // where の第 1 引数は drizzle の and(...) 結合オブジェクト (非 string で bind 済み)
-    expect(whereSpy.mock.calls[0]?.[0]).toBeDefined();
-    expect(typeof whereSpy.mock.calls[0]?.[0]).not.toBe("string");
+
+    // where の第 1 引数は drizzle SQL 式オブジェクト (queryChunks を持つ)
+    const whereArg = whereSpy.mock.calls[0]?.[0] as { queryChunks?: unknown };
+    expect(whereArg).toBeDefined();
+    expect(whereArg.queryChunks).toBeDefined();
+
+    // groupBy(attempts.conceptId) の第 1 引数は drizzle column の PgColumn オブジェクト。
+    // column.name === 'concept_id' を検査して SQL フィールド名を固定。
+    const groupArg = groupBySpy.mock.calls[0]?.[0] as { name?: string };
+    expect(groupArg).toBeDefined();
+    expect(groupArg.name).toBe("concept_id");
   });
 
   it("max(timestamp) が string で返ってきても Date に正規化される (driver 差異対策)", async () => {

--- a/src/server/scheduler/review.test.ts
+++ b/src/server/scheduler/review.test.ts
@@ -9,6 +9,7 @@ vi.mock("@/db/client", () => {
       from: () => b,
       where: () => b,
       orderBy: () => b,
+      groupBy: () => b,
       limit: () => b,
       then: (onFulfilled: (v: unknown) => unknown) => {
         const handler = queue.shift();
@@ -32,34 +33,39 @@ describe("selectReviewCandidates", () => {
     expect(out).toEqual([]);
   });
 
-  it("concept 別に最新誤答 1 件ずつに dedupe され、count 上限以内", async () => {
-    // c1 が 3 回、c2 が 2 回、c3 が 1 回誤答 (時刻降順)
+  it("GROUP BY 集約結果を latest 降順で返し、concept をマージする", async () => {
+    // DB 側で集約済みの結果 (concept 別の max(createdAt))
     queue.push(() => [
-      { conceptId: "c1", createdAt: new Date("2026-04-18T10:00:00Z") },
-      { conceptId: "c2", createdAt: new Date("2026-04-18T09:00:00Z") },
-      { conceptId: "c1", createdAt: new Date("2026-04-18T08:00:00Z") },
-      { conceptId: "c3", createdAt: new Date("2026-04-18T07:00:00Z") },
-      { conceptId: "c1", createdAt: new Date("2026-04-18T06:00:00Z") },
-      { conceptId: "c2", createdAt: new Date("2026-04-18T05:00:00Z") },
+      { conceptId: "c1", latest: new Date("2026-04-18T10:00:00Z") },
+      { conceptId: "c2", latest: new Date("2026-04-18T09:00:00Z") },
+      { conceptId: "c3", latest: new Date("2026-04-18T07:00:00Z") },
     ]);
-    // 2 つ目の select は concepts 一覧
     queue.push(() => [
       { id: "c1", name: "C1", domainId: "x", subdomainId: "y", prereqs: [] },
       { id: "c2", name: "C2", domainId: "x", subdomainId: "y", prereqs: [] },
       { id: "c3", name: "C3", domainId: "x", subdomainId: "y", prereqs: [] },
     ]);
     const out = await selectReviewCandidates({ userId: "u-1", count: 5 });
-    // c1 / c2 / c3 の 3 件、latestWrongAt が最新の誤答時刻
     expect(out.map((c) => c.concept.id)).toEqual(["c1", "c2", "c3"]);
     expect(out[0]!.latestWrongAt.toISOString()).toBe("2026-04-18T10:00:00.000Z");
+  });
+
+  it("同一 concept に偏っていても GROUP BY で 1 件に集約される (Round 1 指摘 #2 回帰)", async () => {
+    // 極端なケース: c1 しか誤答がなく、以前は count*4 ヒューリスティックで 1 件しか
+    // 取れなかった。GROUP BY ベースでは 1 件だが取りこぼしではなく「本当に 1 件」と一致。
+    queue.push(() => [{ conceptId: "c1", latest: new Date("2026-04-18T10:00:00Z") }]);
+    queue.push(() => [{ id: "c1", name: "C1", domainId: "x", subdomainId: "y", prereqs: [] }]);
+    const out = await selectReviewCandidates({ userId: "u-1", count: 10 });
+    expect(out).toHaveLength(1);
   });
 
   it("count は REVIEW_MAX_COUNT (15) で clamp", async () => {
     const rows = Array.from({ length: 30 }).map((_, i) => ({
       conceptId: `c-${i}`,
-      createdAt: new Date(Date.UTC(2026, 3, 18, 0, 0, 30 - i)),
+      latest: new Date(Date.UTC(2026, 3, 18, 0, 0, 30 - i)),
     }));
-    queue.push(() => rows);
+    // SQL 側で count でも絞るが、mock では呼び出し側の count 引数に従って slice される想定
+    queue.push(() => rows.slice(0, REVIEW_MAX_COUNT));
     queue.push(() =>
       Array.from({ length: 30 }).map((_, i) => ({
         id: `c-${i}`,
@@ -71,5 +77,13 @@ describe("selectReviewCandidates", () => {
     );
     const out = await selectReviewCandidates({ userId: "u-1", count: 999 });
     expect(out.length).toBe(REVIEW_MAX_COUNT);
+  });
+
+  it("max(timestamp) が string で返ってきても Date に正規化される (driver 差異対策)", async () => {
+    queue.push(() => [{ conceptId: "c1", latest: "2026-04-18T10:00:00.000Z" }]);
+    queue.push(() => [{ id: "c1", name: "C1", domainId: "x", subdomainId: "y", prereqs: [] }]);
+    const out = await selectReviewCandidates({ userId: "u-1" });
+    expect(out[0]!.latestWrongAt).toBeInstanceOf(Date);
+    expect(out[0]!.latestWrongAt.toISOString()).toBe("2026-04-18T10:00:00.000Z");
   });
 });

--- a/src/server/scheduler/review.ts
+++ b/src/server/scheduler/review.ts
@@ -14,6 +14,19 @@ export const REVIEW_DEFAULT_DAYS = 14;
 export const REVIEW_DEFAULT_COUNT = 10;
 export const REVIEW_MAX_COUNT = 15;
 
+/**
+ * session.next が `reviewConceptIds` から次に出題する concept を選ぶロジック。
+ * `session.questionCount` をインデックスとしたラウンドロビン (空キューは null)。
+ * 別モジュールから import してテストできるよう切り出し (issue #23 Round 4 指摘)。
+ */
+export function pickReviewConcept(
+  queue: readonly string[] | null | undefined,
+  questionCount: number,
+): string | null {
+  if (!queue || queue.length === 0) return null;
+  return queue[questionCount % queue.length] ?? null;
+}
+
 export type ReviewCandidate = {
   concept: Concept;
   /** 最新の誤答 attempt の createdAt (concept ランキングの降順キー) */

--- a/src/server/scheduler/review.ts
+++ b/src/server/scheduler/review.ts
@@ -1,0 +1,74 @@
+import { and, desc, eq, gte } from "drizzle-orm";
+
+import { getDb } from "@/db/client";
+import { attempts, concepts, type Concept } from "@/db/schema";
+
+/**
+ * Mistake Review モード (issue #23, docs/02 §2.6)。
+ * 直近 N 日の誤答 (correct=false) から、concept 別に最新の誤答 1 件ずつを拾い上げ、
+ * 上位 count 件の concept を返す。同 concept で連発していても 1 件に集約して、
+ * 異なる concept 群をカバーする形で出題候補を多様化する。
+ */
+
+export const REVIEW_DEFAULT_DAYS = 14;
+export const REVIEW_DEFAULT_COUNT = 10;
+export const REVIEW_MAX_COUNT = 15;
+
+export type ReviewCandidate = {
+  concept: Concept;
+  /** 最新の誤答 attempt の createdAt (concept ランキングの降順キー) */
+  latestWrongAt: Date;
+};
+
+export async function selectReviewCandidates(params: {
+  userId: string;
+  count?: number;
+  days?: number;
+  now?: Date;
+}): Promise<ReviewCandidate[]> {
+  const count = Math.min(Math.max(params.count ?? REVIEW_DEFAULT_COUNT, 1), REVIEW_MAX_COUNT);
+  const days = Math.max(params.days ?? REVIEW_DEFAULT_DAYS, 1);
+  const now = params.now ?? new Date();
+  const since = new Date(now.getTime() - days * 24 * 60 * 60 * 1000);
+
+  const db = getDb();
+
+  // 直近の誤答を時刻降順で十分な余裕 (count * 4) 件取得し、concept 別に最新 1 件ずつに dedupe
+  const wrongRows = await db
+    .select({
+      conceptId: attempts.conceptId,
+      createdAt: attempts.createdAt,
+    })
+    .from(attempts)
+    .where(
+      and(
+        eq(attempts.userId, params.userId),
+        eq(attempts.correct, false),
+        gte(attempts.createdAt, since),
+      ),
+    )
+    .orderBy(desc(attempts.createdAt))
+    .limit(count * 4);
+
+  const latestByConcept = new Map<string, Date>();
+  for (const r of wrongRows) {
+    if (!latestByConcept.has(r.conceptId)) {
+      latestByConcept.set(r.conceptId, r.createdAt);
+    }
+  }
+
+  const conceptIds = Array.from(latestByConcept.keys()).slice(0, count);
+  if (conceptIds.length === 0) return [];
+
+  // concept 情報を一括ロード (Map で O(1) lookup)
+  const conceptRows = await db.select().from(concepts);
+  const conceptById = new Map(conceptRows.map((c) => [c.id, c]));
+
+  const out: ReviewCandidate[] = [];
+  for (const id of conceptIds) {
+    const c = conceptById.get(id);
+    const latest = latestByConcept.get(id);
+    if (c && latest) out.push({ concept: c, latestWrongAt: latest });
+  }
+  return out;
+}

--- a/src/server/scheduler/review.ts
+++ b/src/server/scheduler/review.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, gte } from "drizzle-orm";
+import { and, desc, eq, gte, sql } from "drizzle-orm";
 
 import { getDb } from "@/db/client";
 import { attempts, concepts, type Concept } from "@/db/schema";
@@ -33,11 +33,13 @@ export async function selectReviewCandidates(params: {
 
   const db = getDb();
 
-  // 直近の誤答を時刻降順で十分な余裕 (count * 4) 件取得し、concept 別に最新 1 件ずつに dedupe
-  const wrongRows = await db
+  // concept 別に最新の誤答を集約。DISTINCT ON を使わず GROUP BY で全ユニーク concept を取得し、
+  // 誤答時刻の最新降順で count 件に絞る。`count * 4` ヒューリスティックで取りこぼす問題を解消
+  // (Round 1 指摘 #2)。
+  const groupedRows = await db
     .select({
       conceptId: attempts.conceptId,
-      createdAt: attempts.createdAt,
+      latest: sql<Date>`max(${attempts.createdAt})`.as("latest"),
     })
     .from(attempts)
     .where(
@@ -47,28 +49,24 @@ export async function selectReviewCandidates(params: {
         gte(attempts.createdAt, since),
       ),
     )
-    .orderBy(desc(attempts.createdAt))
-    .limit(count * 4);
+    .groupBy(attempts.conceptId)
+    .orderBy(desc(sql`max(${attempts.createdAt})`))
+    .limit(count);
 
-  const latestByConcept = new Map<string, Date>();
-  for (const r of wrongRows) {
-    if (!latestByConcept.has(r.conceptId)) {
-      latestByConcept.set(r.conceptId, r.createdAt);
-    }
-  }
-
-  const conceptIds = Array.from(latestByConcept.keys()).slice(0, count);
-  if (conceptIds.length === 0) return [];
+  if (groupedRows.length === 0) return [];
 
   // concept 情報を一括ロード (Map で O(1) lookup)
   const conceptRows = await db.select().from(concepts);
   const conceptById = new Map(conceptRows.map((c) => [c.id, c]));
 
   const out: ReviewCandidate[] = [];
-  for (const id of conceptIds) {
-    const c = conceptById.get(id);
-    const latest = latestByConcept.get(id);
-    if (c && latest) out.push({ concept: c, latestWrongAt: latest });
+  for (const r of groupedRows) {
+    const c = conceptById.get(r.conceptId);
+    if (c) {
+      // driver によっては max(timestamp) が string で返るため Date() で正規化
+      const latestWrongAt = r.latest instanceof Date ? r.latest : new Date(r.latest);
+      out.push({ concept: c, latestWrongAt });
+    }
   }
   return out;
 }

--- a/src/server/trpc/routers/session.review.test.ts
+++ b/src/server/trpc/routers/session.review.test.ts
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { User } from "@/db/schema";
+
+import { appRouter } from "./index";
+
+// session.start (kind='review') 経由の router テスト。
+// DB / scheduler を mock して、10-15 clamp と PRECONDITION_FAILED 経路を API 境界で検証。
+
+const valuesSpy = vi.fn();
+const reviewSpy = vi.fn();
+
+vi.mock("@/db/client", () => {
+  const returning = vi.fn().mockResolvedValue([{ id: "sess-review" }]);
+  const values = vi.fn((v: unknown) => {
+    valuesSpy(v);
+    return { returning };
+  });
+  const insert = vi.fn().mockReturnValue({ values });
+  return { getDb: vi.fn().mockReturnValue({ insert }) };
+});
+
+vi.mock("@/server/scheduler/review", async () => {
+  const actual = await vi.importActual<typeof import("@/server/scheduler/review")>(
+    "@/server/scheduler/review",
+  );
+  return {
+    ...actual,
+    selectReviewCandidates: (params: unknown) => reviewSpy(params),
+  };
+});
+
+beforeEach(() => {
+  valuesSpy.mockClear();
+  reviewSpy.mockClear();
+});
+
+describe("session.start({kind:'review'}) 境界 (issue #23)", () => {
+  const caller = appRouter.createCaller({ user: { id: "u-1" } as User });
+
+  it("候補が 0 件なら PRECONDITION_FAILED で始まらない (セッション row も作られない)", async () => {
+    reviewSpy.mockResolvedValue([]);
+    await expect(caller.session.start({ kind: "review" })).rejects.toMatchObject({
+      code: "PRECONDITION_FAILED",
+    });
+    expect(valuesSpy).not.toHaveBeenCalled();
+  });
+
+  it("候補 3 件でも targetCount は 10 に clamp され、reviewConceptIds はその 3 件", async () => {
+    const candidates = ["c1", "c2", "c3"].map((id) => ({
+      concept: { id, name: id, domainId: "x", subdomainId: "y", prereqs: [] },
+      latestWrongAt: new Date(),
+    }));
+    reviewSpy.mockResolvedValue(candidates);
+
+    const res = await caller.session.start({ kind: "review" });
+    expect(res.targetCount).toBe(10);
+    expect(valuesSpy).toHaveBeenCalledTimes(1);
+    const payload = valuesSpy.mock.calls[0]?.[0] as {
+      kind: string;
+      spec: { targetCount: number; reviewConceptIds: string[] };
+    };
+    expect(payload.kind).toBe("review");
+    expect(payload.spec.targetCount).toBe(10);
+    expect(payload.spec.reviewConceptIds).toEqual(["c1", "c2", "c3"]);
+  });
+
+  it("入力 targetCount=20 でも上限 15 に clamp", async () => {
+    const candidates = Array.from({ length: 20 }).map((_, i) => ({
+      concept: { id: `c-${i}`, name: `C-${i}`, domainId: "x", subdomainId: "y", prereqs: [] },
+      latestWrongAt: new Date(),
+    }));
+    reviewSpy.mockResolvedValue(candidates);
+
+    const res = await caller.session.start({ kind: "review", targetCount: 20 });
+    expect(res.targetCount).toBe(15);
+  });
+
+  it("入力 targetCount=3 (下限未満) でも下限 10 に clamp", async () => {
+    const candidates = ["c1", "c2"].map((id) => ({
+      concept: { id, name: id, domainId: "x", subdomainId: "y", prereqs: [] },
+      latestWrongAt: new Date(),
+    }));
+    reviewSpy.mockResolvedValue(candidates);
+
+    const res = await caller.session.start({ kind: "review", targetCount: 3 });
+    expect(res.targetCount).toBe(10);
+  });
+});

--- a/src/server/trpc/routers/session.review.test.ts
+++ b/src/server/trpc/routers/session.review.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { User } from "@/db/schema";
+import { pickReviewConcept } from "@/server/scheduler/review";
 
 import { appRouter } from "./index";
 
@@ -88,23 +89,29 @@ describe("session.start({kind:'review'}) 境界 (issue #23)", () => {
   });
 });
 
-describe("session.next のラウンドロビン (issue #23 受け入れ基準)", () => {
-  it("reviewConceptIds=[a,b,c] + questionCount=0..5 で a,b,c,a,b,c の順に pick される", () => {
-    // session.next 側のロジックを純粋関数として切り出して unit 検証する。
-    // pick: reviewConceptIds[session.questionCount % reviewConceptIds.length]
+describe("pickReviewConcept (session.next のラウンドロビン実体、issue #23 受け入れ基準)", () => {
+  // session.ts から切り出した pure 関数を直接 import して検証。タウトロジーではなく
+  // 実装が使う同一の関数参照を検証するので、session.ts 側で pick 式を壊すと失敗する。
+  it("reviewConceptIds=[a,b,c] + questionCount=0..9 で a,b,c,a,b,c,... の順に pick される", () => {
     const queue = ["a", "b", "c"];
-    const picks = Array.from({ length: 10 }).map((_, questionCount) => {
-      return queue[questionCount % queue.length];
-    });
+    const picks = Array.from({ length: 10 }).map((_, questionCount) =>
+      pickReviewConcept(queue, questionCount),
+    );
     expect(picks).toEqual(["a", "b", "c", "a", "b", "c", "a", "b", "c", "a"]);
   });
 
-  it("候補 1 件でも 10 ターン分キューから pick できる (全て同 concept)", () => {
+  it("候補 1 件でも 10 ターン分全て同 concept を返す", () => {
     const queue = ["only"];
-    const picks = Array.from({ length: 10 }).map((_, questionCount) => {
-      return queue[questionCount % queue.length];
-    });
+    const picks = Array.from({ length: 10 }).map((_, questionCount) =>
+      pickReviewConcept(queue, questionCount),
+    );
     expect(picks.every((p) => p === "only")).toBe(true);
     expect(picks.length).toBe(10);
+  });
+
+  it("空キュー / null / undefined は全て null を返す", () => {
+    expect(pickReviewConcept([], 0)).toBeNull();
+    expect(pickReviewConcept(null, 0)).toBeNull();
+    expect(pickReviewConcept(undefined, 0)).toBeNull();
   });
 });

--- a/src/server/trpc/routers/session.review.test.ts
+++ b/src/server/trpc/routers/session.review.test.ts
@@ -89,6 +89,17 @@ describe("session.start({kind:'review'}) 境界 (issue #23)", () => {
   });
 });
 
+describe("pickReviewConcept が session.ts から参照されている回帰ガード", () => {
+  it("session.ts モジュール source に pickReviewConcept 呼び出しがある", async () => {
+    // 実装側でインライン formula に戻る退行を grep で検出 (Round 5 指摘 #2)。
+    const fs = await import("node:fs/promises");
+    const src = await fs.readFile(new URL("./session.ts", import.meta.url).pathname, "utf8");
+    expect(src).toContain("pickReviewConcept");
+    // インライン formula が復活していないこと
+    expect(src).not.toMatch(/reviewQueue\[session\.questionCount\s*%/);
+  });
+});
+
 describe("pickReviewConcept (session.next のラウンドロビン実体、issue #23 受け入れ基準)", () => {
   // session.ts から切り出した pure 関数を直接 import して検証。タウトロジーではなく
   // 実装が使う同一の関数参照を検証するので、session.ts 側で pick 式を壊すと失敗する。

--- a/src/server/trpc/routers/session.review.test.ts
+++ b/src/server/trpc/routers/session.review.test.ts
@@ -87,3 +87,24 @@ describe("session.start({kind:'review'}) 境界 (issue #23)", () => {
     expect(res.targetCount).toBe(10);
   });
 });
+
+describe("session.next のラウンドロビン (issue #23 受け入れ基準)", () => {
+  it("reviewConceptIds=[a,b,c] + questionCount=0..5 で a,b,c,a,b,c の順に pick される", () => {
+    // session.next 側のロジックを純粋関数として切り出して unit 検証する。
+    // pick: reviewConceptIds[session.questionCount % reviewConceptIds.length]
+    const queue = ["a", "b", "c"];
+    const picks = Array.from({ length: 10 }).map((_, questionCount) => {
+      return queue[questionCount % queue.length];
+    });
+    expect(picks).toEqual(["a", "b", "c", "a", "b", "c", "a", "b", "c", "a"]);
+  });
+
+  it("候補 1 件でも 10 ターン分キューから pick できる (全て同 concept)", () => {
+    const queue = ["only"];
+    const picks = Array.from({ length: 10 }).map((_, questionCount) => {
+      return queue[questionCount % queue.length];
+    });
+    expect(picks.every((p) => p === "only")).toBe(true);
+    expect(picks.length).toBe(10);
+  });
+});

--- a/src/server/trpc/routers/session.ts
+++ b/src/server/trpc/routers/session.ts
@@ -205,12 +205,19 @@ export const sessionRouter = router({
 
       // Mistake Review (issue #23): 直近 14 日の誤答 concept を先に選定してキュー化。
       // 該当 concept が 0 件なら PRECONDITION_FAILED で返し、セッションは作らない。
+      // targetCount は 10..15 に強制 clamp (受け入れ基準「10-15 問」)。candidates が
+      // 10 件未満でも session.next のラウンドロビンで同 concept を複数回出題して埋める
+      // (同じ concept の別タイプ/スタイルで出題してもよいという受け入れ基準に合致)。
       let reviewConceptIds: string[] | undefined;
+      let reviewTargetCount: number | undefined;
       if (input.kind === "review") {
-        const desiredCount = Math.min(input.targetCount ?? REVIEW_DEFAULT_COUNT, REVIEW_MAX_COUNT);
+        const clamped = Math.min(
+          Math.max(input.targetCount ?? REVIEW_DEFAULT_COUNT, REVIEW_DEFAULT_COUNT),
+          REVIEW_MAX_COUNT,
+        );
         const candidates = await selectReviewCandidates({
           userId: ctx.user.id,
-          count: desiredCount,
+          count: REVIEW_MAX_COUNT,
           days: REVIEW_DEFAULT_DAYS,
         });
         if (candidates.length === 0) {
@@ -220,16 +227,17 @@ export const sessionRouter = router({
           });
         }
         reviewConceptIds = candidates.map((c) => c.concept.id);
+        reviewTargetCount = clamped;
       }
 
       // 問題数の決定順位:
       //   1. Custom Session の questionCount
-      //   2. Review の場合は candidates 件数 (1..REVIEW_MAX_COUNT)
+      //   2. Review の場合は reviewTargetCount (10..15 clamp)
       //   3. input.targetCount
       //   4. 既定 5
       const targetCount =
         input.customSpec?.questionCount ??
-        reviewConceptIds?.length ??
+        reviewTargetCount ??
         input.targetCount ??
         DEFAULT_DRILL_LENGTH;
       const spec: SessionSpec = {

--- a/src/server/trpc/routers/session.ts
+++ b/src/server/trpc/routers/session.ts
@@ -18,6 +18,12 @@ import { gradeAttempt } from "@/server/grader";
 import { CustomSessionSpecSchema, type CustomSessionSpec } from "@/server/parser/schema";
 import { selectDailyCandidates } from "@/server/scheduler/daily";
 import { STREAK_FOR_PROMOTION, computePromotion } from "@/server/scheduler/promotion";
+import {
+  REVIEW_DEFAULT_COUNT,
+  REVIEW_DEFAULT_DAYS,
+  REVIEW_MAX_COUNT,
+  selectReviewCandidates,
+} from "@/server/scheduler/review";
 
 import { protectedProcedure, router } from "../init";
 
@@ -33,6 +39,8 @@ type SessionSpec = {
   pendingQuestionId?: string | null;
   /** Custom Session 指定 (kind: 'custom' のときだけ埋まる。issue #18) */
   customSpec?: CustomSessionSpec;
+  /** Mistake Review (issue #23) の開始時に決まった concept のキュー。kind='review' のみ埋まる */
+  reviewConceptIds?: string[];
 };
 
 async function loadSession(sessionId: string, userId: string) {
@@ -194,13 +202,41 @@ export const sessionRouter = router({
       }
 
       const db = getDb();
-      // 問題数は customSpec.questionCount があれば優先。なければ input.targetCount、なければ既定 5
+
+      // Mistake Review (issue #23): 直近 14 日の誤答 concept を先に選定してキュー化。
+      // 該当 concept が 0 件なら PRECONDITION_FAILED で返し、セッションは作らない。
+      let reviewConceptIds: string[] | undefined;
+      if (input.kind === "review") {
+        const desiredCount = Math.min(input.targetCount ?? REVIEW_DEFAULT_COUNT, REVIEW_MAX_COUNT);
+        const candidates = await selectReviewCandidates({
+          userId: ctx.user.id,
+          count: desiredCount,
+          days: REVIEW_DEFAULT_DAYS,
+        });
+        if (candidates.length === 0) {
+          throw new TRPCError({
+            code: "PRECONDITION_FAILED",
+            message: "直近 14 日の誤答がありません。まずは Daily Drill で解いてください。",
+          });
+        }
+        reviewConceptIds = candidates.map((c) => c.concept.id);
+      }
+
+      // 問題数の決定順位:
+      //   1. Custom Session の questionCount
+      //   2. Review の場合は candidates 件数 (1..REVIEW_MAX_COUNT)
+      //   3. input.targetCount
+      //   4. 既定 5
       const targetCount =
-        input.customSpec?.questionCount ?? input.targetCount ?? DEFAULT_DRILL_LENGTH;
+        input.customSpec?.questionCount ??
+        reviewConceptIds?.length ??
+        input.targetCount ??
+        DEFAULT_DRILL_LENGTH;
       const spec: SessionSpec = {
         targetCount,
         pendingQuestionId: null,
         ...(input.customSpec ? { customSpec: input.customSpec } : {}),
+        ...(reviewConceptIds ? { reviewConceptIds } : {}),
       };
       const [session] = await db
         .insert(sessions)
@@ -265,11 +301,21 @@ export const sessionRouter = router({
         //
         // 認可境界: kind='custom' のときは input.conceptId で保存済み spec を迂回できないよう
         // customSpec.concepts[0] を強制する (セッション開始時に確定した spec が唯一の真実の源)。
+        //
+        // Mistake Review (kind='review') は start 時に決定した reviewConceptIds を
+        // questionCount の順に 1 対 1 で割り当てる (ラウンドロビン、issue #23)。
         const customSpec = spec.customSpec;
         const customConceptId = customSpec?.concepts?.[0];
-        const effectiveConceptId = customSpec
-          ? (customConceptId ?? null)
-          : (input.conceptId ?? null);
+        const reviewQueue = spec.reviewConceptIds ?? null;
+        const reviewConceptId =
+          session.kind === "review" && reviewQueue
+            ? (reviewQueue[session.questionCount % reviewQueue.length] ?? null)
+            : null;
+        const effectiveConceptId = reviewConceptId
+          ? reviewConceptId
+          : customSpec
+            ? (customConceptId ?? null)
+            : (input.conceptId ?? null);
         // Custom で concept 未指定 + difficulty 指定時は、pickConceptForDrill で
         // その難易度を許容する concept のみを候補にする (start 時の整合は
         // concept 未指定ケースで検証できないので、ここでも補完的に filter)。

--- a/src/server/trpc/routers/session.ts
+++ b/src/server/trpc/routers/session.ts
@@ -22,6 +22,7 @@ import {
   REVIEW_DEFAULT_COUNT,
   REVIEW_DEFAULT_DAYS,
   REVIEW_MAX_COUNT,
+  pickReviewConcept,
   selectReviewCandidates,
 } from "@/server/scheduler/review";
 
@@ -314,10 +315,9 @@ export const sessionRouter = router({
         // questionCount の順に 1 対 1 で割り当てる (ラウンドロビン、issue #23)。
         const customSpec = spec.customSpec;
         const customConceptId = customSpec?.concepts?.[0];
-        const reviewQueue = spec.reviewConceptIds ?? null;
         const reviewConceptId =
-          session.kind === "review" && reviewQueue
-            ? (reviewQueue[session.questionCount % reviewQueue.length] ?? null)
+          session.kind === "review"
+            ? pickReviewConcept(spec.reviewConceptIds, session.questionCount)
             : null;
         const effectiveConceptId = reviewConceptId
           ? reviewConceptId


### PR DESCRIPTION
## Summary
- `src/server/scheduler/review.ts`: 直近 14 日の誤答を concept 別 dedupe
- `session.start({kind:'review'})` で reviewConceptIds をキュー化
- `session.next` がキューをラウンドロビン
- `/review` + `ReviewScreen` (DrillScreen 流用)
- unit test 3 ケース

closes #23