### PR TITLE
feat(ui): モバイル UX 最終調整 (#25)

### DIFF
--- a/docs/06-architecture.md
+++ b/docs/06-architecture.md
@@ -540,7 +540,9 @@ Tanren/
 │   │   ├── insights/              # Dashboard / History / Search
 │   │   ├── review/                # Mistake Review 入口
 │   │   └── pwa/                   # Service Worker 登録 (issue #24)
-│   ├── components/ui/             # shadcn/ui
+│   ├── components/
+│   │   ├── ui/                    # shadcn/ui
+│   │   └── layout/                # BottomNav / AppShell (issue #25)
 │   └── lib/                       # 共通ユーティリティ
 │       ├── openai/                # OpenAI client / model 定数 (CLAUDE.md §4.6)
 │       ├── share/                 # copy-for-llm 整形

--- a/docs/07-ux-and-pwa.md
+++ b/docs/07-ux-and-pwa.md
@@ -370,8 +370,11 @@ Phase 5+ で実運用テスト (iOS で確実に届くか) をした上で導入
 
 ### 7.6.1. モバイル (〜 640px)
 
-- ボタン / 入力は画面下部
-- ナビは bottom tab bar
+- ボタン / 入力は画面下部 (CardFooter / 主要 CTA は最低 48px の高さ)
+- ナビは bottom tab bar (Home / Drill / Insights、`src/components/layout/bottom-nav.tsx`)
+- 没入画面 (`/drill`, `/custom`, `/review`, `/login`) では BottomNav を非表示にして
+  セッション中に意図せず別画面に飛ばないようにする (`AppShell` の `isNavHidden`)
+- セッション中は `beforeunload` で戻る/タブ閉じに警告 (DrillScreen `phase === asking|graded`)
 - 問題1つで画面埋まる
 
 ### 7.6.2. デスクトップ (1024px+)

--- a/docs/07-ux-and-pwa.md
+++ b/docs/07-ux-and-pwa.md
@@ -374,7 +374,11 @@ Phase 5+ で実運用テスト (iOS で確実に届くか) をした上で導入
 - ナビは bottom tab bar (Home / Drill / Insights、`src/components/layout/bottom-nav.tsx`)
 - 没入画面 (`/drill`, `/custom`, `/review`, `/login`) では BottomNav を非表示にして
   セッション中に意図せず別画面に飛ばないようにする (`AppShell` の `isNavHidden`)
-- セッション中は `beforeunload` で戻る/タブ閉じに警告 (DrillScreen `phase === asking|graded`)
+- セッション中は二段構えで戻る操作を guard:
+  - `beforeunload` — タブ閉じ / リロード / 外部ドメイン遷移 (ブラウザネイティブ確認)
+  - `popstate` + sentinel `pushState` — SPA 内の戻るジェスチャ (iOS edge swipe / Android back)。
+    `beforeunload` は SPA の popstate では発火しないため別経路で intercept する。
+  - 共に `phase === asking|graded` のときのみ有効。`finished | idle` ではブロックしない
 - 問題1つで画面埋まる
 
 ### 7.6.2. デスクトップ (1024px+)

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata, Viewport } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import { NuqsAdapter } from "nuqs/adapters/next/app";
 
+import { AppShell } from "@/components/layout/app-shell";
 import { RegisterServiceWorker } from "@/features/pwa/register-sw";
 import { TrpcProvider } from "@/lib/trpc/react";
 
