### PR TITLE
feat(onboarding): 初回オンボーディング + 診断テスト (#26)

### DIFF
--- a/docs/06-architecture.md
+++ b/docs/06-architecture.md
@@ -523,7 +523,7 @@ Tanren/
 │   ├── server/
 │   │   ├── trpc/                  # tRPC ルータ
 │   │   ├── auth/                  # Passkey (WebAuthn) セッション管理
-│   │   ├── scheduler/             # FSRS ロジック + daily / review 候補選定
+│   │   ├── scheduler/             # FSRS ロジック + daily / review / diagnostic 候補選定
 │   │   ├── generator/             # 問題生成
 │   │   ├── grader/                # 採点 + rebut + 誤概念抽出
 │   │   ├── parser/                # NL パース (Custom Session)
@@ -539,6 +539,7 @@ Tanren/
 │   │   ├── custom/                # Custom Session 入力フロー
 │   │   ├── insights/              # Dashboard / History / Search
 │   │   ├── review/                # Mistake Review 入口
+│   │   ├── onboarding/            # 初回ウェルカム + 興味分野 + 診断テスト (issue #26)
 │   │   └── pwa/                   # Service Worker 登録 (issue #24)
 │   ├── components/
 │   │   ├── ui/                    # shadcn/ui

--- a/docs/07-ux-and-pwa.md
+++ b/docs/07-ux-and-pwa.md
@@ -475,17 +475,28 @@ Streak at risk は **やらない** (Streak 自体を出さない方針)。
   ☑ programming  ☑ network  ☐ security ...
     ↓
 [レベル自己申告]
-  beginner / junior / mid / senior / staff
+  beginner / junior / mid / senior
     ↓
-[初期診断テスト (3-5分, 20問)]
-  各分野から数問 → 初期 mastery 設定
+[初期診断テスト (5-20問、seed の concept 数で clamp)]
+  各分野から round-robin → 初期 mastery 設定
     ↓
 [診断結果表示]
-  「programming と network が強く、db が伸びしろです」
+  正答率の簡易サマリ
     ↓
 [最初の Daily Drill へ誘導]
   「では、今日の 10 問を始めましょう」
 ```
+
+### MVP 実装範囲 (issue #26)
+
+- `users.onboarding_completed_at` が NULL なら `/` から `/onboarding` に強制リダイレクト (`src/app/page.tsx`)。
+- `users.interest_domains` (Tier 1 6 ドメイン subset) と `users.self_level` を `onboarding.savePreferences` で保存。
+- 診断 session は `kind='diagnostic'` (`SESSION_KINDS` に追加)。`spec.diagnosticConceptIds` に
+  `selectDiagnosticConcepts` で生成した concept キューを保存し、`session.next` で round-robin 消費する。
+- 出題難易度は `user.self_level` 固定 (custom と同様、3 連続正解での昇格は行わない)。
+- 診断完了後 `onboarding.complete` で `onboarding_completed_at` を NOW() に更新。
+- 自己申告レベルは `staff` / `principal` を MVP 対象外 (seed の concept レンジが mid 中心で
+  当たりが 0 件になり診断テストが成立しないため、MVP では `beginner..senior` の 4 段階)。
 
 個人用途なので「新規登録」UI は**作らない**。初期 user 行は `pnpm run auth:bootstrap` で 1 回だけ作成し、
 以降は Passkey 登録 → ログインの繰り返し。

--- a/drizzle/0009_users_onboarding.sql
+++ b/drizzle/0009_users_onboarding.sql
@@ -1,0 +1,5 @@
+-- issue #26: Onboarding 完了状態 + 興味分野 + 自己申告レベルを users に追加
+ALTER TABLE "users"
+  ADD COLUMN "onboarding_completed_at" timestamp with time zone,
+  ADD COLUMN "interest_domains" jsonb DEFAULT '[]'::jsonb,
+  ADD COLUMN "self_level" text;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1776496000000,
       "tag": "0008_misconceptions_unique",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "7",
+      "when": 1776497000000,
+      "tag": "0009_users_onboarding",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/onboarding/page.tsx
+++ b/src/app/onboarding/page.tsx
@@ -1,0 +1,22 @@
+import { redirect } from "next/navigation";
+
+import { OnboardingScreen } from "@/features/onboarding/onboarding-screen";
+import { getCurrentUser } from "@/server/auth/session";
+
+export const dynamic = "force-dynamic";
+
+export default async function OnboardingPage() {
+  const user = await getCurrentUser();
+  if (!user) {
+    redirect("/login");
+  }
+  // 既に完了しているユーザーは Home に戻す (戻るボタンや手打ち URL での再訪を吸収)
+  if (user.onboardingCompletedAt) {
+    redirect("/");
+  }
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center gap-6 p-6">
+      <OnboardingScreen />
+    </main>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,9 +1,16 @@
+import { redirect } from "next/navigation";
+
 import { getCurrentUser } from "@/server/auth/session";
 
 import { HomeScreen } from "@/features/home/home-screen";
 
 export default async function Home() {
   const initialUser = await getCurrentUser();
+  // ログイン済みでオンボーディング未完了なら /onboarding へ強制リダイレクト (issue #26)。
+  // 未ログインや未完了なら HomeScreen 側でログイン誘導 / リダイレクトをハンドル。
+  if (initialUser && !initialUser.onboardingCompletedAt) {
+    redirect("/onboarding");
+  }
   return (
     <main className="flex min-h-screen flex-col items-center justify-center gap-6 p-8">
       <HomeScreen

--- a/src/components/layout/nav-routes.test.ts
+++ b/src/components/layout/nav-routes.test.ts
@@ -34,6 +34,7 @@ describe("isNavHidden", () => {
     expect(isNavHidden("/custom")).toBe(true);
     expect(isNavHidden("/review")).toBe(true);
     expect(isNavHidden("/login")).toBe(true);
+    expect(isNavHidden("/onboarding")).toBe(true);
   });
 
   it("Home / Insights では表示", () => {

--- a/src/components/layout/nav-routes.ts
+++ b/src/components/layout/nav-routes.ts
@@ -27,8 +27,8 @@ export const NAV_TABS: NavTab[] = [
   },
 ];
 
-/** BottomNav を出さないルート (セッション中の没入画面 + 認証画面) */
-export const NAV_HIDDEN_PREFIXES = ["/drill", "/custom", "/review", "/login"];
+/** BottomNav を出さないルート (セッション中の没入画面 + 認証画面 + オンボーディング) */
+export const NAV_HIDDEN_PREFIXES = ["/drill", "/custom", "/review", "/login", "/onboarding"];
 
 export function isNavHidden(pathname: string): boolean {
   return NAV_HIDDEN_PREFIXES.some(

--- a/src/db/schema/_constants.ts
+++ b/src/db/schema/_constants.ts
@@ -34,8 +34,21 @@ export const DIFFICULTY_LEVELS = [
 ] as const;
 export type DifficultyLevel = (typeof DIFFICULTY_LEVELS)[number];
 
-export const SESSION_KINDS = ["daily", "deep", "custom", "review"] as const;
+export const SESSION_KINDS = ["daily", "deep", "custom", "review", "diagnostic"] as const;
 export type SessionKind = (typeof SESSION_KINDS)[number];
+
+/** Onboarding (issue #26) でユーザーが選べる興味分野 = Tier 1 6 ドメイン。
+ *  docs/02-learning-system.md §2.1.1 参照 (MVP は Tier 1 のみ)。
+ */
+export const TIER_1_DOMAIN_IDS = [
+  "programming",
+  "dsa",
+  "network",
+  "db",
+  "tools",
+  "frontend",
+] as const satisfies readonly DomainId[];
+export type Tier1DomainId = (typeof TIER_1_DOMAIN_IDS)[number];
 
 export const QUESTION_TYPES = ["mcq", "short", "written", "cloze", "code_read", "design"] as const;
 export type QuestionType = (typeof QUESTION_TYPES)[number];

--- a/src/db/schema/users.ts
+++ b/src/db/schema/users.ts
@@ -1,5 +1,7 @@
 import { sql } from "drizzle-orm";
-import { integer, pgTable, text, timestamp } from "drizzle-orm/pg-core";
+import { integer, jsonb, pgTable, text, timestamp } from "drizzle-orm/pg-core";
+
+import type { DifficultyLevel, DomainId } from "./_constants";
 
 export const users = pgTable("users", {
   id: text("id")
@@ -11,6 +13,14 @@ export const users = pgTable("users", {
   dailyGoal: integer("daily_goal").notNull().default(15),
   /** 'HH:mm' 形式 */
   notificationTime: text("notification_time"),
+  /** 初回オンボーディング (issue #26) 完了時刻。null なら /onboarding にリダイレクト */
+  onboardingCompletedAt: timestamp("onboarding_completed_at", { withTimezone: true }),
+  /** オンボーディングで選んだ興味分野 (Tier 1 6 ドメイン中の subset) */
+  interestDomains: jsonb("interest_domains")
+    .$type<DomainId[]>()
+    .default(sql`'[]'::jsonb`),
+  /** オンボーディングでの自己申告レベル */
+  selfLevel: text("self_level").$type<DifficultyLevel>(),
   createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
 });
 

--- a/src/features/drill/drill-screen.tsx
+++ b/src/features/drill/drill-screen.tsx
@@ -20,8 +20,10 @@ import { normalizeRubricChecks, useDrillStore } from "./drill-state";
 
 type DrillScreenProps = {
   /** 完了後「ホームに戻る」を押したときの遷移ハンドラ (例: /custom に戻る)。
-   *  未指定ならデフォルトの useDrillStore.reset() が走り、Daily Drill 開始カードに戻る。 */
-  onReset?: () => void;
+   *  未指定ならデフォルトの useDrillStore.reset() が走り、Daily Drill 開始カードに戻る。
+   *  最終 summary を引数で渡す: 親側は reset() で store がクリアされる前にスナップショット
+   *  できる (issue #26 onboarding 結果カード用、Codex Round 1 指摘 #1)。 */
+  onReset?: (finalSummary: import("./drill-state").DrillSummary | null) => void;
   /** idle で出るスタートカードの挙動を差し替える (例: /custom では使わない) */
   skipInitialStartCard?: boolean;
 };
@@ -29,7 +31,9 @@ type DrillScreenProps = {
 export function DrillScreen({ onReset, skipInitialStartCard }: DrillScreenProps = {}) {
   const { phase, sessionId, question, selectedIndex, grading, summary } = useDrillStore();
   const { reset, setSession, setQuestion, setSelected, setGrading, setSummary } = useDrillStore();
-  const handleReset = onReset ?? reset;
+  // 既定 (onReset 未指定) は zustand reset。引数 finalSummary は無視されるが
+  // 関数シグネチャは optional 引数で互換 (custom / review もそのまま動く)。
+  const handleReset = onReset ?? (() => reset());
 
   const startMutation = trpc.session.start.useMutation();
   const nextMutation = trpc.session.next.useMutation();
@@ -252,8 +256,11 @@ export function DrillScreen({ onReset, skipInitialStartCard }: DrillScreenProps 
         <CardFooter>
           <Button
             onClick={() => {
+              // reset() より先に summary をローカル変数に取り出し、handleReset に渡す。
+              // store を先にクリアすると親側 (onboarding 等) で summary を読み損ねるため。
+              const finalSummary = summary;
               reset();
-              handleReset();
+              handleReset(finalSummary);
             }}
             className="min-h-12 px-6"
           >

--- a/src/features/onboarding/onboarding-screen.tsx
+++ b/src/features/onboarding/onboarding-screen.tsx
@@ -74,12 +74,20 @@ export function OnboardingScreen() {
   const [interestDomains, setInterestDomains] = useState<Tier1DomainId[]>([]);
   const [selfLevel, setSelfLevel] = useState<SelfLevel | null>(null);
   const [error, setError] = useState<string | null>(null);
+  // result カードに表示する診断結果のスナップショット。
+  // DrillScreen が onReset 経由で finalSummary を渡してくれるので、
+  // event handler 内で setState するだけで済む (Codex Round 1 指摘 #1)。
+  const [resultSnapshot, setResultSnapshot] = useState<{
+    questionCount: number;
+    correctCount: number;
+    accuracy: number;
+  } | null>(null);
 
   const savePrefs = trpc.onboarding.savePreferences.useMutation();
   const completeOnboarding = trpc.onboarding.complete.useMutation();
   const startSession = trpc.session.start.useMutation();
   const nextQuestion = trpc.session.next.useMutation();
-  const { reset, setSession, setQuestion, summary } = useDrillStore();
+  const { reset, setSession, setQuestion } = useDrillStore();
 
   const toggleDomain = useCallback((d: Tier1DomainId) => {
     setInterestDomains((prev) => (prev.includes(d) ? prev.filter((x) => x !== d) : [...prev, d]));
@@ -124,7 +132,15 @@ export function OnboardingScreen() {
 
   // === running: DrillScreen を埋め込み、終了時 (summary が埋まったら) result に遷移 ===
   if (step.kind === "running") {
-    return <DrillScreen onReset={() => setStep({ kind: "result" })} skipInitialStartCard />;
+    return (
+      <DrillScreen
+        onReset={(finalSummary) => {
+          setResultSnapshot(finalSummary);
+          setStep({ kind: "result" });
+        }}
+        skipInitialStartCard
+      />
+    );
   }
 
   // === result: 簡易サマリ + 「最初の Daily Drill へ」 ===
@@ -134,8 +150,8 @@ export function OnboardingScreen() {
         <CardHeader>
           <CardTitle>診断テスト完了</CardTitle>
           <CardDescription>
-            {summary
-              ? `${summary.questionCount} 問中 ${summary.correctCount} 問正解 (${Math.round(summary.accuracy * 100)}%)`
+            {resultSnapshot
+              ? `${resultSnapshot.questionCount} 問中 ${resultSnapshot.correctCount} 問正解 (${Math.round(resultSnapshot.accuracy * 100)}%)`
               : "結果を保存しました"}
           </CardDescription>
         </CardHeader>

--- a/src/features/onboarding/onboarding-screen.tsx
+++ b/src/features/onboarding/onboarding-screen.tsx
@@ -1,0 +1,283 @@
+"use client";
+
+import { ArrowRight, BookOpen, Brain, ListChecks, Loader2 } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useCallback, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { cn } from "@/lib/cn";
+import { TIER_1_DOMAIN_IDS, type DomainId, type Tier1DomainId } from "@/db/schema";
+import { DrillScreen } from "@/features/drill/drill-screen";
+import { useDrillStore } from "@/features/drill/drill-state";
+import { trpc } from "@/lib/trpc/react";
+
+type Step =
+  | { kind: "welcome"; index: 0 | 1 | 2 }
+  | { kind: "preferences" }
+  | { kind: "running" }
+  | { kind: "result" };
+
+const WELCOME_SLIDES: Array<{ icon: typeof Brain; title: string; body: string }> = [
+  {
+    icon: Brain,
+    title: "AI がエンジニアのための問題を出します",
+    body: "domain × thinking style に沿って、あなたに合わせた MCQ を生成します。",
+  },
+  {
+    icon: BookOpen,
+    title: "忘れる前に再出題する科学的な仕組み",
+    body: "FSRS (Spaced Repetition) で「忘れそうなタイミング」を狙って復習します。",
+  },
+  {
+    icon: ListChecks,
+    title: "あなたの学習状態を診断します",
+    body: "次の数問で出発点を測ります。3〜5 分で終わります。",
+  },
+];
+
+const TIER_1_LABELS: Record<DomainId, string> = {
+  programming: "Programming",
+  dsa: "DSA",
+  os: "OS",
+  network: "Network",
+  db: "Database",
+  security: "Security",
+  distributed: "Distributed",
+  design: "Design",
+  devops: "DevOps",
+  tools: "Tools",
+  low_level: "Low-level",
+  ai_ml: "AI / ML",
+  frontend: "Frontend",
+};
+
+type SelfLevel = "beginner" | "junior" | "mid" | "senior";
+
+const SELF_LEVELS: Array<{ id: SelfLevel; label: string; hint: string }> = [
+  { id: "beginner", label: "Beginner", hint: "学習を始めたばかり" },
+  { id: "junior", label: "Junior", hint: "業務 1〜2 年" },
+  { id: "mid", label: "Mid", hint: "業務 3〜5 年" },
+  { id: "senior", label: "Senior", hint: "業務 5 年以上" },
+];
+
+export function OnboardingScreen() {
+  const router = useRouter();
+  const [step, setStep] = useState<Step>({ kind: "welcome", index: 0 });
+  const [interestDomains, setInterestDomains] = useState<Tier1DomainId[]>([]);
+  const [selfLevel, setSelfLevel] = useState<SelfLevel | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const savePrefs = trpc.onboarding.savePreferences.useMutation();
+  const completeOnboarding = trpc.onboarding.complete.useMutation();
+  const startSession = trpc.session.start.useMutation();
+  const nextQuestion = trpc.session.next.useMutation();
+  const { reset, setSession, setQuestion, summary } = useDrillStore();
+
+  const toggleDomain = useCallback((d: Tier1DomainId) => {
+    setInterestDomains((prev) => (prev.includes(d) ? prev.filter((x) => x !== d) : [...prev, d]));
+  }, []);
+
+  const onStartDiagnostic = useCallback(async () => {
+    if (interestDomains.length === 0 || !selfLevel) return;
+    setError(null);
+    try {
+      await savePrefs.mutateAsync({ interestDomains, selfLevel });
+      reset();
+      const { sessionId } = await startSession.mutateAsync({ kind: "diagnostic" });
+      const next = await nextQuestion.mutateAsync({ sessionId });
+      setSession(sessionId);
+      setStep({ kind: "running" });
+      if (!next.done) setQuestion(next.question);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "診断テストの開始に失敗しました");
+    }
+  }, [
+    interestDomains,
+    selfLevel,
+    savePrefs,
+    startSession,
+    nextQuestion,
+    reset,
+    setSession,
+    setQuestion,
+  ]);
+
+  const onComplete = useCallback(async () => {
+    setError(null);
+    try {
+      await completeOnboarding.mutateAsync();
+      reset();
+      router.replace("/");
+      router.refresh(); // Server Component の getCurrentUser を再評価
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "オンボーディング完了の保存に失敗しました");
+    }
+  }, [completeOnboarding, reset, router]);
+
+  // === running: DrillScreen を埋め込み、終了時 (summary が埋まったら) result に遷移 ===
+  if (step.kind === "running") {
+    return <DrillScreen onReset={() => setStep({ kind: "result" })} skipInitialStartCard />;
+  }
+
+  // === result: 簡易サマリ + 「最初の Daily Drill へ」 ===
+  if (step.kind === "result") {
+    return (
+      <Card className="w-full max-w-md">
+        <CardHeader>
+          <CardTitle>診断テスト完了</CardTitle>
+          <CardDescription>
+            {summary
+              ? `${summary.questionCount} 問中 ${summary.correctCount} 問正解 (${Math.round(summary.accuracy * 100)}%)`
+              : "結果を保存しました"}
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="text-muted-foreground space-y-2 text-sm">
+          <p>各 concept の初期 mastery を更新しました。</p>
+          <p>次は今日の Daily Drill から始めましょう。</p>
+        </CardContent>
+        <CardFooter className="flex flex-col gap-2">
+          {error && <p className="text-destructive text-xs">{error}</p>}
+          <Button
+            onClick={onComplete}
+            disabled={completeOnboarding.isPending}
+            className="min-h-12 w-full px-6"
+          >
+            {completeOnboarding.isPending && <Loader2 className="mr-1 h-4 w-4 animate-spin" />}
+            ホームへ
+            <ArrowRight className="ml-1 h-4 w-4" />
+          </Button>
+        </CardFooter>
+      </Card>
+    );
+  }
+
+  // === preferences: 興味分野 + 自己申告レベル ===
+  if (step.kind === "preferences") {
+    const startDisabled =
+      interestDomains.length === 0 ||
+      !selfLevel ||
+      savePrefs.isPending ||
+      startSession.isPending ||
+      nextQuestion.isPending;
+    return (
+      <Card className="w-full max-w-md">
+        <CardHeader>
+          <CardTitle>あなたについて</CardTitle>
+          <CardDescription>分野とレベルを教えてください (後から変更可能)</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div>
+            <p className="mb-2 text-sm font-medium">興味のある分野 (複数可)</p>
+            <div className="grid grid-cols-2 gap-2">
+              {TIER_1_DOMAIN_IDS.map((d) => {
+                const active = interestDomains.includes(d);
+                return (
+                  <button
+                    key={d}
+                    type="button"
+                    onClick={() => toggleDomain(d)}
+                    aria-pressed={active}
+                    className={cn(
+                      "min-h-12 rounded-md border px-3 py-2 text-sm transition-colors",
+                      active
+                        ? "border-primary bg-primary/10"
+                        : "border-border hover:border-muted-foreground",
+                    )}
+                  >
+                    {TIER_1_LABELS[d]}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+          <div>
+            <p className="mb-2 text-sm font-medium">自己申告レベル</p>
+            <div className="grid grid-cols-2 gap-2">
+              {SELF_LEVELS.map(({ id, label, hint }) => {
+                const active = selfLevel === id;
+                return (
+                  <button
+                    key={id}
+                    type="button"
+                    onClick={() => setSelfLevel(id)}
+                    aria-pressed={active}
+                    className={cn(
+                      "min-h-12 rounded-md border px-3 py-2 text-left text-sm transition-colors",
+                      active
+                        ? "border-primary bg-primary/10"
+                        : "border-border hover:border-muted-foreground",
+                    )}
+                  >
+                    <div className="font-medium">{label}</div>
+                    <div className="text-muted-foreground text-xs">{hint}</div>
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+          {error && <p className="text-destructive text-xs">{error}</p>}
+        </CardContent>
+        <CardFooter>
+          <Button
+            onClick={onStartDiagnostic}
+            disabled={startDisabled}
+            className="min-h-12 w-full px-6"
+          >
+            {(savePrefs.isPending || startSession.isPending || nextQuestion.isPending) && (
+              <Loader2 className="mr-1 h-4 w-4 animate-spin" />
+            )}
+            診断テストを始める
+            <ArrowRight className="ml-1 h-4 w-4" />
+          </Button>
+        </CardFooter>
+      </Card>
+    );
+  }
+
+  // === welcome: 3 枚のカードをページネーション ===
+  const slide = WELCOME_SLIDES[step.index]!;
+  const Icon = slide.icon;
+  return (
+    <Card className="w-full max-w-md">
+      <CardHeader>
+        <Icon className="text-primary h-8 w-8" aria-hidden="true" />
+        <CardTitle>{slide.title}</CardTitle>
+        <CardDescription>{slide.body}</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div className="flex justify-center gap-1.5" aria-label={`スライド ${step.index + 1} / 3`}>
+          {WELCOME_SLIDES.map((_, i) => (
+            <span
+              key={i}
+              className={cn("h-1.5 w-6 rounded-full", i === step.index ? "bg-primary" : "bg-muted")}
+              aria-hidden="true"
+            />
+          ))}
+        </div>
+      </CardContent>
+      <CardFooter>
+        <Button
+          onClick={() => {
+            if (step.index < 2) {
+              setStep({ kind: "welcome", index: (step.index + 1) as 1 | 2 });
+            } else {
+              setStep({ kind: "preferences" });
+            }
+          }}
+          className="min-h-12 w-full px-6"
+        >
+          次へ
+          <ArrowRight className="ml-1 h-4 w-4" />
+        </Button>
+      </CardFooter>
+    </Card>
+  );
+}

--- a/src/server/scheduler/diagnostic.test.ts
+++ b/src/server/scheduler/diagnostic.test.ts
@@ -1,0 +1,98 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { pickDiagnosticConcept, selectDiagnosticConcepts } from "./diagnostic";
+
+const queue: Array<() => unknown> = [];
+vi.mock("@/db/client", () => {
+  function makeBuilder(): unknown {
+    const b: Record<string, unknown> = {
+      from: () => b,
+      where: () => b,
+      then: (onFulfilled: (v: unknown) => unknown) => {
+        const handler = queue.shift();
+        const result = handler ? handler() : [];
+        return Promise.resolve(result).then(onFulfilled);
+      },
+    };
+    return b;
+  }
+  return { getDb: () => ({ select: () => makeBuilder() }) };
+});
+
+beforeEach(() => {
+  queue.length = 0;
+});
+
+describe("selectDiagnosticConcepts", () => {
+  it("interestDomains が空なら早期 return で空配列 (DB を叩かない)", async () => {
+    const out = await selectDiagnosticConcepts({
+      interestDomains: [],
+      selfLevel: "junior",
+      count: 10,
+    });
+    expect(out).toEqual([]);
+  });
+
+  it("self_level に合致する concept が 0 件なら空配列", async () => {
+    queue.push(() => [
+      { id: "p1", domainId: "programming", difficultyLevels: ["senior"] },
+      { id: "n1", domainId: "network", difficultyLevels: ["staff"] },
+    ]);
+    const out = await selectDiagnosticConcepts({
+      interestDomains: ["programming", "network"],
+      selfLevel: "junior",
+      count: 5,
+    });
+    expect(out).toEqual([]);
+  });
+
+  it("domain ごとに round-robin、不足時は循環で重複出題", async () => {
+    queue.push(() => [
+      { id: "p1", domainId: "programming", difficultyLevels: ["junior"] },
+      { id: "p2", domainId: "programming", difficultyLevels: ["junior"] },
+      { id: "n1", domainId: "network", difficultyLevels: ["junior"] },
+    ]);
+    const out = await selectDiagnosticConcepts({
+      interestDomains: ["programming", "network"],
+      selfLevel: "junior",
+      count: 5,
+    });
+    // round 0: [p1, n1] -> round 1: [p2, n1] -> round 2: [p1] (count=5 達成)
+    expect(out).toEqual(["p1", "n1", "p2", "n1", "p1"]);
+  });
+
+  it("count が available より少ないと count 件で打ち切り", async () => {
+    queue.push(() => [
+      { id: "p1", domainId: "programming", difficultyLevels: ["junior"] },
+      { id: "p2", domainId: "programming", difficultyLevels: ["junior"] },
+      { id: "p3", domainId: "programming", difficultyLevels: ["junior"] },
+    ]);
+    const out = await selectDiagnosticConcepts({
+      interestDomains: ["programming"],
+      selfLevel: "junior",
+      count: 2,
+    });
+    expect(out).toEqual(["p1", "p2"]);
+  });
+});
+
+describe("pickDiagnosticConcept", () => {
+  it("空キューは null", () => {
+    expect(pickDiagnosticConcept([], 0)).toBeNull();
+    expect(pickDiagnosticConcept([], 5)).toBeNull();
+  });
+
+  it("単一キューは常に同じ concept を返す", () => {
+    expect(pickDiagnosticConcept(["a"], 0)).toBe("a");
+    expect(pickDiagnosticConcept(["a"], 7)).toBe("a");
+  });
+
+  it("複数キューは round-robin で順番に返す", () => {
+    const queue = ["a", "b", "c"];
+    expect(pickDiagnosticConcept(queue, 0)).toBe("a");
+    expect(pickDiagnosticConcept(queue, 1)).toBe("b");
+    expect(pickDiagnosticConcept(queue, 2)).toBe("c");
+    expect(pickDiagnosticConcept(queue, 3)).toBe("a");
+    expect(pickDiagnosticConcept(queue, 4)).toBe("b");
+  });
+});

--- a/src/server/scheduler/diagnostic.ts
+++ b/src/server/scheduler/diagnostic.ts
@@ -1,0 +1,87 @@
+import { inArray } from "drizzle-orm";
+
+import { getDb } from "@/db/client";
+import { concepts, type DifficultyLevel, type DomainId } from "@/db/schema";
+
+/** Onboarding 診断テスト (issue #26) のデフォルト出題数 / clamp 上下限。
+ *  seed が 10 concept しかない MVP 環境でも成立するよう低めに設定。
+ *  docs/07.11 の「20 問」は内部上限とし、実数は available concepts に応じて clamp する。
+ */
+export const DIAGNOSTIC_DEFAULT_COUNT = 10;
+export const DIAGNOSTIC_MIN_COUNT = 5;
+export const DIAGNOSTIC_MAX_COUNT = 20;
+
+type SelectArgs = {
+  interestDomains: DomainId[];
+  selfLevel: DifficultyLevel;
+  count: number;
+};
+
+/** ユーザーが選んだ興味分野で、self_level を許容する concepts を均等に取得して
+ *  「先頭から count 件」のキューにする。各 concept は session.next で
+ *  pickDiagnosticConcept(queue, questionCount) によりラウンドロビン消費される
+ *  (selectReviewCandidates / pickReviewConcept と同じ pattern)。
+ *
+ *  ストラテジ:
+ *    1. interest_domains のいずれかに属する concept を取得
+ *    2. self_level を difficulty_levels に含む concept のみ
+ *    3. domain ごとにグループ化して round-robin (programming, dsa, ... の順番に 1 件ずつ拾う)
+ *    4. 件数が count に満たない場合はループの先頭から再度拾う (concept 重複可)
+ *    5. 0 件しか取れない場合は空配列を返す (呼び出し側で PRECONDITION_FAILED)
+ */
+export async function selectDiagnosticConcepts({
+  interestDomains,
+  selfLevel,
+  count,
+}: SelectArgs): Promise<string[]> {
+  if (interestDomains.length === 0) return [];
+  const rows = await getDb()
+    .select({
+      id: concepts.id,
+      domainId: concepts.domainId,
+      difficultyLevels: concepts.difficultyLevels,
+    })
+    .from(concepts)
+    .where(inArray(concepts.domainId, interestDomains));
+
+  // self_level を含む concept のみ採用 (空 difficulty_levels は CHECK 制約で排除済み)
+  const eligible = rows.filter((r) => r.difficultyLevels.includes(selfLevel));
+  if (eligible.length === 0) return [];
+
+  // domain ごとにグループ化し、interest_domains の順番でラウンドロビン
+  const groups = new Map<DomainId, string[]>();
+  for (const d of interestDomains) groups.set(d, []);
+  for (const r of eligible) {
+    const arr = groups.get(r.domainId);
+    if (arr) arr.push(r.id);
+  }
+  // 安定ソート: id 昇順 (テスト容易性)
+  for (const arr of groups.values()) arr.sort();
+
+  const queue: string[] = [];
+  // round-robin で重複なく取れるだけ取る → 不足分は循環で重複出題
+  // 例: domains=[programming, dsa] で programming=2 / dsa=1 / count=5 →
+  //     [P0, D0, P1, P0, D0]  (P0/D0 が再出題されるのは MVP の許容)
+  let exhausted = false;
+  while (queue.length < count && !exhausted) {
+    let pickedThisRound = 0;
+    for (const d of interestDomains) {
+      if (queue.length >= count) break;
+      const arr = groups.get(d);
+      if (!arr || arr.length === 0) continue;
+      // ラウンド進行に応じて index を回す
+      const round = Math.floor(queue.length / Math.max(interestDomains.length, 1));
+      const idx = round % arr.length;
+      queue.push(arr[idx]!);
+      pickedThisRound += 1;
+    }
+    if (pickedThisRound === 0) exhausted = true;
+  }
+  return queue;
+}
+
+/** session.next で呼び出して conceptId を取り出す。空キューは呼び出し前に弾く想定 */
+export function pickDiagnosticConcept(queue: string[], questionCount: number): string | null {
+  if (queue.length === 0) return null;
+  return queue[questionCount % queue.length] ?? null;
+}

--- a/src/server/trpc/routers/index.ts
+++ b/src/server/trpc/routers/index.ts
@@ -3,6 +3,7 @@ import { attemptsRouter } from "./attempts";
 import { authRouter } from "./auth";
 import { customRouter } from "./custom";
 import { insightsRouter } from "./insights";
+import { onboardingRouter } from "./onboarding";
 import { pingRouter } from "./ping";
 import { questionsRouter } from "./questions";
 import { sessionRouter } from "./session";
@@ -13,6 +14,7 @@ export const appRouter = router({
   attempts: attemptsRouter,
   custom: customRouter,
   insights: insightsRouter,
+  onboarding: onboardingRouter,
   questions: questionsRouter,
   session: sessionRouter,
 });

--- a/src/server/trpc/routers/onboarding.test.ts
+++ b/src/server/trpc/routers/onboarding.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { User } from "@/db/schema";
+
+import { appRouter } from "./index";
+
+const updateSpy = vi.fn();
+vi.mock("@/db/client", () => {
+  return {
+    getDb: () => ({
+      update: () => ({
+        set: (vals: unknown) => ({
+          where: (cond: unknown) => {
+            updateSpy(vals, cond);
+            return Promise.resolve();
+          },
+        }),
+      }),
+    }),
+  };
+});
+
+function userWith(overrides: Partial<User>): User {
+  return {
+    id: "u-1",
+    email: "x@y.z",
+    displayName: null,
+    timezone: "Asia/Tokyo",
+    dailyGoal: 15,
+    notificationTime: null,
+    onboardingCompletedAt: null,
+    interestDomains: [],
+    selfLevel: null,
+    createdAt: new Date(),
+    ...overrides,
+  } as User;
+}
+
+describe("onboarding.savePreferences input validation", () => {
+  beforeEach(() => updateSpy.mockClear());
+  afterEach(() => vi.clearAllMocks());
+
+  const caller = appRouter.createCaller({ user: userWith({}) });
+
+  it("interestDomains が空は reject", async () => {
+    await expect(
+      caller.onboarding.savePreferences({ interestDomains: [], selfLevel: "junior" }),
+    ).rejects.toThrow();
+  });
+
+  it("Tier 1 以外の domain は reject (zod enum)", async () => {
+    await expect(
+      // @ts-expect-error 'os' は Tier 1 でない (security/distributed/...)
+      caller.onboarding.savePreferences({ interestDomains: ["os"], selfLevel: "junior" }),
+    ).rejects.toThrow();
+  });
+
+  it("staff / principal は MVP では reject (concept レンジ外)", async () => {
+    await expect(
+      // @ts-expect-error staff は MVP の selfLevel に未対応
+      caller.onboarding.savePreferences({ interestDomains: ["programming"], selfLevel: "staff" }),
+    ).rejects.toThrow();
+  });
+
+  it("正しい入力は accept、users への update が呼ばれる", async () => {
+    await caller.onboarding.savePreferences({
+      interestDomains: ["programming", "network"],
+      selfLevel: "mid",
+    });
+    expect(updateSpy).toHaveBeenCalledTimes(1);
+    const [vals] = updateSpy.mock.calls[0]!;
+    expect(vals).toEqual({
+      interestDomains: ["programming", "network"],
+      selfLevel: "mid",
+    });
+  });
+});
+
+describe("onboarding.complete prerequisite check", () => {
+  beforeEach(() => updateSpy.mockClear());
+
+  it("interestDomains 未設定は PRECONDITION_FAILED", async () => {
+    const caller = appRouter.createCaller({
+      user: userWith({ interestDomains: [], selfLevel: "junior" }),
+    });
+    await expect(caller.onboarding.complete()).rejects.toThrow();
+    expect(updateSpy).not.toHaveBeenCalled();
+  });
+
+  it("selfLevel 未設定は PRECONDITION_FAILED", async () => {
+    const caller = appRouter.createCaller({
+      user: userWith({ interestDomains: ["programming"], selfLevel: null }),
+    });
+    await expect(caller.onboarding.complete()).rejects.toThrow();
+    expect(updateSpy).not.toHaveBeenCalled();
+  });
+
+  it("両方揃っていれば onboarding_completed_at をセット", async () => {
+    const caller = appRouter.createCaller({
+      user: userWith({ interestDomains: ["programming"], selfLevel: "junior" }),
+    });
+    await caller.onboarding.complete();
+    expect(updateSpy).toHaveBeenCalledTimes(1);
+    const [vals] = updateSpy.mock.calls[0]!;
+    expect(vals).toHaveProperty("onboardingCompletedAt");
+    expect((vals as { onboardingCompletedAt: Date }).onboardingCompletedAt).toBeInstanceOf(Date);
+  });
+});
+
+describe("onboarding.getStatus", () => {
+  it("未完了ユーザー → completed: false", () => {
+    const caller = appRouter.createCaller({ user: userWith({}) });
+    const out = caller.onboarding.getStatus();
+    return expect(out).resolves.toMatchObject({ completed: false, interestDomains: [] });
+  });
+
+  it("完了済みユーザー → completed: true + 設定値", () => {
+    const caller = appRouter.createCaller({
+      user: userWith({
+        onboardingCompletedAt: new Date(),
+        interestDomains: ["programming", "db"],
+        selfLevel: "mid",
+      }),
+    });
+    return expect(caller.onboarding.getStatus()).resolves.toMatchObject({
+      completed: true,
+      interestDomains: ["programming", "db"],
+      selfLevel: "mid",
+    });
+  });
+});

--- a/src/server/trpc/routers/onboarding.ts
+++ b/src/server/trpc/routers/onboarding.ts
@@ -1,0 +1,67 @@
+import { TRPCError } from "@trpc/server";
+import { eq } from "drizzle-orm";
+import { z } from "zod";
+
+import { getDb } from "@/db/client";
+import { DIFFICULTY_LEVELS, TIER_1_DOMAIN_IDS, users } from "@/db/schema";
+
+import { protectedProcedure, router } from "../init";
+
+const InterestDomainsSchema = z
+  .array(z.enum(TIER_1_DOMAIN_IDS))
+  .min(1, "興味分野を 1 つ以上選んでください")
+  .max(TIER_1_DOMAIN_IDS.length);
+
+// 自己申告レベルは MVP の Tier 1 用途で beginner..senior に絞る (docs/07.11)。
+// staff / principal は申告できても今 seed の concept レンジが mid 中心で当たりが
+// ほぼ 0 件になるため、診断テストが成立しない。
+const SelfLevelSchema = z.enum(["beginner", "junior", "mid", "senior"] as const);
+
+export const onboardingRouter = router({
+  /** /onboarding ページや / 側で「リダイレクトすべきか」を判定するための最小情報 */
+  getStatus: protectedProcedure.query(({ ctx }) => {
+    const u = ctx.user;
+    return {
+      completed: u.onboardingCompletedAt !== null,
+      interestDomains: (u.interestDomains ?? []) as (typeof TIER_1_DOMAIN_IDS)[number][],
+      selfLevel: (u.selfLevel ?? null) as z.infer<typeof SelfLevelSchema> | null,
+    };
+  }),
+
+  /** 興味分野 + 自己申告レベルを保存。診断 session の起動は session.start({ kind:'diagnostic' }) */
+  savePreferences: protectedProcedure
+    .input(
+      z.object({
+        interestDomains: InterestDomainsSchema,
+        selfLevel: SelfLevelSchema,
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      await getDb()
+        .update(users)
+        .set({
+          interestDomains: input.interestDomains,
+          selfLevel: input.selfLevel,
+        })
+        .where(eq(users.id, ctx.user.id));
+      return { ok: true as const };
+    }),
+
+  /** 診断テスト完了後に呼ぶ。onboarding_completed_at を NOW() に更新 */
+  complete: protectedProcedure.mutation(async ({ ctx }) => {
+    if (!ctx.user.interestDomains || ctx.user.interestDomains.length === 0 || !ctx.user.selfLevel) {
+      throw new TRPCError({
+        code: "PRECONDITION_FAILED",
+        message: "興味分野と自己申告レベルが未設定です",
+      });
+    }
+    await getDb()
+      .update(users)
+      .set({ onboardingCompletedAt: new Date() })
+      .where(eq(users.id, ctx.user.id));
+    return { ok: true as const };
+  }),
+});
+
+export const ONBOARDING_DIFFICULTY_LEVELS =
+  SelfLevelSchema.options satisfies readonly (typeof DIFFICULTY_LEVELS)[number][];

--- a/src/server/trpc/routers/session.ts
+++ b/src/server/trpc/routers/session.ts
@@ -17,6 +17,13 @@ import { generateMcq } from "@/server/generator/mcq";
 import { gradeAttempt } from "@/server/grader";
 import { CustomSessionSpecSchema, type CustomSessionSpec } from "@/server/parser/schema";
 import { selectDailyCandidates } from "@/server/scheduler/daily";
+import {
+  DIAGNOSTIC_DEFAULT_COUNT,
+  DIAGNOSTIC_MAX_COUNT,
+  DIAGNOSTIC_MIN_COUNT,
+  pickDiagnosticConcept,
+  selectDiagnosticConcepts,
+} from "@/server/scheduler/diagnostic";
 import { STREAK_FOR_PROMOTION, computePromotion } from "@/server/scheduler/promotion";
 import {
   REVIEW_DEFAULT_COUNT,
@@ -42,6 +49,10 @@ type SessionSpec = {
   customSpec?: CustomSessionSpec;
   /** Mistake Review (issue #23) の開始時に決まった concept のキュー。kind='review' のみ埋まる */
   reviewConceptIds?: string[];
+  /** Diagnostic (issue #26) の開始時に決まった concept のキュー。kind='diagnostic' のみ埋まる */
+  diagnosticConceptIds?: string[];
+  /** Diagnostic で使う固定難易度 (= user.selfLevel)。kind='diagnostic' のみ埋まる */
+  diagnosticDifficulty?: DifficultyLevel;
 };
 
 async function loadSession(sessionId: string, userId: string) {
@@ -231,14 +242,53 @@ export const sessionRouter = router({
         reviewTargetCount = clamped;
       }
 
+      // Diagnostic (issue #26): user.interestDomains × user.selfLevel から concept キューを作る。
+      // user 側の prefs が空なら PRECONDITION_FAILED で onboarding.savePreferences を促す。
+      // targetCount は DIAGNOSTIC_MIN..MAX に強制 clamp。candidates 0 件なら PRECONDITION_FAILED。
+      let diagnosticConceptIds: string[] | undefined;
+      let diagnosticTargetCount: number | undefined;
+      let diagnosticDifficulty: DifficultyLevel | undefined;
+      if (input.kind === "diagnostic") {
+        const interestDomains = ctx.user.interestDomains ?? [];
+        const selfLevel = ctx.user.selfLevel;
+        if (interestDomains.length === 0 || !selfLevel) {
+          throw new TRPCError({
+            code: "PRECONDITION_FAILED",
+            message:
+              "興味分野と自己申告レベルが未設定です。先に onboarding.savePreferences を呼んでください",
+          });
+        }
+        const clamped = Math.min(
+          Math.max(input.targetCount ?? DIAGNOSTIC_DEFAULT_COUNT, DIAGNOSTIC_MIN_COUNT),
+          DIAGNOSTIC_MAX_COUNT,
+        );
+        const queue = await selectDiagnosticConcepts({
+          interestDomains,
+          selfLevel,
+          count: clamped,
+        });
+        if (queue.length === 0) {
+          throw new TRPCError({
+            code: "PRECONDITION_FAILED",
+            message:
+              "選んだ興味分野・レベルに合致する concept がありません。seed を確認してください",
+          });
+        }
+        diagnosticConceptIds = queue;
+        diagnosticTargetCount = queue.length; // 実際に出題する数 (queue 不足時は count より少ない)
+        diagnosticDifficulty = selfLevel;
+      }
+
       // 問題数の決定順位:
       //   1. Custom Session の questionCount
       //   2. Review の場合は reviewTargetCount (10..15 clamp)
-      //   3. input.targetCount
-      //   4. 既定 5
+      //   3. Diagnostic の場合は diagnosticTargetCount (= queue.length)
+      //   4. input.targetCount
+      //   5. 既定 5
       const targetCount =
         input.customSpec?.questionCount ??
         reviewTargetCount ??
+        diagnosticTargetCount ??
         input.targetCount ??
         DEFAULT_DRILL_LENGTH;
       const spec: SessionSpec = {
@@ -246,6 +296,8 @@ export const sessionRouter = router({
         pendingQuestionId: null,
         ...(input.customSpec ? { customSpec: input.customSpec } : {}),
         ...(reviewConceptIds ? { reviewConceptIds } : {}),
+        ...(diagnosticConceptIds ? { diagnosticConceptIds } : {}),
+        ...(diagnosticDifficulty ? { diagnosticDifficulty } : {}),
       };
       const [session] = await db
         .insert(sessions)
@@ -319,11 +371,17 @@ export const sessionRouter = router({
           session.kind === "review"
             ? pickReviewConcept(spec.reviewConceptIds, session.questionCount)
             : null;
+        const diagnosticConceptId =
+          session.kind === "diagnostic"
+            ? pickDiagnosticConcept(spec.diagnosticConceptIds ?? [], session.questionCount)
+            : null;
         const effectiveConceptId = reviewConceptId
           ? reviewConceptId
-          : customSpec
-            ? (customConceptId ?? null)
-            : (input.conceptId ?? null);
+          : diagnosticConceptId
+            ? diagnosticConceptId
+            : customSpec
+              ? (customConceptId ?? null)
+              : (input.conceptId ?? null);
         // Custom で concept 未指定 + difficulty 指定時は、pickConceptForDrill で
         // その難易度を許容する concept のみを候補にする (start 時の整合は
         // concept 未指定ケースで検証できないので、ここでも補完的に filter)。
@@ -338,14 +396,22 @@ export const sessionRouter = router({
           .where(and(eq(attempts.userId, ctx.user.id), eq(attempts.conceptId, conceptRow.id)))
           .orderBy(desc(attempts.createdAt))
           .limit(STREAK_FOR_PROMOTION);
-        // custom spec があれば絶対難易度を優先 (昇格は無視。ユーザー指定を尊重)。
-        // customSpec.difficulty が未指定のときは concept がサポートする最初の難易度を
-        // fallback として使う (input.difficulty 既定 junior が concept 非対応で
-        // generateMcq が落ちるのを避ける)。
-        const requestedDifficulty: DifficultyLevel = customSpec
-          ? (customSpec.difficulty?.level ?? conceptRow.difficultyLevels[0] ?? input.difficulty)
+        // 難易度の決定順位:
+        //   1. Custom spec の絶対難易度 (ユーザー指定尊重、昇格しない)
+        //   2. Diagnostic の固定難易度 (= user.selfLevel、昇格しない)
+        //   3. それ以外: input.difficulty を起点に 3 連続正解で 1 段昇格
+        // concept がその難易度をサポートしない場合は concept.difficultyLevels[0] にフォールバック。
+        const fixedDifficulty: DifficultyLevel | null = customSpec
+          ? (customSpec.difficulty?.level ?? null)
+          : session.kind === "diagnostic"
+            ? (spec.diagnosticDifficulty ?? null)
+            : null;
+        const requestedDifficulty: DifficultyLevel = fixedDifficulty
+          ? conceptRow.difficultyLevels.includes(fixedDifficulty)
+            ? fixedDifficulty
+            : (conceptRow.difficultyLevels[0] ?? input.difficulty)
           : input.difficulty;
-        const promoted = customSpec
+        const promoted = fixedDifficulty
           ? null
           : computePromotion({
               concept: { difficultyLevels: conceptRow.difficultyLevels },

--- a/src/server/trpc/routers/session.ts
+++ b/src/server/trpc/routers/session.ts
@@ -396,22 +396,25 @@ export const sessionRouter = router({
           .where(and(eq(attempts.userId, ctx.user.id), eq(attempts.conceptId, conceptRow.id)))
           .orderBy(desc(attempts.createdAt))
           .limit(STREAK_FOR_PROMOTION);
-        // 難易度の決定順位:
-        //   1. Custom spec の絶対難易度 (ユーザー指定尊重、昇格しない)
-        //   2. Diagnostic の固定難易度 (= user.selfLevel、昇格しない)
-        //   3. それ以外: input.difficulty を起点に 3 連続正解で 1 段昇格
-        // concept がその難易度をサポートしない場合は concept.difficultyLevels[0] にフォールバック。
-        const fixedDifficulty: DifficultyLevel | null = customSpec
-          ? (customSpec.difficulty?.level ?? null)
+        // 難易度の決定:
+        //   1. 「昇格しない」モード = Custom Session または Diagnostic
+        //      - Custom: customSpec.difficulty を優先、無ければ concept.difficultyLevels[0] → input.difficulty fallback
+        //      - Diagnostic: spec.diagnosticDifficulty (= user.selfLevel) を優先、無ければ concept fallback
+        //   2. 通常 (Daily / Review): input.difficulty を起点に 3 連続正解で 1 段昇格
+        // どちらのモードでも、concept が選んだ難易度を含まなければ concept.difficultyLevels[0] に
+        // 改めて fallback する (input.difficulty 既定 'junior' が concept 非対応で generateMcq が落ちる回避)。
+        const skipPromotion = customSpec != null || session.kind === "diagnostic";
+        const preferredDifficulty: DifficultyLevel = customSpec
+          ? (customSpec.difficulty?.level ?? conceptRow.difficultyLevels[0] ?? input.difficulty)
           : session.kind === "diagnostic"
-            ? (spec.diagnosticDifficulty ?? null)
-            : null;
-        const requestedDifficulty: DifficultyLevel = fixedDifficulty
-          ? conceptRow.difficultyLevels.includes(fixedDifficulty)
-            ? fixedDifficulty
-            : (conceptRow.difficultyLevels[0] ?? input.difficulty)
-          : input.difficulty;
-        const promoted = fixedDifficulty
+            ? (spec.diagnosticDifficulty ?? conceptRow.difficultyLevels[0] ?? input.difficulty)
+            : input.difficulty;
+        const requestedDifficulty: DifficultyLevel = conceptRow.difficultyLevels.includes(
+          preferredDifficulty,
+        )
+          ? preferredDifficulty
+          : (conceptRow.difficultyLevels[0] ?? input.difficulty);
+        const promoted = skipPromotion
           ? null
           : computePromotion({
               concept: { difficultyLevels: conceptRow.difficultyLevels },


### PR DESCRIPTION
## Summary
issue #26 (Phase 4 初回オンボーディング + 初期診断テスト) を MVP スコープで実装。
docs/07.11 の「ウェルカム → 興味分野 → レベル → 診断 → 結果 → ホーム」フローを実装し、初回ログイン時のみ /onboarding に強制リダイレクトする。

### 実装内容

**DB / Schema**
- migration 0009: `users.onboarding_completed_at`, `interest_domains` (jsonb), `self_level` を追加
- `_constants.ts`: `SESSION_KINDS` に `'diagnostic'` を追加、Tier 1 6 ドメインの定数 `TIER_1_DOMAIN_IDS` を新設

**サーバー側ロジック**
- `src/server/scheduler/diagnostic.ts`: `selectDiagnosticConcepts({ interestDomains, selfLevel, count })` で domain 横断 round-robin に concept キューを生成。seed が 10 concept しかない MVP 環境で count に達しなければ循環で重複出題。`pickDiagnosticConcept(queue, questionCount)` は session.next 用の round-robin getter (review と同じ pattern)
- `src/server/trpc/routers/onboarding.ts`: `getStatus` / `savePreferences` / `complete` を実装。`interestDomains` は Tier 1 enum、`selfLevel` は MVP で beginner..senior の 4 段階 (staff/principal は seed の concept レンジ外で診断が成立しないため対象外、docs/07.11 に明記)
- `session.ts`: `kind='diagnostic'` を `start` で受けて `spec.diagnosticConceptIds` + `diagnosticDifficulty` に保存。`next` で round-robin 出題。`user.selfLevel` を固定難易度として使い、3 連続正解での昇格は行わない (`computePromotion` を bypass)。user の prefs が未設定なら `PRECONDITION_FAILED`

**UI**
- `src/app/onboarding/page.tsx`: SSR で getCurrentUser を見て、未ログインは /login、完了済みは / にリダイレクト
- `src/features/onboarding/onboarding-screen.tsx`: 4 段階 state machine (welcome 3 枚 → preferences → running → result)。running フェーズは既存 `<DrillScreen>` を `skipInitialStartCard` で埋め込み、`onReset` で result に遷移。Result で `complete` → `router.replace('/')` + `router.refresh()` で Server Component の getCurrentUser を再評価
- `src/app/page.tsx`: 認証済みかつ `!user.onboardingCompletedAt` なら `redirect('/onboarding')`
- `src/components/layout/nav-routes.ts`: `/onboarding` を `NAV_HIDDEN_PREFIXES` に追加 (没入画面なので BottomNav 非表示)

### 受け入れ基準の対応
- [x] 初回ログイン時のみ `/onboarding` にリダイレクト → app/page.tsx の SSR redirect
- [x] 興味分野 (Tier 1 の 6 ドメインから選択) → TIER_1_DOMAIN_IDS から複数選択
- [x] レベル自己申告 (beginner/junior/mid/senior) → SELF_LEVELS の 4 段階
- [x] 各分野から 2-3 問ずつ ~20 問の診断セッション → selectDiagnosticConcepts で domain 横断 round-robin、count は DIAGNOSTIC_DEFAULT=10 / MAX=20 (seed が増えれば自動拡張)
- [x] 結果から mastery 初期値を設定 → 既存の attempt → updateMasteryAfterAttempt パスをそのまま使う (各回答が mastery row を作る/更新する)
- [x] 完了後 / に遷移して Daily Drill に誘導 → onComplete で router.replace('/') + refresh

### Test plan
- [x] `pnpm typecheck` ✓
- [x] `pnpm test -- --run` ✓ (233/233、新規 +16: pickDiagnosticConcept / selectDiagnosticConcepts / onboarding router validation / onboarding.complete prerequisites / onboarding.getStatus)
- [x] `pnpm build` ✓ (/onboarding ルート登録確認済み)

closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)