### PR TITLE
feat(qtype): cloze / code_read 完全一致採点 + textarea UI (#31)

### DIFF
--- a/src/features/drill/drill-screen.tsx
+++ b/src/features/drill/drill-screen.tsx
@@ -29,8 +29,13 @@ type DrillScreenProps = {
 };
 
 export function DrillScreen({ onReset, skipInitialStartCard }: DrillScreenProps = {}) {
-  const { phase, sessionId, question, selectedIndex, grading, summary } = useDrillStore();
-  const { reset, setSession, setQuestion, setSelected, setGrading, setSummary } = useDrillStore();
+  const { phase, sessionId, question, selectedIndex, textAnswer, grading, summary } =
+    useDrillStore();
+  const { reset, setSession, setQuestion, setSelected, setTextAnswer, setGrading, setSummary } =
+    useDrillStore();
+
+  // mcq 以外 (cloze / code_read / short / written) は textarea で自由入力
+  const isTextInput = question?.type !== "mcq";
   // 既定 (onReset 未指定) は zustand reset。引数 finalSummary は無視されるが
   // 関数シグネチャは optional 引数で互換 (custom / review もそのまま動く)。
   const handleReset = onReset ?? (() => reset());
@@ -84,8 +89,9 @@ export function DrillScreen({ onReset, skipInitialStartCard }: DrillScreenProps 
   }, [sessionId, nextMutation, finishMutation, setQuestion, setSummary]);
 
   const handleSubmit = useCallback(async () => {
-    if (!sessionId || !question || selectedIndex === null) return;
-    const answer = question.options[selectedIndex];
+    if (!sessionId || !question) return;
+    // mcq は selectedIndex から option を取り出す、それ以外は textAnswer を使う (issue #31)
+    const answer = isTextInput ? textAnswer.trim() : question.options[selectedIndex ?? -1];
     if (!answer) return;
     setErrorMessage(null);
     try {
@@ -99,7 +105,8 @@ export function DrillScreen({ onReset, skipInitialStartCard }: DrillScreenProps 
         correct: result.correct,
         score: result.score,
         feedback: result.feedback,
-        correctIndex: result.correct ? selectedIndex : null,
+        // correctIndex は mcq でユーザーが選んだインデックスが正解だったか UI ハイライトに使う
+        correctIndex: !isTextInput && result.correct ? selectedIndex : null,
         questionType: result.questionType ?? null,
         correctAnswer: result.correctAnswer ?? null,
         userAnswer: answer,
@@ -108,7 +115,7 @@ export function DrillScreen({ onReset, skipInitialStartCard }: DrillScreenProps 
     } catch (e) {
       setErrorMessage(toMessage(e));
     }
-  }, [sessionId, question, selectedIndex, submitMutation, setGrading]);
+  }, [sessionId, question, selectedIndex, textAnswer, isTextInput, submitMutation, setGrading]);
 
   const handleRetry = useCallback(() => {
     setErrorMessage(null);
@@ -116,12 +123,16 @@ export function DrillScreen({ onReset, skipInitialStartCard }: DrillScreenProps 
       void handleStart();
     } else if (phase === "asking" && !question) {
       void handleNext();
-    } else if (phase === "asking" && question && selectedIndex !== null) {
+    } else if (
+      phase === "asking" &&
+      question &&
+      (selectedIndex !== null || textAnswer.trim().length > 0)
+    ) {
       void handleSubmit();
     } else if (phase === "graded") {
       void handleNext();
     }
-  }, [phase, question, selectedIndex, handleStart, handleNext, handleSubmit]);
+  }, [phase, question, selectedIndex, textAnswer, handleStart, handleNext, handleSubmit]);
 
   // セッション中の戻るジェスチャ / タブ閉じで意図せず終了しないよう警告
   // (issue #25 受け入れ基準: 戻るジェスチャで意図しない終了を防ぐ)。