@@ -51,7 +52,9 @@ export default function RootLayout({
       <body className="flex min-h-full flex-col">
         <RegisterServiceWorker />
         <NuqsAdapter>
-          <TrpcProvider>{children}</TrpcProvider>
+          <TrpcProvider>
+            <AppShell>{children}</AppShell>
+          </TrpcProvider>
         </NuqsAdapter>
       </body>
     </html>

--- a/src/components/layout/app-shell.tsx
+++ b/src/components/layout/app-shell.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+
+import { cn } from "@/lib/cn";
+
+import { BottomNav } from "./bottom-nav";
+import { isNavHidden } from "./nav-routes";
+
+export function AppShell({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname() ?? "/";
+  const navVisible = !isNavHidden(pathname);
+  return (
+    <>
+      <div className={cn("flex flex-1 flex-col", navVisible && "pb-16 md:pb-0")}>{children}</div>
+      {navVisible && <BottomNav />}
+    </>
+  );
+}

--- a/src/components/layout/bottom-nav.tsx
+++ b/src/components/layout/bottom-nav.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { BarChart3, Home, ListChecks } from "lucide-react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+import { cn } from "@/lib/cn";
+
+import { NAV_TABS, type NavTabId } from "./nav-routes";
+
+const ICONS: Record<NavTabId, typeof Home> = {
+  home: Home,
+  drill: ListChecks,
+  insights: BarChart3,
+};
+
+export function BottomNav() {
+  const pathname = usePathname() ?? "/";
+  return (
+    <nav
+      aria-label="主要ナビゲーション"
+      className="bg-background fixed inset-x-0 bottom-0 z-50 grid grid-cols-3 border-t md:hidden"
+    >
+      {NAV_TABS.map((tab) => {
+        const Icon = ICONS[tab.id];
+        const active = tab.matches(pathname);
+        return (
+          <Link
+            key={tab.id}
+            href={tab.href}
+            aria-current={active ? "page" : undefined}
+            className={cn(
+              "flex min-h-14 flex-col items-center justify-center gap-0.5 text-xs",
+              active ? "text-primary" : "text-muted-foreground hover:text-foreground",
+            )}
+          >
+            <Icon className="h-5 w-5" aria-hidden="true" />
+            <span>{tab.label}</span>
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}

--- a/src/components/layout/bottom-nav.tsx
+++ b/src/components/layout/bottom-nav.tsx
@@ -6,7 +6,7 @@ import { usePathname } from "next/navigation";
 
 import { cn } from "@/lib/cn";
 
-import { NAV_TABS, type NavTabId } from "./nav-routes";
+import { activeTabId, NAV_TABS, type NavTabId } from "./nav-routes";
 
 const ICONS: Record<NavTabId, typeof Home> = {
   home: Home,
@@ -16,6 +16,7 @@ const ICONS: Record<NavTabId, typeof Home> = {
 
 export function BottomNav() {
   const pathname = usePathname() ?? "/";
+  const activeId = activeTabId(pathname);
   return (
     <nav
       aria-label="主要ナビゲーション"
@@ -23,7 +24,7 @@ export function BottomNav() {
     >
       {NAV_TABS.map((tab) => {
         const Icon = ICONS[tab.id];
-        const active = tab.matches(pathname);
+        const active = tab.id === activeId;
         return (
           <Link
             key={tab.id}

--- a/src/components/layout/nav-routes.test.ts
+++ b/src/components/layout/nav-routes.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+
+import { activeTabId, isNavHidden } from "./nav-routes";
+
+describe("activeTabId", () => {
+  it("/ → home", () => {
+    expect(activeTabId("/")).toBe("home");
+  });
+
+  it("/drill / /drill/anything → drill", () => {
+    expect(activeTabId("/drill")).toBe("drill");
+    expect(activeTabId("/drill/123")).toBe("drill");
+  });
+
+  it("/insights / /insights/* → insights", () => {
+    expect(activeTabId("/insights")).toBe("insights");
+    expect(activeTabId("/insights/history")).toBe("insights");
+    expect(activeTabId("/insights/search")).toBe("insights");
+  });
+
+  it("nav に存在しないパスは null", () => {
+    expect(activeTabId("/login")).toBeNull();
+    expect(activeTabId("/custom")).toBeNull();
+    expect(activeTabId("/review")).toBeNull();
+    // /home のような prefix collision を起こさない
+    expect(activeTabId("/drillsomething")).toBeNull();
+  });
+});
+
+describe("isNavHidden", () => {
+  it("セッション中の没入画面では非表示", () => {
+    expect(isNavHidden("/drill")).toBe(true);
+    expect(isNavHidden("/drill/foo")).toBe(true);
+    expect(isNavHidden("/custom")).toBe(true);
+    expect(isNavHidden("/review")).toBe(true);
+    expect(isNavHidden("/login")).toBe(true);
+  });
+
+  it("Home / Insights では表示", () => {
+    expect(isNavHidden("/")).toBe(false);
+    expect(isNavHidden("/insights")).toBe(false);
+    expect(isNavHidden("/insights/history")).toBe(false);
+  });
+
+  it("prefix collision 安全 (/drill で始まる別ルート名を巻き込まない)", () => {
+    // /drillarchive のような未来のルート名が誤って隠されないこと
+    expect(isNavHidden("/drillarchive")).toBe(false);
+    expect(isNavHidden("/customizer")).toBe(false);
+  });
+});

--- a/src/components/layout/nav-routes.ts
+++ b/src/components/layout/nav-routes.ts
@@ -1,0 +1,44 @@
+/** Bottom tab bar の純粋ロジックを UI 層から切り離して unit test 可能にする
+ *  (Vitest の environment: "node" なので React render を直接は叩かない)。
+ */
+
+export type NavTabId = "home" | "drill" | "insights";
+
+export type NavTab = {
+  id: NavTabId;
+  href: string;
+  label: string;
+  matches: (pathname: string) => boolean;
+};
+
+export const NAV_TABS: NavTab[] = [
+  { id: "home", href: "/", label: "Home", matches: (p) => p === "/" },
+  {
+    id: "drill",
+    href: "/drill",
+    label: "Drill",
+    matches: (p) => p === "/drill" || p.startsWith("/drill/"),
+  },
+  {
+    id: "insights",
+    href: "/insights",
+    label: "Insights",
+    matches: (p) => p === "/insights" || p.startsWith("/insights/"),
+  },
+];
+
+/** BottomNav を出さないルート (セッション中の没入画面 + 認証画面) */
+export const NAV_HIDDEN_PREFIXES = ["/drill", "/custom", "/review", "/login"];
+
+export function isNavHidden(pathname: string): boolean {
+  return NAV_HIDDEN_PREFIXES.some(
+    (prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`),
+  );
+}
+
+export function activeTabId(pathname: string): NavTabId | null {
+  for (const tab of NAV_TABS) {
+    if (tab.matches(pathname)) return tab.id;
+  }
+  return null;
+}

--- a/src/features/drill/drill-screen.tsx
+++ b/src/features/drill/drill-screen.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { AlertTriangle, Check, Loader2, X } from "lucide-react";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import { Button } from "@/components/ui/button";
 import {
@@ -121,20 +121,62 @@ export function DrillScreen({ onReset, skipInitialStartCard }: DrillScreenProps 
 
   // セッション中の戻るジェスチャ / タブ閉じで意図せず終了しないよう警告
   // (issue #25 受け入れ基準: 戻るジェスチャで意図しない終了を防ぐ)。
-  // - asking: 解答前
-  // - graded: 解答済みで「次へ」未操作
-  // finished / idle ではブロックしない (作業継続中ではないため)。
+  //
+  // - beforeunload: タブ閉じ / リロード / 外部ドメイン遷移 (browser ネイティブの確認)
+  // - popstate + sentinel pushState: SPA 内の戻る (iOS edge swipe / Android back / browser back)。
+  //   beforeunload は SPA の popstate では発火しないため、別経路で intercept する必要がある。
+  //
+  // phase が asking | graded のときのみ guard を有効化。最新 phase は ref 経由で参照し、
+  // listener を毎回 re-bind しない (sentinel が phase 切替で重複 push されないように)。
+  const phaseRef = useRef(phase);
+  useEffect(() => {
+    phaseRef.current = phase;
+  }, [phase]);
+
   useEffect(() => {
     if (!sessionId) return;
-    if (phase !== "asking" && phase !== "graded") return;
+
+    // beforeunload: タブ閉じ / reload
     function onBeforeUnload(e: BeforeUnloadEvent) {
+      const p = phaseRef.current;
+      if (p !== "asking" && p !== "graded") return;
       e.preventDefault();
-      // Chrome 互換のため returnValue を空文字でもセットする
       e.returnValue = "";
     }
     window.addEventListener("beforeunload", onBeforeUnload);
-    return () => window.removeEventListener("beforeunload", onBeforeUnload);
-  }, [sessionId, phase]);
+
+    // popstate guard: SPA 内の戻るジェスチャ
+    let trapPushed = false;
+    function pushTrap() {
+      if (trapPushed) return;
+      window.history.pushState({ tanren: "drill-guard" }, "");
+      trapPushed = true;
+    }
+    function onPopState() {
+      // popstate 発火 = trap entry が consume された
+      trapPushed = false;
+      const p = phaseRef.current;
+      if (p !== "asking" && p !== "graded") return;
+      const leave = window.confirm("セッションを離れますか? 回答中の進捗は失われます。");
+      if (leave) {
+        // 確認 OK: もう 1 段戻って元の画面へ
+        window.history.back();
+      } else {
+        // キャンセル: trap を再度積んで /drill に留まる
+        pushTrap();
+      }
+    }
+    pushTrap();
+    window.addEventListener("popstate", onPopState);
+
+    return () => {
+      window.removeEventListener("beforeunload", onBeforeUnload);
+      window.removeEventListener("popstate", onPopState);
+      // 残った trap entry はクリーンアップしない (history.back を呼ぶと
+      // セッション完了直後に意図しない戻りが起きる)。stack に 1 つ余分に残るだけで、
+      // 次回ユーザーが back した時に consume される。
+    };
+  }, [sessionId]);
 
   useEffect(() => {
     function onKey(e: KeyboardEvent) {

--- a/src/features/drill/drill-screen.tsx
+++ b/src/features/drill/drill-screen.tsx
@@ -136,22 +136,21 @@ export function DrillScreen({ onReset, skipInitialStartCard }: DrillScreenProps 
   useEffect(() => {
     if (!sessionId) return;
 
-    // beforeunload: タブ閉じ / reload
+    let trapPushed = false;
+
+    function pushTrap() {
+      if (trapPushed) return;
+      window.history.pushState({ tanren: "drill-guard" }, "");
+      trapPushed = true;
+    }
+
     function onBeforeUnload(e: BeforeUnloadEvent) {
       const p = phaseRef.current;
       if (p !== "asking" && p !== "graded") return;
       e.preventDefault();
       e.returnValue = "";
     }
-    window.addEventListener("beforeunload", onBeforeUnload);
 
-    // popstate guard: SPA 内の戻るジェスチャ
-    let trapPushed = false;
-    function pushTrap() {
-      if (trapPushed) return;
-      window.history.pushState({ tanren: "drill-guard" }, "");
-      trapPushed = true;
-    }
     function onPopState() {
       // popstate 発火 = trap entry が consume された
       trapPushed = false;
@@ -159,22 +158,32 @@ export function DrillScreen({ onReset, skipInitialStartCard }: DrillScreenProps 
       if (p !== "asking" && p !== "graded") return;
       const leave = window.confirm("セッションを離れますか? 回答中の進捗は失われます。");
       if (leave) {
-        // 確認 OK: もう 1 段戻って元の画面へ
+        // 自分自身を外してから history.back() を呼ぶ。続けて発火する popstate は
+        // listener なしで silent に処理され、confirm の再入や多重 back を起こさない
+        // (Codex Round 2 指摘 #1)。
+        window.removeEventListener("popstate", onPopState);
+        window.removeEventListener("beforeunload", onBeforeUnload);
         window.history.back();
       } else {
         // キャンセル: trap を再度積んで /drill に留まる
         pushTrap();
       }
     }
+
     pushTrap();
     window.addEventListener("popstate", onPopState);
+    window.addEventListener("beforeunload", onBeforeUnload);
 
     return () => {
-      window.removeEventListener("beforeunload", onBeforeUnload);
       window.removeEventListener("popstate", onPopState);
-      // 残った trap entry はクリーンアップしない (history.back を呼ぶと
-      // セッション完了直後に意図しない戻りが起きる)。stack に 1 つ余分に残るだけで、
-      // 次回ユーザーが back した時に consume される。
+      window.removeEventListener("beforeunload", onBeforeUnload);
+      // session が終了したら sentinel を回収して、次の戻る操作が「無音の back」に
+      // ならないようにする (Codex Round 2 指摘 #2)。
+      // listener は既に外しているので history.back() の popstate は silent に処理される。
+      if (trapPushed) {
+        trapPushed = false;
+        window.history.back();
+      }
     };
   }, [sessionId]);
 

--- a/src/features/drill/drill-screen.tsx
+++ b/src/features/drill/drill-screen.tsx
@@ -119,6 +119,23 @@ export function DrillScreen({ onReset, skipInitialStartCard }: DrillScreenProps 
     }
   }, [phase, question, selectedIndex, handleStart, handleNext, handleSubmit]);
 
+  // セッション中の戻るジェスチャ / タブ閉じで意図せず終了しないよう警告
+  // (issue #25 受け入れ基準: 戻るジェスチャで意図しない終了を防ぐ)。
+  // - asking: 解答前
+  // - graded: 解答済みで「次へ」未操作
+  // finished / idle ではブロックしない (作業継続中ではないため)。
+  useEffect(() => {
+    if (!sessionId) return;
+    if (phase !== "asking" && phase !== "graded") return;
+    function onBeforeUnload(e: BeforeUnloadEvent) {
+      e.preventDefault();
+      // Chrome 互換のため returnValue を空文字でもセットする
+      e.returnValue = "";
+    }
+    window.addEventListener("beforeunload", onBeforeUnload);
+    return () => window.removeEventListener("beforeunload", onBeforeUnload);
+  }, [sessionId, phase]);
+
   useEffect(() => {
     function onKey(e: KeyboardEvent) {
       // キーリピート / 既に通信中の発火を全て無視 (submit/next の二重発火抑止)
@@ -162,7 +179,7 @@ export function DrillScreen({ onReset, skipInitialStartCard }: DrillScreenProps 
           <CardDescription>5 問の mcq に解答します。</CardDescription>
         </CardHeader>
         <CardFooter>
-          <Button onClick={handleStart} disabled={pending}>
+          <Button onClick={handleStart} disabled={pending} className="min-h-12 px-6">
             {pending ? <Loader2 className="mr-1 h-4 w-4 animate-spin" /> : null}
             スタート
           </Button>
@@ -187,6 +204,7 @@ export function DrillScreen({ onReset, skipInitialStartCard }: DrillScreenProps 
               reset();
               handleReset();
             }}
+            className="min-h-12 px-6"
           >
             ホームに戻る
           </Button>
@@ -241,7 +259,7 @@ export function DrillScreen({ onReset, skipInitialStartCard }: DrillScreenProps 
               disabled={phase === "graded"}
               onClick={() => setSelected(i)}
               className={[
-                "flex w-full items-start gap-3 rounded-md border p-3 text-left text-sm transition-colors",
+                "flex min-h-12 w-full items-start gap-3 rounded-md border p-3 text-left text-sm transition-colors",
                 isGradedCorrect
                   ? "border-emerald-500 bg-emerald-50 dark:bg-emerald-950"
                   : isWrongSelected
@@ -299,12 +317,16 @@ export function DrillScreen({ onReset, skipInitialStartCard }: DrillScreenProps 
       </CardContent>
       <CardFooter className="flex justify-end gap-2">
         {phase === "asking" ? (
-          <Button onClick={handleSubmit} disabled={selectedIndex === null || pending}>
+          <Button
+            onClick={handleSubmit}
+            disabled={selectedIndex === null || pending}
+            className="min-h-12 px-6"
+          >
             {pending ? <Loader2 className="mr-1 h-4 w-4 animate-spin" /> : null}
             回答する (Enter)
           </Button>
         ) : (
-          <Button onClick={handleNext} disabled={pending}>
+          <Button onClick={handleNext} disabled={pending} className="min-h-12 px-6">
             次へ (Enter)
           </Button>
         )}


### PR DESCRIPTION
## Summary
issue #25 (Phase 4 モバイル UX 最終調整) を MVP スコープで実装。
docs/07 §7.1, §7.6 の「片手操作 / 1 問完結」原則を実コードに落とす。

### 実装内容
- `src/components/layout/bottom-nav.tsx` — Home / Drill / Insights の bottom tab bar (`md:hidden`)。`aria-current="page"` と active カラーを付与
- `src/components/layout/app-shell.tsx` — root layout で `usePathname` を見て `/drill` `/custom` `/review` `/login` 配下では BottomNav を非表示にする client wrapper。表示時は `pb-16 md:pb-0` を当てて nav と本文が重ならないようにする
- `src/components/layout/nav-routes.ts` + `.test.ts` — tab matcher (`activeTabId`) と非表示判定 (`isNavHidden`) を pure 関数化して unit test (Vitest `environment: "node"` のままで検証)
- `src/features/drill/drill-screen.tsx`:
  - `phase === "asking" | "graded"` で `beforeunload` warning (戻るジェスチャ / タブ閉じで意図せずセッションを失わない)
  - 主要 CTA (回答する / 次へ / スタート / ホームに戻る) と MCQ option ボタンを `min-h-12` (48px) に
- `src/app/layout.tsx` — `<TrpcProvider>` 直下に `<AppShell>` を mount
- docs/06 §6.7 構造ツリー: `src/components/{ui,layout}` に分割
- docs/07 §7.6.1: BottomNav / 没入画面非表示 / 48px CTA / `beforeunload` を明記

### 受け入れ基準の対応
- [x] 主要 CTA は下部に集約、48px 以上 → CardFooter + `min-h-12`
- [x] 1 問が縦スクロール不要で収まるレイアウト → 既存 Card レイアウトで満たしている (drill 画面は質問 + 4 選択肢 + CTA で 1 viewport)
- [x] Bottom tab bar (Home / Drill / Insights) → `<BottomNav>` (`md:hidden`)
- [x] セッション中の戻るジェスチャで意図しない終了を防ぐ → DrillScreen の `beforeunload` listener (`phase === asking|graded` のみ)
- [ ] iPhone 15 / Android 標準ブラウザで目視確認 → **#27 (本番初回デプロイ) 後の手動確認に委譲** (作者 1 人運用、本番 URL が立ったタイミングで実機検証する方が現実的なため)

closes #25

## Test plan
- [x] `pnpm typecheck` ✓
- [x] `pnpm test -- --run` ✓ (217/217、新規 7 件 = nav-routes.test.ts)
- [x] `pnpm build` ✓
- [ ] 実機 (iPhone 15 / Android) は #27 デプロイ後に確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)