### PR TITLE
feat(deep-dive): 1 ドメイン集中の Deep Dive モード (#28)

### DIFF
--- a/docs/06-architecture.md
+++ b/docs/06-architecture.md
@@ -523,7 +523,7 @@ Tanren/
 │   ├── server/
 │   │   ├── trpc/                  # tRPC ルータ
 │   │   ├── auth/                  # Passkey (WebAuthn) セッション管理
-│   │   ├── scheduler/             # FSRS ロジック + daily / review / diagnostic 候補選定
+│   │   ├── scheduler/             # FSRS ロジック + daily / review / diagnostic / deep-dive 候補選定
 │   │   ├── generator/             # 問題生成
 │   │   ├── grader/                # 採点 + rebut + 誤概念抽出
 │   │   ├── parser/                # NL パース (Custom Session)
@@ -540,6 +540,7 @@ Tanren/
 │   │   ├── insights/              # Dashboard / History / Search
 │   │   ├── review/                # Mistake Review 入口
 │   │   ├── onboarding/            # 初回ウェルカム + 興味分野 + 診断テスト (issue #26)
+│   │   ├── deep-dive/             # Deep Dive モード (1 ドメイン集中、issue #28)
 │   │   └── pwa/                   # Service Worker 登録 (issue #24)
 │   ├── components/
 │   │   ├── ui/                    # shadcn/ui

--- a/src/app/deep/[domain]/page.tsx
+++ b/src/app/deep/[domain]/page.tsx
@@ -1,0 +1,26 @@
+import { notFound, redirect } from "next/navigation";
+
+import { DOMAIN_IDS, type DomainId } from "@/db/schema";
+import { DeepDiveScreen } from "@/features/deep-dive/deep-dive-screen";
+import { getCurrentUser } from "@/server/auth/session";
+
+export const dynamic = "force-dynamic";
+
+function isDomainId(v: string): v is DomainId {
+  return (DOMAIN_IDS as readonly string[]).includes(v);
+}
+
+export default async function DeepDivePage({ params }: { params: Promise<{ domain: string }> }) {
+  const user = await getCurrentUser();
+  if (!user) redirect("/login");
+  if (!user.onboardingCompletedAt) redirect("/onboarding");
+
+  const { domain } = await params;
+  if (!isDomainId(domain)) notFound();
+
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center gap-6 p-6">
+      <DeepDiveScreen domainId={domain} />
+    </main>
+  );
+}