@@ -196,13 +207,28 @@ export function DrillScreen({ onReset, skipInitialStartCard }: DrillScreenProps 
       // キーリピート / 既に通信中の発火を全て無視 (submit/next の二重発火抑止)
       if (e.repeat || pending) return;
       if (phase === "asking" && question) {
-        const n = Number.parseInt(e.key, 10);
-        if (n >= 1 && n <= options.length) {
-          setSelected(n - 1);
-          e.preventDefault();
-        } else if (e.key === "Enter" && selectedIndex !== null) {
-          void handleSubmit();
-          e.preventDefault();
+        // mcq: 数字キー 1-N で選択肢、Enter で送信。textarea の中での数字キーやスペースは
+        // document レベルで拾わないため、isTextInput のときは textarea に任せる。
+        if (!isTextInput) {
+          const n = Number.parseInt(e.key, 10);
+          if (n >= 1 && n <= options.length) {
+            setSelected(n - 1);
+            e.preventDefault();
+            return;
+          }
+        }
+        // Cmd/Ctrl+Enter で送信 (textarea 内では naked Enter は改行)
+        const submitKey = isTextInput
+          ? e.key === "Enter" && (e.metaKey || e.ctrlKey)
+          : e.key === "Enter";
+        if (submitKey) {
+          const canSubmit =
+            (!isTextInput && selectedIndex !== null) ||
+            (isTextInput && textAnswer.trim().length > 0);
+          if (canSubmit) {
+            void handleSubmit();
+            e.preventDefault();
+          }
         }
       } else if (phase === "graded" && e.key === "Enter") {
         void handleNext();
@@ -216,6 +242,8 @@ export function DrillScreen({ onReset, skipInitialStartCard }: DrillScreenProps 
     question,
     options.length,
     selectedIndex,
+    textAnswer,
+    isTextInput,
     pending,
     handleSubmit,
     handleNext,
@@ -297,45 +325,78 @@ export function DrillScreen({ onReset, skipInitialStartCard }: DrillScreenProps 
     );
   }
 
+  const isCodeRead = question.type === "code_read";
   return (
     <Card className="w-full max-w-xl">
       <CardHeader>
-        <CardDescription>{question.tags.join(" / ")}</CardDescription>
-        <CardTitle className="text-base font-medium whitespace-pre-wrap">
-          {question.prompt}
-        </CardTitle>
+        <CardDescription>
+          {question.tags.join(" / ")}
+          {question.type !== "mcq" ? ` ・ ${question.type}` : null}
+        </CardDescription>
+        {isCodeRead ? (
+          // code_read: prompt は「次のコードの出力を答えよ」+ コード。
+          // コード部分を <pre> でモノスペース表示 (CodeMirror は重い+display-only なので MVP では不要)。
+          <CardTitle className="text-base font-medium">
+            <pre className="bg-muted/50 overflow-x-auto rounded-md p-3 font-mono text-xs whitespace-pre">
+              {question.prompt}
+            </pre>
+            <p className="mt-2 text-sm font-normal">このコードの出力を予測して入力してください。</p>
+          </CardTitle>
+        ) : (
+          <CardTitle className="text-base font-medium whitespace-pre-wrap">
+            {question.prompt}
+          </CardTitle>
+        )}
       </CardHeader>
       <CardContent className="space-y-2">
-        {options.map((opt, i) => {
-          const isSelected = i === selectedIndex;
-          const isGradedCorrect = phase === "graded" && grading?.correctIndex === i;
-          const isWrongSelected = phase === "graded" && isSelected && grading?.correct === false;
-          return (
-            <button
-              key={`${question.id}-${i}`}
-              type="button"
-              disabled={phase === "graded"}
-              onClick={() => setSelected(i)}
-              className={[
-                "flex min-h-12 w-full items-start gap-3 rounded-md border p-3 text-left text-sm transition-colors",
-                isGradedCorrect
-                  ? "border-emerald-500 bg-emerald-50 dark:bg-emerald-950"
-                  : isWrongSelected
-                    ? "border-destructive bg-red-50 dark:bg-red-950"
-                    : isSelected
-                      ? "border-primary"
-                      : "border-border hover:border-muted-foreground",
-              ].join(" ")}
-            >
-              <span className="inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-full border text-xs">
-                {i + 1}
-              </span>
-              <span className="flex-1 whitespace-pre-wrap">{opt}</span>
-              {isGradedCorrect && <Check className="h-4 w-4 text-emerald-600" />}
-              {isWrongSelected && <X className="text-destructive h-4 w-4" />}
-            </button>
-          );
-        })}
+        {isTextInput && (
+          <textarea
+            value={textAnswer}
+            onChange={(e) => setTextAnswer(e.target.value)}
+            disabled={phase === "graded"}
+            rows={isCodeRead ? 6 : 3}
+            placeholder={
+              question.type === "cloze"
+                ? "穴埋めする内容を入力"
+                : isCodeRead
+                  ? "期待される出力"
+                  : "回答を入力"
+            }
+            className="border-input bg-background min-h-20 w-full rounded-md border p-2 font-mono text-sm"
+            aria-label="回答入力"
+          />
+        )}
+        {!isTextInput &&
+          options.map((opt, i) => {
+            const isSelected = i === selectedIndex;
+            const isGradedCorrect = phase === "graded" && grading?.correctIndex === i;
+            const isWrongSelected = phase === "graded" && isSelected && grading?.correct === false;
+            return (
+              <button
+                key={`${question.id}-${i}`}
+                type="button"
+                disabled={phase === "graded"}
+                onClick={() => setSelected(i)}
+                className={[
+                  "flex min-h-12 w-full items-start gap-3 rounded-md border p-3 text-left text-sm transition-colors",
+                  isGradedCorrect
+                    ? "border-emerald-500 bg-emerald-50 dark:bg-emerald-950"
+                    : isWrongSelected
+                      ? "border-destructive bg-red-50 dark:bg-red-950"
+                      : isSelected
+                        ? "border-primary"
+                        : "border-border hover:border-muted-foreground",
+                ].join(" ")}
+              >
+                <span className="inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-full border text-xs">
+                  {i + 1}
+                </span>
+                <span className="flex-1 whitespace-pre-wrap">{opt}</span>
+                {isGradedCorrect && <Check className="h-4 w-4 text-emerald-600" />}
+                {isWrongSelected && <X className="text-destructive h-4 w-4" />}
+              </button>
+            );
+          })}
         {phase === "graded" && grading && question && (
           <div className="space-y-2">
             <div className="bg-muted/50 rounded-md p-3 text-sm">{grading.feedback}</div>
@@ -377,11 +438,13 @@ export function DrillScreen({ onReset, skipInitialStartCard }: DrillScreenProps 
         {phase === "asking" ? (
           <Button
             onClick={handleSubmit}
-            disabled={selectedIndex === null || pending}
+            disabled={
+              pending || (isTextInput ? textAnswer.trim().length === 0 : selectedIndex === null)
+            }
             className="min-h-12 px-6"
           >
             {pending ? <Loader2 className="mr-1 h-4 w-4 animate-spin" /> : null}
-            回答する (Enter)
+            {isTextInput ? "回答する (Cmd+Enter)" : "回答する (Enter)"}
           </Button>
         ) : (
           <Button onClick={handleNext} disabled={pending} className="min-h-12 px-6">

--- a/src/features/drill/drill-state.test.ts
+++ b/src/features/drill/drill-state.test.ts
@@ -5,6 +5,7 @@ import { normalizeRubricChecks, useDrillStore, type DrillQuestion } from "./dril
 const sampleQuestion: DrillQuestion = {
   id: "q-1",
   prompt: "HTTP の PUT と PATCH の違いは?",
+  type: "mcq",
   options: [
     "PUT は body 不要",
     "PUT は冪等、PATCH は部分更新",

--- a/src/features/drill/drill-state.ts
+++ b/src/features/drill/drill-state.ts
@@ -16,7 +16,10 @@ export function normalizeRubricChecks(
 export type DrillQuestion = {
   id: string;
   prompt: string;
-  /** サーバー側でシャッフル済み (answer + distractors が混在、正答位置は UI には渡さない) */
+  /** UI ディスパッチ用。mcq は option ボタン、cloze/code_read/short/written は textarea 入力 (issue #31) */
+  type: string;
+  /** サーバー側でシャッフル済み (answer + distractors が混在、正答位置は UI には渡さない)。
+   *  cloze / code_read 等 mcq 以外では空配列 */
   options: string[];
   hint: string | null;
   tags: string[];
@@ -55,7 +58,10 @@ export type DrillState = {
   phase: Phase;
   sessionId: string | null;
   question: DrillQuestion | null;
+  /** mcq での選択肢インデックス (cloze/code_read 等では使用しない) */
   selectedIndex: number | null;
+  /** cloze / code_read / short / written での自由入力テキスト (issue #31) */
+  textAnswer: string;
   grading: DrillGrading | null;
   summary: DrillSummary | null;
 };
@@ -65,6 +71,7 @@ type Actions = {
   setSession: (sessionId: string) => void;
   setQuestion: (q: DrillQuestion | null) => void;
   setSelected: (idx: number) => void;
+  setTextAnswer: (text: string) => void;
   setGrading: (g: DrillGrading) => void;
   updateGrading: (patch: Partial<DrillGrading>) => void;
   setSummary: (s: DrillSummary) => void;
@@ -75,6 +82,7 @@ export const useDrillStore = create<DrillState & Actions>((set) => ({
   sessionId: null,
   question: null,
   selectedIndex: null,
+  textAnswer: "",
   grading: null,
   summary: null,
 
@@ -84,6 +92,7 @@ export const useDrillStore = create<DrillState & Actions>((set) => ({
       sessionId: null,
       question: null,
       selectedIndex: null,
+      textAnswer: "",
       grading: null,
       summary: null,
     }),
@@ -92,11 +101,25 @@ export const useDrillStore = create<DrillState & Actions>((set) => ({
 
   setQuestion: (q) =>
     set(() => {
-      if (!q) return { question: null, selectedIndex: null, phase: "asking" as const };
-      return { question: q, selectedIndex: null, grading: null, phase: "asking" as const };
+      if (!q)
+        return {
+          question: null,
+          selectedIndex: null,
+          textAnswer: "",
+          phase: "asking" as const,
+        };
+      return {
+        question: q,
+        selectedIndex: null,
+        textAnswer: "",
+        grading: null,
+        phase: "asking" as const,
+      };
     }),
 
   setSelected: (idx) => set({ selectedIndex: idx }),
+
+  setTextAnswer: (text) => set({ textAnswer: text }),
 
   setGrading: (g) => set({ grading: g, phase: "graded" }),
 

--- a/src/server/grader/exact-match.test.ts
+++ b/src/server/grader/exact-match.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+
+import type { Question } from "@/db/schema";
+
+import { gradeExactMatch } from "./exact-match";
+
+function q(answer: string, type: Question["type"] = "cloze") {
+  return { answer, type } as Pick<Question, "answer" | "type">;
+}
+
+describe("gradeExactMatch", () => {
+  it("完全一致は correct=true / score=1", () => {
+    const r = gradeExactMatch(q("42"), "42");
+    expect(r.correct).toBe(true);
+    expect(r.score).toBe(1);
+  });
+
+  it("trim で前後空白を無視", () => {
+    expect(gradeExactMatch(q("race condition"), "  race condition  ").correct).toBe(true);
+  });
+
+  it("全角英数字は NFKC で半角に正規化して比較", () => {
+    expect(gradeExactMatch(q("ABC123"), "ＡＢＣ１２３").correct).toBe(true);
+  });
+
+  it("連続空白は 1 個に圧縮 (タブ / 全角スペース含む)", () => {
+    expect(gradeExactMatch(q("a b"), "a   b").correct).toBe(true);
+    expect(gradeExactMatch(q("a b"), "a\tb").correct).toBe(true);
+    expect(gradeExactMatch(q("a b"), "a\u3000b").correct).toBe(true);
+  });
+
+  it("行頭行末の空白と CRLF → LF の違いは吸収、改行自体は保持", () => {
+    expect(gradeExactMatch(q("line1\nline2"), "line1\r\nline2").correct).toBe(true);
+    expect(gradeExactMatch(q("line1\nline2"), " line1 \n line2 ").correct).toBe(true);
+  });
+
+  it("case sensitive (code_read は大文字小文字重要)", () => {
+    expect(gradeExactMatch(q("Hello", "code_read"), "hello").correct).toBe(false);
+  });
+
+  it("不一致は correct=false / score=0、正解を feedback に含める", () => {
+    const r = gradeExactMatch(q("42"), "43");
+    expect(r.correct).toBe(false);
+    expect(r.score).toBe(0);
+    expect(r.feedback).toContain("42");
+  });
+});

--- a/src/server/grader/exact-match.ts
+++ b/src/server/grader/exact-match.ts
@@ -1,0 +1,43 @@
+import type { Question } from "@/db/schema";
+
+export type ExactMatchGradeResult = {
+  correct: boolean;
+  score: 0 | 1;
+  feedback: string;
+};
+
+/**
+ * cloze (穴埋め) / code_read (コード読解: 出力予測) 用の完全一致採点 (issue #31)。
+ *
+ * 判定ロジック:
+ *   1. trim
+ *   2. 全角 → 半角 (NFKC 正規化) で数字記号の表記ゆれを吸収
+ *   3. 末尾改行 / 連続空白を 1 個に圧縮 (タブ / スペース / 全角スペース)
+ *   4. 大文字小文字を ignore しない (code_read で case sensitive が重要なため)
+ *   5. question.answer に同じ正規化を通して比較
+ *
+ * LLM は使わない (docs/03 §3.4.1 の mcq 採点と同じ「プロンプトを節約するための rule-based」)。
+ * code_read の実行結果照合は Phase 6 の Judge0 (issue #34) で置き換える想定だが、
+ * MVP ではユーザーが予測した出力文字列と question.answer (期待出力) の文字列比較で十分。
+ */
+export function gradeExactMatch(
+  question: Pick<Question, "answer" | "type">,
+  userAnswer: string,
+): ExactMatchGradeResult {
+  const normalize = (s: string): string =>
+    s
+      .normalize("NFKC")
+      .replace(/\r\n/g, "\n")
+      .replace(/[ \t\u3000]+/g, " ")
+      .replace(/[ \t\u3000]*\n[ \t\u3000]*/g, "\n")
+      .trim();
+
+  const expected = normalize(question.answer);
+  const actual = normalize(userAnswer);
+  const correct = expected === actual;
+  return {
+    correct,
+    score: correct ? 1 : 0,
+    feedback: correct ? "正解です" : `正解は: ${question.answer}`,
+  };
+}

--- a/src/server/grader/index.ts
+++ b/src/server/grader/index.ts
@@ -15,6 +15,7 @@ import {
 } from "@/db/schema";
 import { updateMasteryAfterAttempt } from "@/server/scheduler/update-mastery";
 
+import { gradeExactMatch } from "./exact-match";
 import { extractAndPersistMisconception } from "./extract-misconception";
 import { gradeMcq } from "./mcq";
 import { gradeShort } from "./short";
@@ -140,6 +141,34 @@ export async function gradeAttempt(input: GradeAttemptInput): Promise<GradeAttem
       questionType: question.type,
       correctAnswer: question.answer,
     };
+  } else if (question.type === "cloze" || question.type === "code_read") {
+    // cloze (穴埋め) / code_read (出力予測) は LLM なしの完全一致採点 (issue #31)。
+    // NFKC + 空白正規化 + 末尾改行除去で表記ゆれを吸収する。
+    const result = gradeExactMatch(question, input.userAnswer);
+    row = {
+      userId: input.userId,
+      sessionId: input.sessionId,
+      questionId: question.id,
+      conceptId: question.conceptId,
+      userAnswer: input.userAnswer,
+      correct: result.correct,
+      score: result.score,
+      feedback: result.feedback,
+      rubricChecks: [],
+      reasonGiven: input.reasonGiven,
+      elapsedMs: input.elapsedMs,
+      gradedBy: null,
+      promptVersion: null,
+    };
+    grade = {
+      attempt: { id: "" },
+      correct: result.correct,
+      score: result.score,
+      feedback: result.feedback,
+      rubricChecks: [],
+      questionType: question.type,
+      correctAnswer: question.answer,
+    };
   } else if (question.type === "short" || question.type === "written") {
     const result =
       question.type === "short"
@@ -222,7 +251,6 @@ export async function gradeAttempt(input: GradeAttemptInput): Promise<GradeAttem
             reasonGiven: reason,
           });
         } catch (err) {
-           
           console.error("extractAndPersistMisconception failed", err);
         }
       });
@@ -237,7 +265,6 @@ export async function gradeAttempt(input: GradeAttemptInput): Promise<GradeAttem
         try {
           await maybeResolveMisconceptions({ userId, conceptId });
         } catch (err) {
-           
           console.error("maybeResolveMisconceptions failed", err);
         }
       });

--- a/src/server/trpc/routers/session.ts
+++ b/src/server/trpc/routers/session.ts
@@ -523,16 +523,23 @@ export const sessionRouter = router({
         .set({ spec: { ...spec, pendingQuestionId: question.id } })
         .where(eq(sessions.id, session.id));
 
-      // answer はクライアントに返さず options だけ返す (正答漏洩防止)
-      const options = shuffleWithSeed(
-        [question.answer, ...((question.distractors ?? []) as string[])],
-        question.id,
-      );
+      // answer はクライアントに返さず options だけ返す (正答漏洩防止)。
+      // mcq は answer + distractors を shuffle、それ以外 (cloze / code_read / short / written) は
+      // 選択肢を持たないため空配列で返す (UI 側で type を見て textarea / code display に分岐)。
+      const qType = (question as { type?: string }).type ?? "mcq";
+      const options =
+        qType === "mcq"
+          ? shuffleWithSeed(
+              [question.answer, ...((question.distractors ?? []) as string[])],
+              question.id,
+            )
+          : [];
       return {
         done: false as const,
         question: {
           id: question.id,
           prompt: question.prompt,
+          type: qType,
           options,
           hint: question.hint,
           tags: (question.tags ?? []) as string[],


### PR DESCRIPTION
## Summary
issue #31 (Phase 5+) cloze と code_read の採点ロジック + UI を追加。MVP は rule-based 完全一致 (LLM 不使用)。Judge0 実行 (#34) との組み合わせで code_read の真の実行結果比較が可能になる。

### 主要実装
- `src/server/grader/exact-match.ts` — `gradeExactMatch(question, userAnswer)`: NFKC 正規化 + 空白圧縮 + CRLF→LF + 行頭行末空白除去。code_read は case sensitive (出力比較で大文字小文字が意味を持つため)
- `src/server/grader/index.ts` — dispatch に cloze / code_read を追加、rule-based 採点 (LLM なし)
- `src/server/trpc/routers/session.ts` — next レスポンスに `question.type` を追加。mcq 以外は `options` を空配列で返す (UI 側で textarea に分岐)
- `src/features/drill/drill-state.ts` — `textAnswer` state + `setTextAnswer` action を追加。reset / setQuestion で初期化
- `src/features/drill/drill-screen.tsx` — type が mcq 以外のときは textarea。code_read は prompt を `<pre><code>` でモノスペース表示 + 「出力を予測」placeholder。cloze は「穴埋めする内容」placeholder。Enter キー挙動: textarea 内では Cmd/Ctrl+Enter で送信、naked Enter は改行を通す

### 受け入れ基準
- [x] cloze: 穴埋め回答欄、完全一致判定
- [x] code_read: コード + 期待出力、ユーザーの「出力予測」を比較
- [ ] UI: CodeMirror でコード表示 → **display-only には CodeMirror の editor 機能は過剰 (CLAUDE.md §3 ライブラリ最小化)。`<pre><code>` + Tailwind `font-mono` でモノスペース表示する方針に変更**。将来コード編集 UI が必要になったタイミングで CodeMirror 6 を導入する (docs/07 §7.4.2 に既に言及あり)

### 注意
本 PR は「cloze / code_read の **問題が DB にあれば** 正しく扱える」状態まで。generator 拡張 (cloze / code_read の prompt 生成) は別 issue。

### Test plan
- [x] `pnpm typecheck` ✓
- [x] `pnpm test -- --run` ✓ (261/261、新規 +7: gradeExactMatch 完全一致 / trim / NFKC / 空白圧縮 / CRLF / case sensitive / 不一致 feedback)
- [x] `pnpm build` ✓

closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)