### PR TITLE
feat(insights): Mastery Map サンバースト (#29)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,5 @@ Thumbs.db
 *.pem
 *.key
 secrets/
+.vercel
+.env*.local

--- a/docs/05-insights.md
+++ b/docs/05-insights.md
@@ -99,10 +99,18 @@
   Network (54%)╰─  DB (71%) ─╯
 ```
 
-### 実装
+### 実装 (issue #29, Phase 5+)
 
-- **Recharts** or **D3.js** で実装
-- Phase 2 以降の機能 (MVP では一覧表形式で代替)
+- **依存ゼロの自作 SVG sunburst** (`src/features/insights/mastery-map-screen.tsx`)
+  - Recharts / D3 は追加しない方針 (CLAUDE.md §3: ライブラリ追加は最小限)。
+  - 3 リング構成: 中心=domain / 中層=subdomain / 外層=concept。
+  - 面積は `attempt_count + 1` smoothing (未着手 concept も目視できる大きさを確保)。
+  - 色は 4 tier (untouched/weak/mid/mastered、docs §5.4 の定義通り)。
+  - 外層 concept のタップで `/custom?conceptId=...` にドリルダウン (Custom Session で単一 concept を出題)。
+- 集計ロジックは `src/server/insights/mastery-map.ts` の `fetchMasteryMap`。
+  Insights overview と同じ 3 テーブル結合を使うが、Top N ではなく階層全体を返す。
+- `/insights/map` ルート (`src/app/insights/map/page.tsx`) で SSR 認証チェック + mount。
+- Insights Dashboard の「Your Learning, Today」カードに「🗺 Mastery Map を開く」導線を追加。
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "openai": "^6.34.0",
     "react": "19.2.4",
     "react-dom": "19.2.4",
+    "server-only": "^0.0.1",
     "tailwind-merge": "^3.5.0",
     "ts-fsrs": "^5.3.2",
     "yaml": "^2.8.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,6 +68,9 @@ importers:
       react-dom:
         specifier: 19.2.4
         version: 19.2.4(react@19.2.4)
+      server-only:
+        specifier: ^0.0.1
+        version: 0.0.1
       tailwind-merge:
         specifier: ^3.5.0
         version: 3.5.0
@@ -3723,6 +3726,9 @@ packages:
     resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
     engines: {node: '>=10'}
     hasBin: true
+
+  server-only@0.0.1:
+    resolution: {integrity: sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==}
 
   set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
@@ -7669,6 +7675,8 @@ snapshots:
   semver@6.3.1: {}
 
   semver@7.7.4: {}
+
+  server-only@0.0.1: {}
 
   set-function-length@1.2.2:
     dependencies:

--- a/src/app/insights/map/page.tsx
+++ b/src/app/insights/map/page.tsx
@@ -1,0 +1,17 @@
+import { redirect } from "next/navigation";
+
+import { MasteryMapScreen } from "@/features/insights/mastery-map-screen";
+import { getCurrentUser } from "@/server/auth/session";
+
+export const dynamic = "force-dynamic";
+
+export default async function MasteryMapPage() {
+  const user = await getCurrentUser();
+  if (!user) redirect("/login");
+  if (!user.onboardingCompletedAt) redirect("/onboarding");
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-start gap-6 p-6">
+      <MasteryMapScreen />
+    </main>
+  );
+}

--- a/src/features/insights/mastery-map-screen.tsx
+++ b/src/features/insights/mastery-map-screen.tsx
@@ -1,0 +1,270 @@
+"use client";
+
+import type { inferRouterOutputs } from "@trpc/server";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { cn } from "@/lib/cn";
+import type { AppRouter } from "@/server/trpc/routers";
+import type { MasteryTier } from "@/server/insights/mastery-map";
+import { trpc } from "@/lib/trpc/react";
+
+type MasteryMap = inferRouterOutputs<AppRouter>["insights"]["masteryMap"];
+
+/** SVG 座標系は上 = 負 Y。sunburst は 12 時方向から時計回りに描画する。 */
+const SIZE = 360;
+const CENTER = SIZE / 2;
+/** 3 rings: domain / subdomain / concept */
+const RING_WIDTHS = {
+  domain: { inner: 0, outer: 48 },
+  subdomain: { inner: 48, outer: 108 },
+  concept: { inner: 108, outer: 170 },
+} as const;
+
+const TIER_COLOR: Record<MasteryTier, string> = {
+  untouched: "#9ca3af", // gray-400
+  weak: "#ef4444", // red-500
+  mid: "#eab308", // yellow-500
+  mastered: "#22c55e", // green-500
+};
+
+/** domain / subdomain など attempt>0 なしで ring に色をつけるために、
+ *  平均 masteryPct と「観測 concept が 1 つでもあるか」で tier を近似する */
+function tierFromAggregate(args: { masteryPct: number; attemptCount: number }): MasteryTier {
+  if (args.attemptCount <= 0) return "untouched";
+  if (args.masteryPct < 0.4) return "weak";
+  if (args.masteryPct < 0.8) return "mid";
+  return "mastered";
+}
+
+/** SVG path: 円環 (ドーナツ) の弧セグメントを 1 つ描く */
+function arcPath(opts: {
+  startAngle: number; // rad, 12 時方向 = -π/2
+  endAngle: number;
+  innerR: number;
+  outerR: number;
+}): string {
+  const { startAngle, endAngle, innerR, outerR } = opts;
+  const x1 = CENTER + outerR * Math.cos(startAngle);
+  const y1 = CENTER + outerR * Math.sin(startAngle);
+  const x2 = CENTER + outerR * Math.cos(endAngle);
+  const y2 = CENTER + outerR * Math.sin(endAngle);
+  const x3 = CENTER + innerR * Math.cos(endAngle);
+  const y3 = CENTER + innerR * Math.sin(endAngle);
+  const x4 = CENTER + innerR * Math.cos(startAngle);
+  const y4 = CENTER + innerR * Math.sin(startAngle);
+  const largeArc = endAngle - startAngle > Math.PI ? 1 : 0;
+  return [
+    `M ${x1} ${y1}`,
+    `A ${outerR} ${outerR} 0 ${largeArc} 1 ${x2} ${y2}`,
+    `L ${x3} ${y3}`,
+    `A ${innerR} ${innerR} 0 ${largeArc} 0 ${x4} ${y4}`,
+    "Z",
+  ].join(" ");
+}
+
+/** concept の面積 (= 角度 span) を決める。
+ *  docs/05 §5.4 では attemptCount に比例。MVP は「まだ解いていない concept も目視できる
+ *  よう最低 1 カウント (smoothing) 扱い」で始める。
+ */
+function normalizedWeight(attemptCount: number): number {
+  return attemptCount + 1;
+}
+
+type Arc = {
+  key: string;
+  path: string;
+  tier: MasteryTier;
+  tooltip: string;
+  href?: string; // concept だけ drill-down 可能
+  conceptId?: string;
+};
+
+function buildArcs(data: MasteryMap): Arc[] {
+  const arcs: Arc[] = [];
+  if (data.domains.length === 0) return arcs;
+
+  const totalWeight = data.domains.reduce((acc, d) => {
+    return (
+      acc +
+      d.subdomains.reduce((sa, s) => {
+        return sa + s.concepts.reduce((ca, c) => ca + normalizedWeight(c.attemptCount), 0);
+      }, 0)
+    );
+  }, 0);
+  if (totalWeight === 0) return arcs;
+
+  const START = -Math.PI / 2; // 12 時方向
+  const FULL = 2 * Math.PI;
+
+  let cursor = START;
+  for (const d of data.domains) {
+    const dWeight = d.subdomains.reduce(
+      (sa, s) => sa + s.concepts.reduce((ca, c) => ca + normalizedWeight(c.attemptCount), 0),
+      0,
+    );
+    const dSpan = (dWeight / totalWeight) * FULL;
+    const dStart = cursor;
+    const dEnd = cursor + dSpan;
+
+    // domain ring
+    arcs.push({
+      key: `d:${d.domainId}`,
+      path: arcPath({
+        startAngle: dStart,
+        endAngle: dEnd,
+        innerR: RING_WIDTHS.domain.inner,
+        outerR: RING_WIDTHS.domain.outer,
+      }),
+      tier: tierFromAggregate({ masteryPct: d.masteryPct, attemptCount: d.attemptCount }),
+      tooltip: `${d.domainId} (${Math.round(d.masteryPct * 100)}%, ${d.attemptCount} 問)`,
+    });
+
+    let subCursor = dStart;
+    for (const s of d.subdomains) {
+      const sWeight = s.concepts.reduce((ca, c) => ca + normalizedWeight(c.attemptCount), 0);
+      const sSpan = (sWeight / totalWeight) * FULL;
+      const sStart = subCursor;
+      const sEnd = subCursor + sSpan;
+
+      arcs.push({
+        key: `s:${d.domainId}/${s.subdomainId}`,
+        path: arcPath({
+          startAngle: sStart,
+          endAngle: sEnd,
+          innerR: RING_WIDTHS.subdomain.inner,
+          outerR: RING_WIDTHS.subdomain.outer,
+        }),
+        tier: tierFromAggregate({ masteryPct: s.masteryPct, attemptCount: s.attemptCount }),
+        tooltip: `${d.domainId} / ${s.subdomainId} (${Math.round(s.masteryPct * 100)}%, ${s.attemptCount} 問)`,
+      });
+
+      let cCursor = sStart;
+      for (const c of s.concepts) {
+        const cWeight = normalizedWeight(c.attemptCount);
+        const cSpan = (cWeight / totalWeight) * FULL;
+        const cStart = cCursor;
+        const cEnd = cCursor + cSpan;
+        arcs.push({
+          key: `c:${c.conceptId}`,
+          path: arcPath({
+            startAngle: cStart,
+            endAngle: cEnd,
+            innerR: RING_WIDTHS.concept.inner,
+            outerR: RING_WIDTHS.concept.outer,
+          }),
+          tier: c.tier,
+          tooltip: `${c.conceptName} (${Math.round(c.masteryPct * 100)}%, ${c.attemptCount} 問)`,
+          conceptId: c.conceptId,
+          href: `/custom?conceptId=${encodeURIComponent(c.conceptId)}`,
+        });
+        cCursor = cEnd;
+      }
+      subCursor = sEnd;
+    }
+    cursor = dEnd;
+  }
+  return arcs;
+}
+
+function Legend() {
+  const items: Array<{ tier: MasteryTier; label: string }> = [
+    { tier: "untouched", label: "未着手" },
+    { tier: "weak", label: "苦手 <40%" },
+    { tier: "mid", label: "中 40-80%" },
+    { tier: "mastered", label: "習得 80%+" },
+  ];
+  return (
+    <ul className="text-muted-foreground flex flex-wrap gap-3 text-xs">
+      {items.map(({ tier, label }) => (
+        <li key={tier} className="flex items-center gap-1">
+          <span
+            aria-hidden="true"
+            className="inline-block h-3 w-3 rounded-sm"
+            style={{ backgroundColor: TIER_COLOR[tier] }}
+          />
+          {label}
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+export function MasteryMapScreen() {
+  const router = useRouter();
+  const { data, isLoading, error } = trpc.insights.masteryMap.useQuery();
+
+  if (isLoading) {
+    return (
+      <Card className="w-full max-w-2xl">
+        <CardContent className="text-muted-foreground p-6 text-sm">読み込み中…</CardContent>
+      </Card>
+    );
+  }
+  if (error) {
+    return (
+      <Card className="w-full max-w-2xl">
+        <CardContent className="text-destructive p-6 text-sm">{error.message}</CardContent>
+      </Card>
+    );
+  }
+  if (!data) return null;
+
+  const arcs = buildArcs(data);
+
+  return (
+    <Card className="w-full max-w-2xl">
+      <CardHeader>
+        <CardTitle>Mastery Map</CardTitle>
+        <CardDescription>
+          中心=domain、中層=subdomain、外層=concept。色 = mastery tier、面積 = attempt 数 (+1
+          smoothing)。 外層をタップで concept 詳細 (Custom Session) にドリルダウン。
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {arcs.length === 0 ? (
+          <div className="text-muted-foreground text-sm">
+            表示できる concept がありません。seed を確認してください。
+          </div>
+        ) : (
+          <div className="flex flex-col items-center gap-4">
+            <svg
+              viewBox={`0 0 ${SIZE} ${SIZE}`}
+              role="img"
+              aria-label="Mastery Map sunburst"
+              className="w-full max-w-sm"
+            >
+              {arcs.map((a) => (
+                <path
+                  key={a.key}
+                  d={a.path}
+                  fill={TIER_COLOR[a.tier]}
+                  stroke="#fff"
+                  strokeWidth={1.2}
+                  className={cn(a.href && "cursor-pointer")}
+                  onClick={() => a.href && router.push(a.href)}
+                  onKeyDown={(e) => {
+                    if ((e.key === "Enter" || e.key === " ") && a.href) {
+                      router.push(a.href);
+                    }
+                  }}
+                  tabIndex={a.href ? 0 : -1}
+                  role={a.href ? "button" : undefined}
+                >
+                  <title>{a.tooltip}</title>
+                </path>
+              ))}
+            </svg>
+            <Legend />
+          </div>
+        )}
+        <div className="text-muted-foreground text-xs">
+          <Link href="/insights" className="underline">
+            ← Dashboard に戻る
+          </Link>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/features/insights/mastery-map-screen.tsx
+++ b/src/features/insights/mastery-map-screen.tsx
@@ -7,7 +7,7 @@ import { useRouter } from "next/navigation";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { cn } from "@/lib/cn";
 import type { AppRouter } from "@/server/trpc/routers";
-import type { MasteryTier } from "@/server/insights/mastery-map";
+import { toMasteryTier, type MasteryTier } from "@/server/insights/mastery-map";
 import { trpc } from "@/lib/trpc/react";
 
 type MasteryMap = inferRouterOutputs<AppRouter>["insights"]["masteryMap"];
@@ -29,16 +29,13 @@ const TIER_COLOR: Record<MasteryTier, string> = {
   mastered: "#22c55e", // green-500
 };
 
-/** domain / subdomain など attempt>0 なしで ring に色をつけるために、
- *  平均 masteryPct と「観測 concept が 1 つでもあるか」で tier を近似する */
-function tierFromAggregate(args: { masteryPct: number; attemptCount: number }): MasteryTier {
-  if (args.attemptCount <= 0) return "untouched";
-  if (args.masteryPct < 0.4) return "weak";
-  if (args.masteryPct < 0.8) return "mid";
-  return "mastered";
-}
+/** SVG path: 円環 (ドーナツ) の弧セグメントを 1 つ描く。
+ *  span がほぼ 2π (= 1 兄弟しか居ない場合) のとき、start/end 点が同一になり
+ *  SVG 仕様で「endpoint 同一の A は省略」になって描画されないため、π ずつ
+ *  2 本に分割する (Codex Round 1 指摘 #2)。
+ */
+const FULL_CIRCLE_EPS = 1e-9;
 
-/** SVG path: 円環 (ドーナツ) の弧セグメントを 1 つ描く */
 function arcPath(opts: {
   startAngle: number; // rad, 12 時方向 = -π/2
   endAngle: number;
@@ -46,6 +43,15 @@ function arcPath(opts: {
   outerR: number;
 }): string {
   const { startAngle, endAngle, innerR, outerR } = opts;
+  const span = endAngle - startAngle;
+  if (span >= 2 * Math.PI - FULL_CIRCLE_EPS) {
+    const mid = startAngle + Math.PI;
+    return (
+      arcPath({ startAngle, endAngle: mid, innerR, outerR }) +
+      " " +
+      arcPath({ startAngle: mid, endAngle, innerR, outerR })
+    );
+  }
   const x1 = CENTER + outerR * Math.cos(startAngle);
   const y1 = CENTER + outerR * Math.sin(startAngle);
   const x2 = CENTER + outerR * Math.cos(endAngle);
@@ -54,7 +60,7 @@ function arcPath(opts: {
   const y3 = CENTER + innerR * Math.sin(endAngle);
   const x4 = CENTER + innerR * Math.cos(startAngle);
   const y4 = CENTER + innerR * Math.sin(startAngle);
-  const largeArc = endAngle - startAngle > Math.PI ? 1 : 0;
+  const largeArc = span > Math.PI ? 1 : 0;
   return [
     `M ${x1} ${y1}`,
     `A ${outerR} ${outerR} 0 ${largeArc} 1 ${x2} ${y2}`,
@@ -117,7 +123,7 @@ function buildArcs(data: MasteryMap): Arc[] {
         innerR: RING_WIDTHS.domain.inner,
         outerR: RING_WIDTHS.domain.outer,
       }),
-      tier: tierFromAggregate({ masteryPct: d.masteryPct, attemptCount: d.attemptCount }),
+      tier: toMasteryTier({ masteryPct: d.masteryPct, attemptCount: d.attemptCount }),
       tooltip: `${d.domainId} (${Math.round(d.masteryPct * 100)}%, ${d.attemptCount} 問)`,
     });
 
@@ -136,7 +142,7 @@ function buildArcs(data: MasteryMap): Arc[] {
           innerR: RING_WIDTHS.subdomain.inner,
           outerR: RING_WIDTHS.subdomain.outer,
         }),
-        tier: tierFromAggregate({ masteryPct: s.masteryPct, attemptCount: s.attemptCount }),
+        tier: toMasteryTier({ masteryPct: s.masteryPct, attemptCount: s.attemptCount }),
         tooltip: `${d.domainId} / ${s.subdomainId} (${Math.round(s.masteryPct * 100)}%, ${s.attemptCount} 問)`,
       });
 

--- a/src/features/insights/mastery-map-screen.tsx
+++ b/src/features/insights/mastery-map-screen.tsx
@@ -7,10 +7,12 @@ import { useRouter } from "next/navigation";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { cn } from "@/lib/cn";
 import type { AppRouter } from "@/server/trpc/routers";
-import { toMasteryTier, type MasteryTier } from "@/server/insights/mastery-map";
 import { trpc } from "@/lib/trpc/react";
 
 type MasteryMap = inferRouterOutputs<AppRouter>["insights"]["masteryMap"];
+// tier 判定はサーバ側で済ませて router 出力に乗せる (docs §5.4、CLAUDE.md §4.7: サーバ専用
+// モジュールを client bundle に引き込まない。Codex Round 2 指摘)。
+type MasteryTier = MasteryMap["domains"][number]["tier"];
 
 /** SVG 座標系は上 = 負 Y。sunburst は 12 時方向から時計回りに描画する。 */
 const SIZE = 360;
@@ -123,7 +125,7 @@ function buildArcs(data: MasteryMap): Arc[] {
         innerR: RING_WIDTHS.domain.inner,
         outerR: RING_WIDTHS.domain.outer,
       }),
-      tier: toMasteryTier({ masteryPct: d.masteryPct, attemptCount: d.attemptCount }),
+      tier: d.tier,
       tooltip: `${d.domainId} (${Math.round(d.masteryPct * 100)}%, ${d.attemptCount} 問)`,
     });
 
@@ -142,7 +144,7 @@ function buildArcs(data: MasteryMap): Arc[] {
           innerR: RING_WIDTHS.subdomain.inner,
           outerR: RING_WIDTHS.subdomain.outer,
         }),
-        tier: toMasteryTier({ masteryPct: s.masteryPct, attemptCount: s.attemptCount }),
+        tier: s.tier,
         tooltip: `${d.domainId} / ${s.subdomainId} (${Math.round(s.masteryPct * 100)}%, ${s.attemptCount} 問)`,
       });
 

--- a/src/features/insights/overview-screen.tsx
+++ b/src/features/insights/overview-screen.tsx
@@ -104,8 +104,13 @@ export function InsightsOverviewScreen() {
             Mastery: {data.masteredConcepts} / {data.totalConcepts} concepts
           </CardDescription>
         </CardHeader>
-        <CardContent>
+        <CardContent className="space-y-3">
           <ProgressBar value={data.masteryPct} />
+          <div>
+            <Button asChild variant="outline" size="sm">
+              <Link href="/insights/map">🗺 Mastery Map を開く</Link>
+            </Button>
+          </div>
         </CardContent>
       </Card>
 

--- a/src/server/insights/mastery-map.test.ts
+++ b/src/server/insights/mastery-map.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+
+import { toMasteryTier } from "./mastery-map";
+
+describe("toMasteryTier", () => {
+  it("attemptCount 0 は untouched (masteryPct に関わらず)", () => {
+    expect(toMasteryTier({ masteryPct: 0, attemptCount: 0 })).toBe("untouched");
+    expect(toMasteryTier({ masteryPct: 1, attemptCount: 0 })).toBe("untouched");
+  });
+
+  it("40% 未満は weak", () => {
+    expect(toMasteryTier({ masteryPct: 0, attemptCount: 1 })).toBe("weak");
+    expect(toMasteryTier({ masteryPct: 0.39, attemptCount: 3 })).toBe("weak");
+  });
+
+  it("40-80% は mid", () => {
+    expect(toMasteryTier({ masteryPct: 0.4, attemptCount: 3 })).toBe("mid");
+    expect(toMasteryTier({ masteryPct: 0.79, attemptCount: 3 })).toBe("mid");
+  });
+
+  it("80% 以上は mastered", () => {
+    expect(toMasteryTier({ masteryPct: 0.8, attemptCount: 3 })).toBe("mastered");
+    expect(toMasteryTier({ masteryPct: 1, attemptCount: 10 })).toBe("mastered");
+  });
+});

--- a/src/server/insights/mastery-map.ts
+++ b/src/server/insights/mastery-map.ts
@@ -1,0 +1,135 @@
+import { eq, sql } from "drizzle-orm";
+
+import { getDb } from "@/db/client";
+import { attempts, concepts, mastery, type Concept, type Mastery } from "@/db/schema";
+
+/** Mastery tier の 4 段階 (docs/05 §5.4)。 */
+export const MASTERY_TIERS = ["untouched", "weak", "mid", "mastered"] as const;
+export type MasteryTier = (typeof MASTERY_TIERS)[number];
+
+/** mastery_pct と attempt_count から tier を決める。docs/05 §5.4:
+ *  - 灰 (untouched): 未着手 (attempt_count === 0)
+ *  - 赤 (weak): mastery < 40%
+ *  - 黄 (mid): 40-80%
+ *  - 緑 (mastered): 80%+
+ */
+export function toMasteryTier(args: { masteryPct: number; attemptCount: number }): MasteryTier {
+  if (args.attemptCount <= 0) return "untouched";
+  if (args.masteryPct < 0.4) return "weak";
+  if (args.masteryPct < 0.8) return "mid";
+  return "mastered";
+}
+
+export type MapConceptNode = {
+  conceptId: string;
+  conceptName: string;
+  masteryPct: number;
+  attemptCount: number;
+  tier: MasteryTier;
+};
+
+export type MapSubdomainNode = {
+  subdomainId: string;
+  /** 配下 concept の attemptCount 合計 */
+  attemptCount: number;
+  /** 配下 concept の masteryPct 平均 (attempt>0 のみ対象、全部 0 なら 0) */
+  masteryPct: number;
+  concepts: MapConceptNode[];
+};
+
+export type MapDomainNode = {
+  domainId: string;
+  attemptCount: number;
+  masteryPct: number;
+  subdomains: MapSubdomainNode[];
+};
+
+export type MasteryMap = {
+  /** 全 concept の attemptCount 合計 (sunburst の面積正規化の分母に使う) */
+  totalAttempts: number;
+  domains: MapDomainNode[];
+};
+
+function weightedAverage(items: Array<{ masteryPct: number; attemptCount: number }>): number {
+  const seen = items.filter((x) => x.attemptCount > 0);
+  if (seen.length === 0) return 0;
+  return seen.reduce((a, x) => a + x.masteryPct, 0) / seen.length;
+}
+
+/** Mastery Map (issue #29) の hierarchical 集計。
+ *  Insights overview と同じ 3 テーブル結合を使うが、Top N ではなく「全 concept を
+ *  domain → subdomain → concept 階層に入れて丸ごと返す」形にする。
+ *  Recharts / D3 を入れずクライアント SVG で描画する前提で、UI 側が必要とするだけの
+ *  (id, name, pct, count) を最小形で返す。
+ */
+export async function fetchMasteryMap(userId: string): Promise<MasteryMap> {
+  const db = getDb();
+  const conceptRows: Concept[] = await db.select().from(concepts);
+  const masteryRows: Mastery[] = await db.select().from(mastery).where(eq(mastery.userId, userId));
+  const attemptCountRows = await db
+    .select({
+      conceptId: attempts.conceptId,
+      total: sql<number>`count(*)::int`.as("total"),
+    })
+    .from(attempts)
+    .where(eq(attempts.userId, userId))
+    .groupBy(attempts.conceptId);
+
+  const masteryByConcept = new Map(masteryRows.map((m) => [m.conceptId, m]));
+  const attemptCountByConcept = new Map(attemptCountRows.map((r) => [r.conceptId, r.total ?? 0]));
+
+  const conceptNodes: MapConceptNode[] = conceptRows.map((c) => {
+    const m = masteryByConcept.get(c.id);
+    const attemptCount = attemptCountByConcept.get(c.id) ?? 0;
+    const masteryPct = m ? m.masteryPct : 0;
+    return {
+      conceptId: c.id,
+      conceptName: c.name,
+      masteryPct,
+      attemptCount,
+      tier: toMasteryTier({ masteryPct, attemptCount }),
+    };
+  });
+
+  // domain → subdomain → concepts の 2 段 grouping。stable sort を保つために
+  // id 昇順で sort (UI 側の色配置が不安定にならないように決定論を優先)。
+  const byDomainSub = new Map<string, Map<string, MapConceptNode[]>>();
+  const conceptMeta = new Map(conceptRows.map((c) => [c.id, c]));
+  for (const cn of conceptNodes) {
+    const meta = conceptMeta.get(cn.conceptId);
+    if (!meta) continue;
+    const dmap = byDomainSub.get(meta.domainId) ?? new Map<string, MapConceptNode[]>();
+    const list = dmap.get(meta.subdomainId) ?? [];
+    list.push(cn);
+    dmap.set(meta.subdomainId, list);
+    byDomainSub.set(meta.domainId, dmap);
+  }
+
+  const domains: MapDomainNode[] = [...byDomainSub.entries()]
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([domainId, subMap]) => {
+      const subdomains: MapSubdomainNode[] = [...subMap.entries()]
+        .sort(([a], [b]) => a.localeCompare(b))
+        .map(([subdomainId, cs]) => {
+          const list = cs.slice().sort((a, b) => a.conceptId.localeCompare(b.conceptId));
+          const attemptCount = list.reduce((a, x) => a + x.attemptCount, 0);
+          return {
+            subdomainId,
+            concepts: list,
+            attemptCount,
+            masteryPct: weightedAverage(list),
+          };
+        });
+      const attemptCount = subdomains.reduce((a, x) => a + x.attemptCount, 0);
+      const allConcepts = subdomains.flatMap((s) => s.concepts);
+      return {
+        domainId,
+        subdomains,
+        attemptCount,
+        masteryPct: weightedAverage(allConcepts),
+      };
+    });
+
+  const totalAttempts = domains.reduce((a, d) => a + d.attemptCount, 0);
+  return { totalAttempts, domains };
+}

--- a/src/server/insights/mastery-map.ts
+++ b/src/server/insights/mastery-map.ts
@@ -1,3 +1,5 @@
+import "server-only";
+
 import { eq, sql } from "drizzle-orm";
 
 import { getDb } from "@/db/client";
@@ -34,6 +36,8 @@ export type MapSubdomainNode = {
   attemptCount: number;
   /** 配下 concept の masteryPct 平均 (attempt>0 のみ対象、全部 0 なら 0) */
   masteryPct: number;
+  /** 集計 tier: attemptCount=0 なら untouched、それ以外は masteryPct から決定 */
+  tier: MasteryTier;
   concepts: MapConceptNode[];
 };
 
@@ -41,6 +45,8 @@ export type MapDomainNode = {
   domainId: string;
   attemptCount: number;
   masteryPct: number;
+  /** 集計 tier */
+  tier: MasteryTier;
   subdomains: MapSubdomainNode[];
 };
 
@@ -113,20 +119,24 @@ export async function fetchMasteryMap(userId: string): Promise<MasteryMap> {
         .map(([subdomainId, cs]) => {
           const list = cs.slice().sort((a, b) => a.conceptId.localeCompare(b.conceptId));
           const attemptCount = list.reduce((a, x) => a + x.attemptCount, 0);
+          const masteryPct = weightedAverage(list);
           return {
             subdomainId,
             concepts: list,
             attemptCount,
-            masteryPct: weightedAverage(list),
+            masteryPct,
+            tier: toMasteryTier({ masteryPct, attemptCount }),
           };
         });
       const attemptCount = subdomains.reduce((a, x) => a + x.attemptCount, 0);
       const allConcepts = subdomains.flatMap((s) => s.concepts);
+      const masteryPct = weightedAverage(allConcepts);
       return {
         domainId,
         subdomains,
         attemptCount,
-        masteryPct: weightedAverage(allConcepts),
+        masteryPct,
+        tier: toMasteryTier({ masteryPct, attemptCount }),
       };
     });
 

--- a/src/server/trpc/routers/insights.ts
+++ b/src/server/trpc/routers/insights.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 
 import { DOMAIN_IDS } from "@/db/schema/_constants";
 import { fetchHistory } from "@/server/insights/history";
+import { fetchMasteryMap } from "@/server/insights/mastery-map";
 import { fetchInsightsOverview } from "@/server/insights/overview";
 import { fetchSearch } from "@/server/insights/search";
 
@@ -13,6 +14,12 @@ export const insightsRouter = router({
    * mastery 全体、top3 strongest / weakest / blindSpots / decaying を返す。
    */
   overview: protectedProcedure.query(({ ctx }) => fetchInsightsOverview(ctx.user.id)),
+
+  /**
+   * Mastery Map (issue #29, docs/05 §5.4)。
+   * 全 concept を domain → subdomain → concept の 3 階層で返す (サンバースト用)。
+   */
+  masteryMap: protectedProcedure.query(({ ctx }) => fetchMasteryMap(ctx.user.id)),
 
   /**
    * History 画面 (issue #21, docs/05 §5.5)。

--- a/src/test/server-only-stub.ts
+++ b/src/test/server-only-stub.ts
@@ -1,0 +1,4 @@
+// Vitest で `import "server-only"` を no-op にするためのスタブ。
+// 本物の server-only は import するだけで throw する poison pill なので、
+// test 環境では空 module に差し替える (vitest.config.ts の alias 参照)。
+export {};

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -15,6 +15,11 @@ export default defineConfig({
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),
+      // `server-only` は import されると常に throw する「poison pill」モジュール
+      // (Next.js bundler が検知して client import を禁止するための仕組み)。
+      // Vitest の Node 環境では通常の import として実行されて全テストが落ちるため、
+      // test 実行時のみ空モジュールに差し替える (issue #29)。
+      "server-only": path.resolve(__dirname, "./src/test/server-only-stub.ts"),
     },
   },
 });


### PR DESCRIPTION
## Summary
issue #29 (Phase 5+) Mastery Map を実装。Recharts / D3 を追加せず、自作 SVG で sunburst を描画 (CLAUDE.md §3 「ライブラリ追加は最小限」)。

### 実装内容
- `src/server/insights/mastery-map.ts` — `fetchMasteryMap` で `domain → subdomain → concept` 3 階層集計。`toMasteryTier` で 4 tier (untouched / weak / mid / mastered) を算出。attempt 0 の concept は "untouched" 固定、masteryPct 平均は attempt>0 のみ対象 (未着手を分母に入れない)
- `insights.masteryMap` tRPC query を追加
- `src/features/insights/mastery-map-screen.tsx` — 自作 SVG sunburst。3 リング (domain/subdomain/concept)、arc span は `attemptCount + 1` smoothing (未着手 concept も視認可能)、tier 色、外層 concept タップで `/custom?conceptId=…` にドリルダウン。`<title>` tooltip + aria で A11y 考慮、キーボード focus/Enter にも対応
- `/insights/map` ルート (`src/app/insights/map/page.tsx`) — auth / onboarding gate
- Insights overview の「Your Learning, Today」カードに「🗺 Mastery Map を開く」導線追加
- docs/05 §5.4 を実装済みに更新

### 受け入れ基準
- [x] Recharts or D3 でサンバースト → **Recharts / D3 非採用の自作 SVG sunburst** (依存ゼロ、保守性と bundle サイズを重視)
- [x] 色で mastery 段階、面積で attempt 数
- [x] タップで concept 詳細へドリルダウン (`/custom?conceptId=…`)

### Test plan
- [x] `pnpm typecheck` ✓
- [x] `pnpm test -- --run` ✓ (253/253、新規 +4: toMasteryTier 4 ケース)
- [x] `pnpm build` ✓ (`/insights/map` 登録確認)

closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)