### PR TITLE
feat(custom): Custom Session テンプレ保存・再利用 (#32)

### DIFF
--- a/src/features/custom/custom-screen.tsx
+++ b/src/features/custom/custom-screen.tsx
@@ -1,6 +1,15 @@
 "use client";
 
-import { AlertTriangle, ArrowRight, Loader2, Sparkles, Undo2 } from "lucide-react";
+import {
+  AlertTriangle,
+  ArrowRight,
+  Bookmark,
+  BookmarkCheck,
+  Loader2,
+  Sparkles,
+  Trash2,
+  Undo2,
+} from "lucide-react";
 import { useCallback, useState } from "react";
 
 import { Button } from "@/components/ui/button";
@@ -55,7 +64,13 @@ export function CustomScreen({
   const parseMutation = trpc.custom.parse.useMutation();
   const startMutation = trpc.session.start.useMutation();
   const nextMutation = trpc.session.next.useMutation();
+  const templatesQuery = trpc.custom.listTemplates.useQuery();
+  const saveTemplate = trpc.custom.saveTemplate.useMutation();
+  const useTemplateMut = trpc.custom.useTemplate.useMutation();
+  const deleteTemplateMut = trpc.custom.deleteTemplate.useMutation();
+  const utils = trpc.useUtils();
   const { reset, setSession, setQuestion } = useDrillStore();
+  const [savingName, setSavingName] = useState("");
 
   const onParse = useCallback(async () => {
     setError(null);
@@ -108,6 +123,49 @@ export function CustomScreen({
     setPhase({ kind: "input" });
   }, [reset]);
 
+  const onSaveTemplate = useCallback(async () => {
+    if (phase.kind !== "previewing") return;
+    const name = savingName.trim();
+    if (name.length === 0) {
+      setError("テンプレ名を入力してください");
+      return;
+    }
+    try {
+      await saveTemplate.mutateAsync({ name, rawRequest: phase.raw, spec: phase.spec });
+      setSavingName("");
+      await utils.custom.listTemplates.invalidate();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "テンプレ保存に失敗しました");
+    }
+  }, [phase, savingName, saveTemplate, utils]);
+
+  const onUseTemplate = useCallback(
+    async (id: string) => {
+      setError(null);
+      try {
+        const t = await useTemplateMut.mutateAsync({ id });
+        setRaw(t.rawRequest ?? "");
+        setPhase({ kind: "previewing", raw: t.rawRequest ?? "", spec: t.spec });
+        await utils.custom.listTemplates.invalidate();
+      } catch (e) {
+        setError(e instanceof Error ? e.message : "テンプレの読み込みに失敗しました");
+      }
+    },
+    [useTemplateMut, utils],
+  );
+
+  const onDeleteTemplate = useCallback(
+    async (id: string) => {
+      try {
+        await deleteTemplateMut.mutateAsync({ id });
+        await utils.custom.listTemplates.invalidate();
+      } catch (e) {
+        setError(e instanceof Error ? e.message : "テンプレの削除に失敗しました");
+      }
+    },
+    [deleteTemplateMut, utils],
+  );
+
   if (phase.kind === "running") {
     return <DrillScreen onReset={backToInput} skipInitialStartCard />;
   }
@@ -129,6 +187,74 @@ export function CustomScreen({
           disabled={phase.kind === "previewing"}
         />
         {phase.kind === "previewing" && <SpecPreview spec={phase.spec} />}
+        {phase.kind === "previewing" && (
+          <div className="bg-muted/20 space-y-2 rounded-md border p-3">
+            <label className="flex items-center gap-2 text-xs font-medium">
+              <Bookmark className="h-3 w-3" />
+              このセッションをテンプレに保存
+            </label>
+            <div className="flex gap-2">
+              <input
+                value={savingName}
+                onChange={(e) => setSavingName(e.target.value)}
+                maxLength={80}
+                placeholder="例: TLS 深掘り"
+                className="border-input bg-background min-h-10 flex-1 rounded-md border px-2 text-sm"
+                aria-label="テンプレ名"
+              />
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={onSaveTemplate}
+                disabled={saveTemplate.isPending || savingName.trim().length === 0}
+              >
+                {saveTemplate.isPending ? (
+                  <Loader2 className="mr-1 h-3 w-3 animate-spin" />
+                ) : (
+                  <BookmarkCheck className="mr-1 h-3 w-3" />
+                )}
+                保存
+              </Button>
+            </div>
+          </div>
+        )}
+        {phase.kind === "input" && (templatesQuery.data?.items.length ?? 0) > 0 && (
+          <div className="bg-muted/20 space-y-2 rounded-md border p-3">
+            <div className="text-xs font-medium">💾 保存済みテンプレート</div>
+            <ul className="space-y-1">
+              {(templatesQuery.data?.items ?? []).map((t) => (
+                <li key={t.id} className="flex items-center gap-2 text-sm">
+                  <button
+                    type="button"
+                    onClick={() => onUseTemplate(t.id)}
+                    disabled={useTemplateMut.isPending}
+                    className="hover:bg-accent flex-1 rounded-md border px-2 py-1 text-left disabled:opacity-50"
+                  >
+                    <div className="font-medium">{t.name}</div>
+                    {t.rawRequest && (
+                      <div className="text-muted-foreground truncate text-xs">{t.rawRequest}</div>
+                    )}
+                    <div className="text-muted-foreground text-xs">
+                      {t.useCount} 回使用
+                      {t.lastUsedAt
+                        ? ` ・ 最終: ${new Date(t.lastUsedAt).toLocaleDateString("ja-JP")}`
+                        : null}
+                    </div>
+                  </button>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => onDeleteTemplate(t.id)}
+                    disabled={deleteTemplateMut.isPending}
+                    aria-label={`${t.name} を削除`}
+                  >
+                    <Trash2 className="h-3 w-3" />
+                  </Button>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
         {error && (
           <div className="text-destructive flex items-start gap-1 text-xs">
             <AlertTriangle className="mt-0.5 h-3 w-3" />

--- a/src/server/trpc/routers/custom.test.ts
+++ b/src/server/trpc/routers/custom.test.ts
@@ -23,6 +23,31 @@ vi.mock("@/server/parser/custom-session", async () => {
   };
 });
 
+describe("custom.saveTemplate input validation (issue #32)", () => {
+  const fakeUser = { id: "u-1" } as User;
+  const caller = appRouter.createCaller({ user: fakeUser });
+  beforeEach(() => vi.clearAllMocks());
+
+  it("空のテンプレ名は reject (whitespace-only を含む)", async () => {
+    await expect(
+      caller.custom.saveTemplate({ name: "   ", spec: { questionCount: 5 } }),
+    ).rejects.toThrow();
+  });
+
+  it("81 文字超のテンプレ名は reject", async () => {
+    await expect(
+      caller.custom.saveTemplate({ name: "a".repeat(81), spec: { questionCount: 5 } }),
+    ).rejects.toThrow();
+  });
+
+  it("未認証は UNAUTHORIZED", async () => {
+    const anon = appRouter.createCaller({ user: null });
+    await expect(
+      anon.custom.saveTemplate({ name: "test", spec: { questionCount: 5 } }),
+    ).rejects.toThrow();
+  });
+});
+
 describe("custom.parse input validation (router 境界テスト)", () => {
   const fakeUser = { id: "u-1" } as User;
   const caller = appRouter.createCaller({ user: fakeUser });

--- a/src/server/trpc/routers/custom.ts
+++ b/src/server/trpc/routers/custom.ts
@@ -1,8 +1,19 @@
+import { TRPCError } from "@trpc/server";
+import { and, eq, sql } from "drizzle-orm";
 import { z } from "zod";
 
+import { getDb } from "@/db/client";
+import { sessionTemplates } from "@/db/schema";
 import { parseCustomSession } from "@/server/parser/custom-session";
+import { CustomSessionSpecSchema } from "@/server/parser/schema";
 
 import { protectedProcedure, router } from "../init";
+
+/** テンプレ名の入力 Schema: trim して 1..80 chars に clamp。空白のみは reject。 */
+const TemplateNameInput = z
+  .string()
+  .transform((s) => s.trim())
+  .pipe(z.string().min(1, "テンプレ名を入力してください").max(80));
 
 export const customRouter = router({
   /**
@@ -23,5 +34,90 @@ export const customRouter = router({
     .mutation(async ({ input }) => {
       const { spec, promptVersion, model } = await parseCustomSession(input.raw);
       return { spec, promptVersion, model };
+    }),
+
+  /**
+   * Custom Session テンプレの一覧取得 (issue #32, docs/04 §4.8)。
+   * last_used_at 降順 (null は末尾)、name 昇順の順でソート。
+   */
+  listTemplates: protectedProcedure.query(async ({ ctx }) => {
+    const rows = await getDb()
+      .select()
+      .from(sessionTemplates)
+      .where(eq(sessionTemplates.userId, ctx.user.id))
+      .orderBy(
+        // lastUsedAt NULL は最後、非 NULL は新しい順
+        sql`${sessionTemplates.lastUsedAt} DESC NULLS LAST`,
+        sessionTemplates.name,
+      );
+    return { items: rows };
+  }),
+
+  /** テンプレ保存 (issue #32)。同名上書きは避け、常に insert。 */
+  saveTemplate: protectedProcedure
+    .input(
+      z.object({
+        name: TemplateNameInput,
+        rawRequest: z.string().max(2000).optional(),
+        spec: CustomSessionSpecSchema,
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      const [row] = await getDb()
+        .insert(sessionTemplates)
+        .values({
+          userId: ctx.user.id,
+          name: input.name,
+          rawRequest: input.rawRequest ?? null,
+          spec: input.spec,
+        })
+        .returning();
+      if (!row) throw new TRPCError({ code: "INTERNAL_SERVER_ERROR" });
+      return { id: row.id };
+    }),
+
+  /**
+   * テンプレ使用時に use_count+1 / last_used_at=NOW() を更新して spec を返す (issue #32)。
+   * 返した spec を呼び出し側が session.start({ kind:'custom', customSpec }) にそのまま渡す。
+   * userId 一致は where 句で担保 (他ユーザーの template に触れないように)。
+   */
+  useTemplate: protectedProcedure
+    .input(z.object({ id: z.string().min(1) }))
+    .mutation(async ({ ctx, input }) => {
+      const rows = await getDb()
+        .update(sessionTemplates)
+        .set({
+          useCount: sql`${sessionTemplates.useCount} + 1`,
+          lastUsedAt: new Date(),
+        })
+        .where(and(eq(sessionTemplates.id, input.id), eq(sessionTemplates.userId, ctx.user.id)))
+        .returning();
+      const row = rows[0];
+      if (!row) throw new TRPCError({ code: "NOT_FOUND", message: "テンプレが見つかりません" });
+      const spec = CustomSessionSpecSchema.safeParse(row.spec);
+      if (!spec.success) {
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: "保存された spec が破損しています",
+        });
+      }
+      return {
+        id: row.id,
+        name: row.name,
+        rawRequest: row.rawRequest,
+        spec: spec.data,
+      };
+    }),
+
+  /** テンプレ削除 (userId 一致を where で担保) */
+  deleteTemplate: protectedProcedure
+    .input(z.object({ id: z.string().min(1) }))
+    .mutation(async ({ ctx, input }) => {
+      const rows = await getDb()
+        .delete(sessionTemplates)
+        .where(and(eq(sessionTemplates.id, input.id), eq(sessionTemplates.userId, ctx.user.id)))
+        .returning({ id: sessionTemplates.id });
+      if (!rows[0]) throw new TRPCError({ code: "NOT_FOUND" });
+      return { ok: true as const };
     }),
 });

--- a/src/server/trpc/routers/custom.ts
+++ b/src/server/trpc/routers/custom.ts
@@ -80,19 +80,20 @@ export const customRouter = router({
    * テンプレ使用時に use_count+1 / last_used_at=NOW() を更新して spec を返す (issue #32)。
    * 返した spec を呼び出し側が session.start({ kind:'custom', customSpec }) にそのまま渡す。
    * userId 一致は where 句で担保 (他ユーザーの template に触れないように)。
+   *
+   * データ整合: SELECT → spec validate → UPDATE の 2 段階で、spec が壊れている場合に
+   * use_count が加算される回帰を防ぐ (Codex Round 1 指摘)。
+   * spec の健全性が確認できない限りカウンタと lastUsedAt は触らない。
    */
   useTemplate: protectedProcedure
     .input(z.object({ id: z.string().min(1) }))
     .mutation(async ({ ctx, input }) => {
-      const rows = await getDb()
-        .update(sessionTemplates)
-        .set({
-          useCount: sql`${sessionTemplates.useCount} + 1`,
-          lastUsedAt: new Date(),
-        })
+      const db = getDb();
+      const [row] = await db
+        .select()
+        .from(sessionTemplates)
         .where(and(eq(sessionTemplates.id, input.id), eq(sessionTemplates.userId, ctx.user.id)))
-        .returning();
-      const row = rows[0];
+        .limit(1);
       if (!row) throw new TRPCError({ code: "NOT_FOUND", message: "テンプレが見つかりません" });
       const spec = CustomSessionSpecSchema.safeParse(row.spec);
       if (!spec.success) {
@@ -101,6 +102,14 @@ export const customRouter = router({
           message: "保存された spec が破損しています",
         });
       }
+      // spec 健全 → カウンタを atomic 加算 (行単位で Postgres がシリアライズする)
+      await db
+        .update(sessionTemplates)
+        .set({
+          useCount: sql`${sessionTemplates.useCount} + 1`,
+          lastUsedAt: new Date(),
+        })
+        .where(and(eq(sessionTemplates.id, input.id), eq(sessionTemplates.userId, ctx.user.id)));
       return {
         id: row.id,
         name: row.name,

--- a/src/server/trpc/routers/custom.ts
+++ b/src/server/trpc/routers/custom.ts
@@ -102,14 +102,23 @@ export const customRouter = router({
           message: "保存された spec が破損しています",
         });
       }
-      // spec 健全 → カウンタを atomic 加算 (行単位で Postgres がシリアライズする)
-      await db
+      // spec 健全 → カウンタを atomic 加算 (行単位で Postgres がシリアライズする)。
+      // SELECT と UPDATE の間に並行 deleteTemplate が走って行が消えているケースに備え、
+      // RETURNING で 0 行を検知したら NOT_FOUND で returns (Codex Round 2 指摘)。
+      const updated = await db
         .update(sessionTemplates)
         .set({
           useCount: sql`${sessionTemplates.useCount} + 1`,
           lastUsedAt: new Date(),
         })
-        .where(and(eq(sessionTemplates.id, input.id), eq(sessionTemplates.userId, ctx.user.id)));
+        .where(and(eq(sessionTemplates.id, input.id), eq(sessionTemplates.userId, ctx.user.id)))
+        .returning({ id: sessionTemplates.id });
+      if (updated.length === 0) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "テンプレが削除されました (並行削除)",
+        });
+      }
       return {
         id: row.id,
         name: row.name,


### PR DESCRIPTION
## Summary
issue #32 (Phase 5+) Custom Session テンプレの保存・再利用。既存の `session_templates` テーブル (migration 0000) をフル活用。

### 実装
- **router** (`src/server/trpc/routers/custom.ts`):
  - `listTemplates`: last_used_at DESC NULLS LAST, name ASC で一覧
  - `saveTemplate`: trim 済み 1-80 chars の名前 + rawRequest + spec を insert (同名上書きはしない)
  - `useTemplate`: use_count+1 / last_used_at=NOW() を atomic update、保存 spec を `CustomSessionSpecSchema.safeParse` で再検証してから返す
  - `deleteTemplate`: userId 一致の where で他ユーザー行へ触れないよう担保
- **UI** (`src/features/custom/custom-screen.tsx`):
  - previewing 時: 「このセッションをテンプレに保存」フォーム (名前入力 + 保存ボタン)
  - input 時: 保存済みテンプレ一覧 (タップで useTemplate → previewing に遷移、ゴミ箱アイコンで削除)
  - useCount / lastUsedAt を各カードにメタ表示
- **tests**: saveTemplate の zod 境界 (空 / 81 文字 / 未認証) 3 件追加、全 264 件 pass

### 受け入れ基準
- [x] セッション開始時「保存」ボタン → 名前を付けて保存
- [x] `/custom` で保存済みテンプレ一覧、タップで再利用
- [x] use_count / last_used_at を更新

closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)