--- a/src/components/layout/nav-routes.test.ts
+++ b/src/components/layout/nav-routes.test.ts
@@ -35,6 +35,8 @@ describe("isNavHidden", () => {
     expect(isNavHidden("/review")).toBe(true);
     expect(isNavHidden("/login")).toBe(true);
     expect(isNavHidden("/onboarding")).toBe(true);
+    expect(isNavHidden("/deep")).toBe(true);
+    expect(isNavHidden("/deep/network")).toBe(true);
   });
 
   it("Home / Insights では表示", () => {

--- a/src/components/layout/nav-routes.ts
+++ b/src/components/layout/nav-routes.ts
@@ -28,7 +28,14 @@ export const NAV_TABS: NavTab[] = [
 ];
 
 /** BottomNav を出さないルート (セッション中の没入画面 + 認証画面 + オンボーディング) */
-export const NAV_HIDDEN_PREFIXES = ["/drill", "/custom", "/review", "/login", "/onboarding"];
+export const NAV_HIDDEN_PREFIXES = [
+  "/drill",
+  "/custom",
+  "/review",
+  "/deep",
+  "/login",
+  "/onboarding",
+];
 
 export function isNavHidden(pathname: string): boolean {
   return NAV_HIDDEN_PREFIXES.some(

--- a/src/features/deep-dive/deep-dive-screen.tsx
+++ b/src/features/deep-dive/deep-dive-screen.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import { AlertTriangle, Loader2, Play } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useCallback, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import type { DomainId } from "@/db/schema";
+import { DrillScreen } from "@/features/drill/drill-screen";
+import { useDrillStore } from "@/features/drill/drill-state";
+import { trpc } from "@/lib/trpc/react";
+
+type Phase =
+  | { kind: "idle" }
+  | { kind: "running"; sessionId: string }
+  | { kind: "error"; message: string };
+
+const DOMAIN_LABELS: Record<DomainId, string> = {
+  programming: "Programming",
+  dsa: "DSA",
+  os: "OS",
+  network: "Network",
+  db: "Database",
+  security: "Security",
+  distributed: "Distributed",
+  design: "Design",
+  devops: "DevOps",
+  tools: "Tools",
+  low_level: "Low-level",
+  ai_ml: "AI / ML",
+  frontend: "Frontend",
+};
+
+/**
+ * Deep Dive セッション画面 (issue #28)。
+ * 1 ドメインを prereqs トポロジカルソート → difficulty 昇順で 10-15 問出題。
+ *
+ * 起動フロー:
+ *   - /deep/:domain でこの画面を表示
+ *   - idle: スタートカード (ドメイン名 + 「集中出題を始める」)
+ *   - 開始ボタン → session.start({kind:'deep', domainId}) → session.next → running
+ *   - running: DrillScreen を skipInitialStartCard で埋め込み
+ *   - 完了後「ホームに戻る」で /insights に遷移 (元の導線 Weakest カードに戻る想定)
+ */
+export function DeepDiveScreen({ domainId }: { domainId: DomainId }) {
+  const router = useRouter();
+  const [phase, setPhase] = useState<Phase>({ kind: "idle" });
+  const startSession = trpc.session.start.useMutation();
+  const nextQuestion = trpc.session.next.useMutation();
+  const { reset, setSession, setQuestion } = useDrillStore();
+
+  const onStart = useCallback(async () => {
+    try {
+      reset();
+      const { sessionId } = await startSession.mutateAsync({ kind: "deep", domainId });
+      const next = await nextQuestion.mutateAsync({ sessionId });
+      setSession(sessionId);
+      setPhase({ kind: "running", sessionId });
+      if (!next.done) setQuestion(next.question);
+    } catch (e) {
+      setPhase({
+        kind: "error",
+        message: e instanceof Error ? e.message : "Deep Dive の開始に失敗しました",
+      });
+    }
+  }, [domainId, reset, startSession, nextQuestion, setSession, setQuestion]);
+
+  if (phase.kind === "running") {
+    return (
+      <DrillScreen
+        onReset={() => {
+          // 完了後は Insights (元の導線 Weakest カードの画面) に戻す
+          router.push("/insights");
+        }}
+        skipInitialStartCard
+      />
+    );
+  }
+
+  const pending = startSession.isPending || nextQuestion.isPending;
+  return (
+    <Card className="w-full max-w-md">
+      <CardHeader>
+        <CardTitle>Deep Dive: {DOMAIN_LABELS[domainId] ?? domainId}</CardTitle>
+        <CardDescription>
+          {DOMAIN_LABELS[domainId] ?? domainId} の concept を prereqs 順・難易度昇順で 10-15
+          問解きます。
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="text-muted-foreground space-y-2 text-sm">
+        <p>1 ドメイン集中 30 分前後のセッションです。</p>
+        {phase.kind === "error" && (
+          <div className="text-destructive flex items-start gap-2">
+            <AlertTriangle className="mt-0.5 h-4 w-4" />
+            <span className="break-all">{phase.message}</span>
+          </div>
+        )}
+      </CardContent>
+      <CardFooter>
+        <Button onClick={onStart} disabled={pending} className="min-h-12 w-full px-6">
+          {pending ? (
+            <Loader2 className="mr-1 h-4 w-4 animate-spin" />
+          ) : (
+            <Play className="mr-1 h-4 w-4" />
+          )}
+          集中出題を始める
+        </Button>
+      </CardFooter>
+    </Card>
+  );
+}

--- a/src/features/insights/overview-screen.tsx
+++ b/src/features/insights/overview-screen.tsx
@@ -31,14 +31,18 @@ function ProgressBar({ value }: { value: number }) {
 function ItemRow({
   item,
   hint,
+  showDeepDive,
 }: {
   item: OverviewItem;
   hint: (it: OverviewItem) => string | null;
+  /** Weakest カード等で「このドメインを Deep Dive」導線を出すかどうか (issue #28) */
+  showDeepDive?: boolean;
 }) {
   const message = hint(item);
   // /custom?conceptId=... に直接 conceptId を渡し、parser を迂回して customSpec.concepts を
   // 決定論的に固定する (Round 3 指摘 #1: 自然言語 prefill では別 concept に解釈されうる)。
   const customHref = `/custom?conceptId=${encodeURIComponent(item.conceptId)}`;
+  const deepHref = `/deep/${encodeURIComponent(item.domainId)}`;
   return (
     <li className="border-border rounded-md border p-2 text-sm">
       <div className="flex items-baseline justify-between gap-2">
@@ -51,10 +55,15 @@ function ItemRow({
       <div className="text-muted-foreground mt-1 text-xs">
         {item.domainId} / {item.subdomainId} ・ {item.conceptId}
       </div>
-      <div className="mt-2">
+      <div className="mt-2 flex flex-wrap gap-2">
         <Button asChild variant="outline" size="sm">
           <Link href={customHref}>🎯 この concept を出題</Link>
         </Button>
+        {showDeepDive && (
+          <Button asChild variant="outline" size="sm">
+            <Link href={deepHref}>🏊 {item.domainId} を Deep Dive</Link>
+          </Button>
+        )}
       </div>
     </li>
   );
@@ -138,6 +147,7 @@ export function InsightsOverviewScreen() {
                       ? `${it.attemptCount} 問中 ${it.wrongCount} 問ミス (全期間)`
                       : null
                   }
+                  showDeepDive
                 />
               ))}
             </ul>

--- a/src/server/scheduler/deep-dive.test.ts
+++ b/src/server/scheduler/deep-dive.test.ts
@@ -1,0 +1,115 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { pickDeepDiveStep, selectDeepDiveQueue, topoSortByPrereqs } from "./deep-dive";
+
+const queue: Array<() => unknown> = [];
+vi.mock("@/db/client", () => {
+  function makeBuilder(): unknown {
+    const b: Record<string, unknown> = {
+      from: () => b,
+      where: () => b,
+      then: (onFulfilled: (v: unknown) => unknown) => {
+        const handler = queue.shift();
+        const result = handler ? handler() : [];
+        return Promise.resolve(result).then(onFulfilled);
+      },
+    };
+    return b;
+  }
+  return { getDb: () => ({ select: () => makeBuilder() }) };
+});
+
+beforeEach(() => {
+  queue.length = 0;
+});
+
+describe("topoSortByPrereqs", () => {
+  it("prereqs のない concept は先頭、依存は後ろに積まれる", () => {
+    const out = topoSortByPrereqs([
+      { id: "b", prereqs: ["a"] },
+      { id: "a", prereqs: [] },
+      { id: "c", prereqs: ["a", "b"] },
+    ]);
+    expect(out).toEqual(["a", "b", "c"]);
+  });
+
+  it("同レベル内は id 昇順で決定論", () => {
+    const out = topoSortByPrereqs([
+      { id: "z", prereqs: [] },
+      { id: "a", prereqs: [] },
+      { id: "m", prereqs: [] },
+    ]);
+    expect(out).toEqual(["a", "m", "z"]);
+  });
+
+  it("domain 外 prereq は無視して domain 内 graph を作る", () => {
+    // "external.x" は今回の入力に存在しない concept: 外部依存扱いで無視される
+    const out = topoSortByPrereqs([
+      { id: "a", prereqs: ["external.x"] },
+      { id: "b", prereqs: ["a"] },
+    ]);
+    expect(out).toEqual(["a", "b"]);
+  });
+
+  it("循環があれば残りを id 順で末尾に積む (MVP 安全網)", () => {
+    // a <-> b の循環
+    const out = topoSortByPrereqs([
+      { id: "a", prereqs: ["b"] },
+      { id: "b", prereqs: ["a"] },
+      { id: "c", prereqs: [] },
+    ]);
+    expect(out[0]).toBe("c");
+    // 残り 2 件は id 順で積まれる
+    expect(out.slice(1).sort()).toEqual(["a", "b"]);
+  });
+});
+
+describe("selectDeepDiveQueue", () => {
+  it("concept 0 件なら空配列", async () => {
+    queue.push(() => []);
+    const out = await selectDeepDiveQueue({ domainId: "network", count: 10 });
+    expect(out).toEqual([]);
+  });
+
+  it("topo 順 → 難易度昇順 → 足りなければ循環で count 件埋める", async () => {
+    queue.push(() => [
+      // 依存順: a -> b / a の difficulty = [junior], b = [junior, mid]
+      { id: "b", prereqs: ["a"], difficultyLevels: ["mid", "junior"] },
+      { id: "a", prereqs: [], difficultyLevels: ["junior"] },
+    ]);
+    const out = await selectDeepDiveQueue({ domainId: "network", count: 5 });
+    // flatten は [(a,junior),(b,junior),(b,mid)] → 5 件は循環で [(a,junior),(b,junior),(b,mid),(a,junior),(b,junior)]
+    expect(out).toEqual([
+      { conceptId: "a", difficulty: "junior" },
+      { conceptId: "b", difficulty: "junior" },
+      { conceptId: "b", difficulty: "mid" },
+      { conceptId: "a", difficulty: "junior" },
+      { conceptId: "b", difficulty: "junior" },
+    ]);
+  });
+
+  it("count が available より少ないと先頭 count 件で打ち切り", async () => {
+    queue.push(() => [{ id: "a", prereqs: [], difficultyLevels: ["beginner", "junior", "mid"] }]);
+    const out = await selectDeepDiveQueue({ domainId: "network", count: 2 });
+    expect(out).toEqual([
+      { conceptId: "a", difficulty: "beginner" },
+      { conceptId: "a", difficulty: "junior" },
+    ]);
+  });
+});
+
+describe("pickDeepDiveStep", () => {
+  it("空キューは null", () => {
+    expect(pickDeepDiveStep([], 0)).toBeNull();
+  });
+
+  it("round-robin で questionCount % len", () => {
+    const q = [
+      { conceptId: "a", difficulty: "junior" as const },
+      { conceptId: "b", difficulty: "mid" as const },
+    ];
+    expect(pickDeepDiveStep(q, 0)).toEqual(q[0]);
+    expect(pickDeepDiveStep(q, 1)).toEqual(q[1]);
+    expect(pickDeepDiveStep(q, 2)).toEqual(q[0]);
+  });
+});

--- a/src/server/scheduler/deep-dive.ts
+++ b/src/server/scheduler/deep-dive.ts
@@ -1,0 +1,116 @@
+import { eq } from "drizzle-orm";
+
+import { getDb } from "@/db/client";
+import { concepts, DIFFICULTY_LEVELS, type DifficultyLevel, type DomainId } from "@/db/schema";
+
+export const DEEP_DIVE_DEFAULT_COUNT = 12;
+export const DEEP_DIVE_MIN_COUNT = 10;
+export const DEEP_DIVE_MAX_COUNT = 15;
+
+/** Deep Dive キューの 1 ステップ (docs/02 §2.6.2)。 */
+export type DeepStep = { conceptId: string; difficulty: DifficultyLevel };
+
+type SelectArgs = {
+  domainId: DomainId;
+  count: number;
+};
+
+/** difficulty_levels を DIFFICULTY_LEVELS 順 (beginner..principal) に sort */
+function sortedDifficulties(levels: DifficultyLevel[]): DifficultyLevel[] {
+  const order = new Map(DIFFICULTY_LEVELS.map((lvl, i) => [lvl, i] as const));
+  return [...levels].sort((a, b) => (order.get(a) ?? 99) - (order.get(b) ?? 99));
+}
+
+/** Kahn 法での topological sort。同レベル内は concept.id 昇順で stable に並べる。
+ *  prereqs に domain 外 concept がある場合は「外部 prereq はとりあえず満たされている」と仮定して
+ *  domain 内 graph を構築する (docs/02 は「ドメイン内で閉じる」と明言していないが、
+ *  1 domain 集中学習の目的に照らすと外部依存を全部解決していない状態でも動かしたい)。
+ *  prereq 循環があれば残った concept は後ろに id 順で積む (MVP、seed は循環を認めない前提)。
+ */
+export function topoSortByPrereqs(rows: Array<{ id: string; prereqs: string[] | null }>): string[] {
+  const ids = new Set(rows.map((r) => r.id));
+  const indeg = new Map<string, number>();
+  const adj = new Map<string, string[]>();
+  for (const r of rows) {
+    indeg.set(r.id, 0);
+    adj.set(r.id, []);
+  }
+  for (const r of rows) {
+    for (const p of r.prereqs ?? []) {
+      if (!ids.has(p)) continue; // domain 外 prereq は無視
+      adj.get(p)!.push(r.id);
+      indeg.set(r.id, (indeg.get(r.id) ?? 0) + 1);
+    }
+  }
+  const queue: string[] = [...indeg.entries()]
+    .filter(([, d]) => d === 0)
+    .map(([id]) => id)
+    .sort(); // 決定論
+  const out: string[] = [];
+  while (queue.length) {
+    const id = queue.shift()!;
+    out.push(id);
+    for (const next of adj.get(id) ?? []) {
+      const d = (indeg.get(next) ?? 0) - 1;
+      indeg.set(next, d);
+      if (d === 0) {
+        // insertion sort で決定論を保つ
+        const pos = queue.findIndex((x) => x > next);
+        if (pos < 0) queue.push(next);
+        else queue.splice(pos, 0, next);
+      }
+    }
+  }
+  // 循環があれば未処理 concept を id 順で末尾に積む (MVP 安全網)
+  for (const id of ids) {
+    if (!out.includes(id)) out.push(id);
+  }
+  return out;
+}
+
+/** domain 内 concept を prereqs → difficulty 昇順で並べて、最大 count 件のキューを作る。
+ *  docs/02 §2.6.2: 指定ドメインの concept を prereqs 順にトポロジカルソート → difficulty 昇順。
+ */
+export async function selectDeepDiveQueue({ domainId, count }: SelectArgs): Promise<DeepStep[]> {
+  const rows = await getDb()
+    .select({
+      id: concepts.id,
+      prereqs: concepts.prereqs,
+      difficultyLevels: concepts.difficultyLevels,
+    })
+    .from(concepts)
+    .where(eq(concepts.domainId, domainId));
+
+  if (rows.length === 0) return [];
+
+  const order = topoSortByPrereqs(rows.map((r) => ({ id: r.id, prereqs: r.prereqs ?? [] })));
+  const byId = new Map(rows.map((r) => [r.id, r] as const));
+
+  // concept を topo 順に巡回し、各 concept の difficulty 昇順で slot を作る。
+  // 全 slot を flatten した後、先頭から count 件を取る (遅い difficulty は 1 周目で出ないため
+  // 後から再度同 concept を上位難度で解く構成にはしない。MVP は 1 回 1 concept × 1 diff)。
+  //
+  // 例: [c1:[beginner,junior], c2:[junior,mid]] → [(c1,beginner),(c1,junior),(c2,junior),(c2,mid)]
+  const steps: DeepStep[] = [];
+  for (const id of order) {
+    const row = byId.get(id);
+    if (!row) continue;
+    for (const d of sortedDifficulties(row.difficultyLevels)) {
+      steps.push({ conceptId: id, difficulty: d });
+    }
+  }
+  if (steps.length === 0) return [];
+
+  // 足りなければ循環で重複出題 (review と同じ発想)
+  const result: DeepStep[] = [];
+  for (let i = 0; i < count; i++) {
+    result.push(steps[i % steps.length]!);
+  }
+  return result;
+}
+
+/** session.next から呼び出す round-robin getter */
+export function pickDeepDiveStep(queue: DeepStep[], questionCount: number): DeepStep | null {
+  if (queue.length === 0) return null;
+  return queue[questionCount % queue.length] ?? null;
+}

--- a/src/server/trpc/routers/session.ts
+++ b/src/server/trpc/routers/session.ts
@@ -7,16 +7,26 @@ import {
   attempts,
   concepts,
   DIFFICULTY_LEVELS,
+  DOMAIN_IDS,
   SESSION_KINDS,
   sessions,
   THINKING_STYLES,
   type DifficultyLevel,
+  type DomainId,
 } from "@/db/schema";
 import type { CopyForLlmQuestionMeta } from "@/lib/share/copy-for-llm";
 import { generateMcq } from "@/server/generator/mcq";
 import { gradeAttempt } from "@/server/grader";
 import { CustomSessionSpecSchema, type CustomSessionSpec } from "@/server/parser/schema";
 import { selectDailyCandidates } from "@/server/scheduler/daily";
+import {
+  DEEP_DIVE_DEFAULT_COUNT,
+  DEEP_DIVE_MAX_COUNT,
+  DEEP_DIVE_MIN_COUNT,
+  pickDeepDiveStep,
+  selectDeepDiveQueue,
+  type DeepStep,
+} from "@/server/scheduler/deep-dive";
 import {
   DIAGNOSTIC_DEFAULT_COUNT,
   DIAGNOSTIC_MAX_COUNT,
@@ -53,6 +63,10 @@ type SessionSpec = {
   diagnosticConceptIds?: string[];
   /** Diagnostic で使う固定難易度 (= user.selfLevel)。kind='diagnostic' のみ埋まる */
   diagnosticDifficulty?: DifficultyLevel;
+  /** Deep Dive (issue #28) の開始時に決まった (conceptId, difficulty) のキュー。kind='deep' のみ埋まる */
+  deepQueue?: DeepStep[];
+  /** Deep Dive のドメイン (spec 整合性チェック用)。kind='deep' のみ埋まる */
+  deepDomainId?: DomainId;
 };
 
 async function loadSession(sessionId: string, userId: string) {
@@ -116,6 +130,8 @@ export const sessionRouter = router({
         targetCount: z.number().int().min(1).max(20).optional(),
         /** Custom Session 指定時のみ。パース結果 (CustomSessionSpec) を Zod で再検証 */
         customSpec: CustomSessionSpecSchema.optional(),
+        /** Deep Dive (issue #28) の対象ドメイン。kind='deep' のとき必須 */
+        domainId: z.enum(DOMAIN_IDS).optional(),
       }),
     )
     .mutation(async ({ ctx, input }) => {
@@ -242,6 +258,40 @@ export const sessionRouter = router({
         reviewTargetCount = clamped;
       }
 
+      // Deep Dive (issue #28): domain 内 concept を prereqs トポロジカルソート + difficulty 昇順で
+      // 並べて targetCount 件の (conceptId, difficulty) キューを作る。domain 未指定なら BAD_REQUEST、
+      // 候補 0 件は PRECONDITION_FAILED。domainId は kind='deep' 以外で指定されたら reject (混入防止)。
+      let deepQueue: DeepStep[] | undefined;
+      let deepTargetCount: number | undefined;
+      let deepDomainId: DomainId | undefined;
+      if (input.kind === "deep") {
+        if (!input.domainId) {
+          throw new TRPCError({
+            code: "BAD_REQUEST",
+            message: "kind='deep' には domainId が必要です",
+          });
+        }
+        const clamped = Math.min(
+          Math.max(input.targetCount ?? DEEP_DIVE_DEFAULT_COUNT, DEEP_DIVE_MIN_COUNT),
+          DEEP_DIVE_MAX_COUNT,
+        );
+        const queue = await selectDeepDiveQueue({ domainId: input.domainId, count: clamped });
+        if (queue.length === 0) {
+          throw new TRPCError({
+            code: "PRECONDITION_FAILED",
+            message: `domain="${input.domainId}" に concept がありません`,
+          });
+        }
+        deepQueue = queue;
+        deepTargetCount = queue.length;
+        deepDomainId = input.domainId;
+      } else if (input.domainId) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: "domainId は kind='deep' のときだけ指定できます",
+        });
+      }
+
       // Diagnostic (issue #26): user.interestDomains × user.selfLevel から concept キューを作る。
       // user 側の prefs が空なら PRECONDITION_FAILED で onboarding.savePreferences を促す。
       // targetCount は DIAGNOSTIC_MIN..MAX に強制 clamp。candidates 0 件なら PRECONDITION_FAILED。
@@ -283,12 +333,14 @@ export const sessionRouter = router({
       //   1. Custom Session の questionCount
       //   2. Review の場合は reviewTargetCount (10..15 clamp)
       //   3. Diagnostic の場合は diagnosticTargetCount (= queue.length)
-      //   4. input.targetCount
-      //   5. 既定 5
+      //   4. Deep Dive の場合は deepTargetCount (= queue.length)
+      //   5. input.targetCount
+      //   6. 既定 5
       const targetCount =
         input.customSpec?.questionCount ??
         reviewTargetCount ??
         diagnosticTargetCount ??
+        deepTargetCount ??
         input.targetCount ??
         DEFAULT_DRILL_LENGTH;
       const spec: SessionSpec = {
@@ -298,6 +350,8 @@ export const sessionRouter = router({
         ...(reviewConceptIds ? { reviewConceptIds } : {}),
         ...(diagnosticConceptIds ? { diagnosticConceptIds } : {}),
         ...(diagnosticDifficulty ? { diagnosticDifficulty } : {}),
+        ...(deepQueue ? { deepQueue } : {}),
+        ...(deepDomainId ? { deepDomainId } : {}),
       };
       const [session] = await db
         .insert(sessions)
@@ -375,13 +429,19 @@ export const sessionRouter = router({
           session.kind === "diagnostic"
             ? pickDiagnosticConcept(spec.diagnosticConceptIds ?? [], session.questionCount)
             : null;
+        const deepStep =
+          session.kind === "deep"
+            ? pickDeepDiveStep(spec.deepQueue ?? [], session.questionCount)
+            : null;
         const effectiveConceptId = reviewConceptId
           ? reviewConceptId
           : diagnosticConceptId
             ? diagnosticConceptId
-            : customSpec
-              ? (customConceptId ?? null)
-              : (input.conceptId ?? null);
+            : deepStep
+              ? deepStep.conceptId
+              : customSpec
+                ? (customConceptId ?? null)
+                : (input.conceptId ?? null);
         // Custom で concept 未指定 + difficulty 指定時は、pickConceptForDrill で
         // その難易度を許容する concept のみを候補にする (start 時の整合は
         // concept 未指定ケースで検証できないので、ここでも補完的に filter)。
@@ -397,18 +457,22 @@ export const sessionRouter = router({
           .orderBy(desc(attempts.createdAt))
           .limit(STREAK_FOR_PROMOTION);
         // 難易度の決定:
-        //   1. 「昇格しない」モード = Custom Session または Diagnostic
+        //   1. 「昇格しない」モード = Custom / Diagnostic / Deep Dive
         //      - Custom: customSpec.difficulty を優先、無ければ concept.difficultyLevels[0] → input.difficulty fallback
         //      - Diagnostic: spec.diagnosticDifficulty (= user.selfLevel) を優先、無ければ concept fallback
+        //      - Deep Dive: deepStep.difficulty (予め topo+difficulty 昇順に決定) を優先、無ければ concept fallback
         //   2. 通常 (Daily / Review): input.difficulty を起点に 3 連続正解で 1 段昇格
         // どちらのモードでも、concept が選んだ難易度を含まなければ concept.difficultyLevels[0] に
         // 改めて fallback する (input.difficulty 既定 'junior' が concept 非対応で generateMcq が落ちる回避)。
-        const skipPromotion = customSpec != null || session.kind === "diagnostic";
+        const skipPromotion =
+          customSpec != null || session.kind === "diagnostic" || session.kind === "deep";
         const preferredDifficulty: DifficultyLevel = customSpec
           ? (customSpec.difficulty?.level ?? conceptRow.difficultyLevels[0] ?? input.difficulty)
           : session.kind === "diagnostic"
             ? (spec.diagnosticDifficulty ?? conceptRow.difficultyLevels[0] ?? input.difficulty)
-            : input.difficulty;
+            : session.kind === "deep"
+              ? (deepStep?.difficulty ?? conceptRow.difficultyLevels[0] ?? input.difficulty)
+              : input.difficulty;
         const requestedDifficulty: DifficultyLevel = conceptRow.difficultyLevels.includes(
           preferredDifficulty,
         )


### PR DESCRIPTION
## Summary
issue #28 (Phase 5+) Deep Dive モードを実装。指定ドメイン内の concept を prereqs トポロジカルソート → difficulty 昇順で 10-15 問出題する。

### 主要実装
- `src/server/scheduler/deep-dive.ts` — Kahn 法による topological sort (同レベル id 昇順で決定論、外部 prereq 無視、循環安全網)、selectDeepDiveQueue で flatten + count 件に循環埋め、pickDeepDiveStep で round-robin
- `session.ts` — kind='deep' を start で受けて domainId 必須検証、`spec.deepQueue` + `deepDomainId` に保存。next で pickDeepDiveStep により (conceptId, difficulty) を同時取得。skipPromotion に deep を追加
- `/deep/[domain]/page.tsx` — 動的ルート。SSR で DomainId 検証 (notFound 404)、未ログイン→/login、onboarding 未完了→/onboarding へ誘導
- `features/deep-dive/deep-dive-screen.tsx` — idle → start → running の 2 phase。完了後は `/insights` に戻す (Weakest カードの導線を閉じる)
- Insights Weakest カード: 「🏊 {domainId} を Deep Dive」リンクを追加 (`showDeepDive` prop で opt-in、Strongest / Blind Spots には出さない)
- `/deep` を `NAV_HIDDEN_PREFIXES` に追加 (セッション中は BottomNav 非表示)

### 受け入れ基準
- [x] `/deep/:domain` ルート
- [x] prereqs トポロジカルソート + difficulty 昇順出題
- [x] 既存 Drill 画面の流用 (DrillScreen を skipInitialStartCard で埋め込み)
- [x] Insights の Weakest カードから導線

### Test plan
- [x] `pnpm typecheck` ✓
- [x] `pnpm test -- --run` ✓ (249/249、新規 +9: topoSortByPrereqs 4 件 / selectDeepDiveQueue 3 件 / pickDeepDiveStep 2 件)
- [x] `pnpm build` ✓ (`/deep/[domain]` ルート登録確認済み)

closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)