### PR TITLE
feat(insights): Trends グラフ (自作 SVG 時系列、#33)

### DIFF
--- a/src/app/insights/trends/page.tsx
+++ b/src/app/insights/trends/page.tsx
@@ -1,0 +1,17 @@
+import { redirect } from "next/navigation";
+
+import { TrendsScreen } from "@/features/insights/trends-screen";
+import { getCurrentUser } from "@/server/auth/session";
+
+export const dynamic = "force-dynamic";
+
+export default async function TrendsPage() {
+  const user = await getCurrentUser();
+  if (!user) redirect("/login");
+  if (!user.onboardingCompletedAt) redirect("/onboarding");
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-start gap-6 p-6">
+      <TrendsScreen />
+    </main>
+  );
+}

--- a/src/features/insights/overview-screen.tsx
+++ b/src/features/insights/overview-screen.tsx
@@ -106,9 +106,12 @@ export function InsightsOverviewScreen() {
         </CardHeader>
         <CardContent className="space-y-3">
           <ProgressBar value={data.masteryPct} />
-          <div>
+          <div className="flex flex-wrap gap-2">
             <Button asChild variant="outline" size="sm">
-              <Link href="/insights/map">🗺 Mastery Map を開く</Link>
+              <Link href="/insights/map">🗺 Mastery Map</Link>
+            </Button>
+            <Button asChild variant="outline" size="sm">
+              <Link href="/insights/trends">📈 Trends</Link>
             </Button>
           </div>
         </CardContent>

--- a/src/features/insights/trends-screen.tsx
+++ b/src/features/insights/trends-screen.tsx
@@ -1,0 +1,257 @@
+"use client";
+
+import type { inferRouterOutputs } from "@trpc/server";
+import Link from "next/link";
+
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { trpc } from "@/lib/trpc/react";
+import type { AppRouter } from "@/server/trpc/routers";
+
+type TrendsResult = inferRouterOutputs<AppRouter>["insights"]["trends"];
+type TrendPoint = TrendsResult["points"][number];
+
+const CHART_W = 560;
+const CHART_H = 140;
+const PAD = { top: 8, right: 8, bottom: 18, left: 32 };
+
+/** 純粋 SVG の折れ線 / 棒グラフ (issue #33, CLAUDE.md §3: Recharts/D3 非採用)。 */
+
+function niceTickStep(maxValue: number): number {
+  if (maxValue <= 0) return 1;
+  const pow = Math.pow(10, Math.floor(Math.log10(maxValue)));
+  const norm = maxValue / pow;
+  const step = norm <= 1 ? 0.25 : norm <= 2 ? 0.5 : norm <= 5 ? 1 : 2;
+  return step * pow;
+}
+
+function LineChart({
+  points,
+  yAccessor,
+  yMax,
+  color,
+  label,
+  yFormat,
+}: {
+  points: TrendPoint[];
+  yAccessor: (p: TrendPoint) => number;
+  yMax: number;
+  color: string;
+  label: string;
+  yFormat: (v: number) => string;
+}) {
+  const innerW = CHART_W - PAD.left - PAD.right;
+  const innerH = CHART_H - PAD.top - PAD.bottom;
+  const n = points.length;
+  const xStep = n > 1 ? innerW / (n - 1) : 0;
+  const yScale = (v: number) => PAD.top + innerH - (v / yMax) * innerH;
+  const path = points
+    .map((p, i) => `${i === 0 ? "M" : "L"} ${PAD.left + i * xStep} ${yScale(yAccessor(p))}`)
+    .join(" ");
+  const ticks = [0, yMax / 2, yMax];
+  const firstDate = points[0]?.date ?? "";
+  const lastDate = points[n - 1]?.date ?? "";
+  return (
+    <figure className="space-y-1">
+      <figcaption className="text-muted-foreground text-xs">{label}</figcaption>
+      <svg viewBox={`0 0 ${CHART_W} ${CHART_H}`} className="w-full" role="img" aria-label={label}>
+        {/* grid + y ticks */}
+        {ticks.map((t, i) => (
+          <g key={i}>
+            <line
+              x1={PAD.left}
+              y1={yScale(t)}
+              x2={CHART_W - PAD.right}
+              y2={yScale(t)}
+              stroke="currentColor"
+              strokeOpacity={0.1}
+            />
+            <text
+              x={PAD.left - 4}
+              y={yScale(t) + 3}
+              textAnchor="end"
+              fontSize={9}
+              fill="currentColor"
+              fillOpacity={0.7}
+            >
+              {yFormat(t)}
+            </text>
+          </g>
+        ))}
+        {/* line */}
+        <path d={path} fill="none" stroke={color} strokeWidth={1.5} />
+        {/* x 軸 (最初と最後の日付のみ) */}
+        <text x={PAD.left} y={CHART_H - 4} fontSize={9} fill="currentColor" fillOpacity={0.7}>
+          {firstDate}
+        </text>
+        <text
+          x={CHART_W - PAD.right}
+          y={CHART_H - 4}
+          textAnchor="end"
+          fontSize={9}
+          fill="currentColor"
+          fillOpacity={0.7}
+        >
+          {lastDate}
+        </text>
+      </svg>
+    </figure>
+  );
+}
+
+function BarChart({
+  points,
+  yAccessor,
+  yMax,
+  color,
+  label,
+  yFormat,
+}: {
+  points: TrendPoint[];
+  yAccessor: (p: TrendPoint) => number;
+  yMax: number;
+  color: string;
+  label: string;
+  yFormat: (v: number) => string;
+}) {
+  const innerW = CHART_W - PAD.left - PAD.right;
+  const innerH = CHART_H - PAD.top - PAD.bottom;
+  const n = points.length;
+  const barW = n > 0 ? (innerW / n) * 0.8 : 0;
+  const xStep = n > 0 ? innerW / n : 0;
+  const yScale = (v: number) => PAD.top + innerH - (v / yMax) * innerH;
+  const ticks = [0, yMax / 2, yMax];
+  const firstDate = points[0]?.date ?? "";
+  const lastDate = points[n - 1]?.date ?? "";
+  return (
+    <figure className="space-y-1">
+      <figcaption className="text-muted-foreground text-xs">{label}</figcaption>
+      <svg viewBox={`0 0 ${CHART_W} ${CHART_H}`} className="w-full" role="img" aria-label={label}>
+        {ticks.map((t, i) => (
+          <g key={i}>
+            <line
+              x1={PAD.left}
+              y1={yScale(t)}
+              x2={CHART_W - PAD.right}
+              y2={yScale(t)}
+              stroke="currentColor"
+              strokeOpacity={0.1}
+            />
+            <text
+              x={PAD.left - 4}
+              y={yScale(t) + 3}
+              textAnchor="end"
+              fontSize={9}
+              fill="currentColor"
+              fillOpacity={0.7}
+            >
+              {yFormat(t)}
+            </text>
+          </g>
+        ))}
+        {points.map((p, i) => {
+          const v = yAccessor(p);
+          const y = yScale(v);
+          const x = PAD.left + i * xStep + (xStep - barW) / 2;
+          return (
+            <rect
+              key={p.date}
+              x={x}
+              y={y}
+              width={barW}
+              height={PAD.top + innerH - y}
+              fill={color}
+              opacity={0.85}
+            >
+              <title>
+                {p.date}: {yFormat(v)}
+              </title>
+            </rect>
+          );
+        })}
+        <text x={PAD.left} y={CHART_H - 4} fontSize={9} fill="currentColor" fillOpacity={0.7}>
+          {firstDate}
+        </text>
+        <text
+          x={CHART_W - PAD.right}
+          y={CHART_H - 4}
+          textAnchor="end"
+          fontSize={9}
+          fill="currentColor"
+          fillOpacity={0.7}
+        >
+          {lastDate}
+        </text>
+      </svg>
+    </figure>
+  );
+}
+
+export function TrendsScreen() {
+  const { data, isLoading, error } = trpc.insights.trends.useQuery();
+
+  if (isLoading) {
+    return (
+      <Card className="w-full max-w-2xl">
+        <CardContent className="text-muted-foreground p-6 text-sm">読み込み中…</CardContent>
+      </Card>
+    );
+  }
+  if (error) {
+    return (
+      <Card className="w-full max-w-2xl">
+        <CardContent className="text-destructive p-6 text-sm">{error.message}</CardContent>
+      </Card>
+    );
+  }
+  if (!data) return null;
+
+  const points = data.points;
+  const maxAttempt = Math.max(1, ...points.map((p) => p.attemptCount));
+  const maxTime = Math.max(1, ...points.map((p) => p.studyTimeMin));
+  // Y 軸の見た目を綺麗な目盛りに (maxAttempt=3 なら 4 まで切り上げ等)
+  const tickMaxAttempt =
+    Math.ceil(maxAttempt / niceTickStep(maxAttempt)) * niceTickStep(maxAttempt);
+  const tickMaxTime = Math.ceil(maxTime / niceTickStep(maxTime)) * niceTickStep(maxTime);
+
+  return (
+    <Card className="w-full max-w-2xl">
+      <CardHeader>
+        <CardTitle>Trends</CardTitle>
+        <CardDescription>
+          直近 {data.days} 日の日次推移 (JST)。MVP は attempts を GROUP BY DATE で集計。
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        <BarChart
+          points={points}
+          yAccessor={(p) => p.attemptCount}
+          yMax={tickMaxAttempt}
+          color="#3b82f6"
+          label="📊 出題数 / 日"
+          yFormat={(v) => String(Math.round(v))}
+        />
+        <LineChart
+          points={points}
+          yAccessor={(p) => p.accuracyPct}
+          yMax={1}
+          color="#22c55e"
+          label="✓ 正答率 (%) / 日"
+          yFormat={(v) => `${Math.round(v * 100)}%`}
+        />
+        <LineChart
+          points={points}
+          yAccessor={(p) => p.studyTimeMin}
+          yMax={tickMaxTime}
+          color="#eab308"
+          label="⏱ 学習時間 (分) / 日"
+          yFormat={(v) => `${v.toFixed(1)}`}
+        />
+        <div className="text-muted-foreground text-xs">
+          <Link href="/insights" className="underline">
+            ← Dashboard に戻る
+          </Link>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/server/insights/trends.test.ts
+++ b/src/server/insights/trends.test.ts
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { fetchTrends } from "./trends";
+
+const queue: Array<() => unknown> = [];
+vi.mock("@/db/client", () => {
+  function makeBuilder(): unknown {
+    const b: Record<string, unknown> = {
+      from: () => b,
+      where: () => b,
+      groupBy: () => b,
+      orderBy: () => b,
+      then: (onFulfilled: (v: unknown) => unknown) => {
+        const handler = queue.shift();
+        const result = handler ? handler() : [];
+        return Promise.resolve(result).then(onFulfilled);
+      },
+    };
+    return b;
+  }
+  return { getDb: () => ({ select: () => makeBuilder() }) };
+});
+
+beforeEach(() => {
+  queue.length = 0;
+});
+
+describe("fetchTrends", () => {
+  it("days を 7..90 に clamp (デフォルト 30)", async () => {
+    queue.push(() => []);
+    const out = await fetchTrends({ userId: "u-1" });
+    expect(out.days).toBe(30);
+    expect(out.points).toHaveLength(30);
+
+    queue.push(() => []);
+    const tiny = await fetchTrends({ userId: "u-1", days: 1 });
+    expect(tiny.days).toBe(7); // 7 まで引き上げ
+
+    queue.push(() => []);
+    const huge = await fetchTrends({ userId: "u-1", days: 10000 });
+    expect(huge.days).toBe(90); // 90 まで clamp
+  });
+
+  it("欠損日は 0 埋めされる (全 7 日分の points が揃う、JST)", async () => {
+    const now = new Date("2026-04-18T05:00:00Z"); // JST 14:00 2026-04-18
+    queue.push(() => [
+      // 4/18 だけデータあり、他は欠損
+      { date: "2026-04-18", attemptCount: 3, correctCount: 2, studyTimeSec: 120000 },
+    ]);
+    const out = await fetchTrends({ userId: "u-1", days: 7, now });
+    expect(out.points).toHaveLength(7);
+    // 降順にソートされず、days-1..0 の昇順で並ぶ: 先頭は 6 日前、末尾が今日
+    const last = out.points.at(-1)!;
+    expect(last.date).toBe("2026-04-18");
+    expect(last.attemptCount).toBe(3);
+    expect(last.accuracyPct).toBeCloseTo(2 / 3, 5);
+    // 欠損日は全て 0
+    for (const p of out.points.slice(0, -1)) {
+      expect(p.attemptCount).toBe(0);
+      expect(p.correctCount).toBe(0);
+      expect(p.accuracyPct).toBe(0);
+      expect(p.studyTimeMin).toBe(0);
+    }
+  });
+
+  it("attemptCount=0 なら accuracyPct は 0 (ゼロ割り防止)", async () => {
+    queue.push(() => []);
+    const out = await fetchTrends({ userId: "u-1", days: 7 });
+    for (const p of out.points) expect(p.accuracyPct).toBe(0);
+  });
+
+  it("studyTimeSec (ms 累積) を分に変換して小数 1 桁で丸める", async () => {
+    const now = new Date("2026-04-18T05:00:00Z");
+    queue.push(() => [
+      // 1,234,567 ms ≈ 20.6 分
+      { date: "2026-04-18", attemptCount: 1, correctCount: 1, studyTimeSec: 1_234_567 },
+    ]);
+    const out = await fetchTrends({ userId: "u-1", days: 7, now });
+    const today = out.points.at(-1)!;
+    expect(today.studyTimeMin).toBeCloseTo(20.6, 1);
+  });
+});

--- a/src/server/insights/trends.test.ts
+++ b/src/server/insights/trends.test.ts
@@ -45,7 +45,7 @@ describe("fetchTrends", () => {
     const now = new Date("2026-04-18T05:00:00Z"); // JST 14:00 2026-04-18
     queue.push(() => [
       // 4/18 だけデータあり、他は欠損
-      { date: "2026-04-18", attemptCount: 3, correctCount: 2, studyTimeSec: 120000 },
+      { date: "2026-04-18", attemptCount: 3, correctCount: 2, studyTimeMs: 120000 },
     ]);
     const out = await fetchTrends({ userId: "u-1", days: 7, now });
     expect(out.points).toHaveLength(7);
@@ -69,11 +69,11 @@ describe("fetchTrends", () => {
     for (const p of out.points) expect(p.accuracyPct).toBe(0);
   });
 
-  it("studyTimeSec (ms 累積) を分に変換して小数 1 桁で丸める", async () => {
+  it("studyTimeMs (ms 累積) を分に変換して小数 1 桁で丸める", async () => {
     const now = new Date("2026-04-18T05:00:00Z");
     queue.push(() => [
       // 1,234,567 ms ≈ 20.6 分
-      { date: "2026-04-18", attemptCount: 1, correctCount: 1, studyTimeSec: 1_234_567 },
+      { date: "2026-04-18", attemptCount: 1, correctCount: 1, studyTimeMs: 1_234_567 },
     ]);
     const out = await fetchTrends({ userId: "u-1", days: 7, now });
     const today = out.points.at(-1)!;

--- a/src/server/insights/trends.ts
+++ b/src/server/insights/trends.ts
@@ -1,0 +1,97 @@
+import "server-only";
+
+import { and, eq, gte, sql } from "drizzle-orm";
+
+import { getDb } from "@/db/client";
+import { attempts } from "@/db/schema";
+
+export type TrendPoint = {
+  /** 'YYYY-MM-DD' (JST) */
+  date: string;
+  attemptCount: number;
+  correctCount: number;
+  accuracyPct: number;
+  studyTimeMin: number;
+};
+
+export type TrendsResult = {
+  days: number;
+  points: TrendPoint[];
+};
+
+/** Trends グラフ (issue #33, docs/05 §5.9)。
+ *
+ *  MVP 実装方針: `daily_stats` テーブルは現時点で populate 経路が無い (docs/02 §2.x や scheduler
+ *  / grader から insert されていない) ため、受け入れ基準「daily_stats から集計」に対しては
+ *  **attempts を GROUP BY DATE(created_at AT TIME ZONE 'Asia/Tokyo') で集計して返す**
+ *  ことで同等のデータを提供する (列名は daily_stats と同構造: attemptCount / correctCount /
+ *  studyTimeMin)。daily_stats にロールアップする cron / batch (将来 issue) が走るように
+ *  なったらこの関数を daily_stats 直読みに切り替えれば、呼び出し側の型は変えずに済む。
+ *
+ *  デフォルトで直近 30 日。timezone は JST (docs/06 §6.3 の notificationTime と同じ扱い)。
+ */
+export async function fetchTrends(params: {
+  userId: string;
+  days?: number;
+  now?: Date;
+}): Promise<TrendsResult> {
+  const days = Math.min(Math.max(params.days ?? 30, 7), 90);
+  const now = params.now ?? new Date();
+  const since = new Date(now.getTime() - days * 24 * 60 * 60 * 1000);
+
+  const rows = await getDb()
+    .select({
+      date: sql<string>`to_char(${attempts.createdAt} AT TIME ZONE 'Asia/Tokyo', 'YYYY-MM-DD')`.as(
+        "date",
+      ),
+      attemptCount: sql<number>`count(*)::int`.as("attempt_count"),
+      correctCount:
+        sql<number>`sum(case when ${attempts.correct} = true then 1 else 0 end)::int`.as(
+          "correct_count",
+        ),
+      studyTimeSec: sql<number>`coalesce(sum(${attempts.elapsedMs}), 0)::int`.as("study_time_sec"),
+    })
+    .from(attempts)
+    .where(and(eq(attempts.userId, params.userId), gte(attempts.createdAt, since)))
+    .groupBy(sql`to_char(${attempts.createdAt} AT TIME ZONE 'Asia/Tokyo', 'YYYY-MM-DD')`)
+    .orderBy(sql`to_char(${attempts.createdAt} AT TIME ZONE 'Asia/Tokyo', 'YYYY-MM-DD') asc`);
+
+  // 欠損日は 0 埋めしてグラフが飛ばないようにする (JST)
+  const byDate = new Map<string, (typeof rows)[number]>();
+  for (const r of rows) byDate.set(r.date, r);
+
+  const points: TrendPoint[] = [];
+  const jstFormatter = new Intl.DateTimeFormat("ja-JP", {
+    timeZone: "Asia/Tokyo",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  });
+  // 時刻は JST 00:00 を基準にずらす (since..now の範囲を 1 日ずつ歩く)
+  // JP locale の `YYYY/MM/DD` を `YYYY-MM-DD` に正規化
+  const toIso = (d: Date): string => {
+    const parts = jstFormatter.formatToParts(d);
+    const y = parts.find((p) => p.type === "year")?.value ?? "";
+    const m = parts.find((p) => p.type === "month")?.value ?? "";
+    const dd = parts.find((p) => p.type === "day")?.value ?? "";
+    return `${y}-${m}-${dd}`;
+  };
+  for (let i = days - 1; i >= 0; i--) {
+    const d = new Date(now.getTime() - i * 24 * 60 * 60 * 1000);
+    const iso = toIso(d);
+    const row = byDate.get(iso);
+    const attemptCount = row?.attemptCount ?? 0;
+    const correctCount = row?.correctCount ?? 0;
+    // elapsedMs の合計は msec で入っている (docs/03 での記録単位)。分換算 (小数 1 桁丸め)
+    const studyTimeMs = row?.studyTimeSec ?? 0;
+    const studyTimeMin = Math.round((studyTimeMs / 60000) * 10) / 10;
+    points.push({
+      date: iso,
+      attemptCount,
+      correctCount,
+      accuracyPct: attemptCount > 0 ? correctCount / attemptCount : 0,
+      studyTimeMin,
+    });
+  }
+  return { days, points };
+}

--- a/src/server/insights/trends.ts
+++ b/src/server/insights/trends.ts
@@ -49,7 +49,8 @@ export async function fetchTrends(params: {
         sql<number>`sum(case when ${attempts.correct} = true then 1 else 0 end)::int`.as(
           "correct_count",
         ),
-      studyTimeSec: sql<number>`coalesce(sum(${attempts.elapsedMs}), 0)::int`.as("study_time_sec"),
+      // attempts.elapsedMs の単位はミリ秒なので sum もミリ秒。UI 側で分換算する (Codex Round 1 指摘)。
+      studyTimeMs: sql<number>`coalesce(sum(${attempts.elapsedMs}), 0)::int`.as("study_time_ms"),
     })
     .from(attempts)
     .where(and(eq(attempts.userId, params.userId), gte(attempts.createdAt, since)))
@@ -83,7 +84,7 @@ export async function fetchTrends(params: {
     const attemptCount = row?.attemptCount ?? 0;
     const correctCount = row?.correctCount ?? 0;
     // elapsedMs の合計は msec で入っている (docs/03 での記録単位)。分換算 (小数 1 桁丸め)
-    const studyTimeMs = row?.studyTimeSec ?? 0;
+    const studyTimeMs = row?.studyTimeMs ?? 0;
     const studyTimeMin = Math.round((studyTimeMs / 60000) * 10) / 10;
     points.push({
       date: iso,

--- a/src/server/trpc/routers/insights.ts
+++ b/src/server/trpc/routers/insights.ts
@@ -5,6 +5,7 @@ import { fetchHistory } from "@/server/insights/history";
 import { fetchMasteryMap } from "@/server/insights/mastery-map";
 import { fetchInsightsOverview } from "@/server/insights/overview";
 import { fetchSearch } from "@/server/insights/search";
+import { fetchTrends } from "@/server/insights/trends";
 
 import { protectedProcedure, router } from "../init";
 
@@ -20,6 +21,15 @@ export const insightsRouter = router({
    * 全 concept を domain → subdomain → concept の 3 階層で返す (サンバースト用)。
    */
   masteryMap: protectedProcedure.query(({ ctx }) => fetchMasteryMap(ctx.user.id)),
+
+  /**
+   * Trends (issue #33, docs/05 §5.9)。
+   * 直近 N 日の attemptCount / correctCount / accuracyPct / studyTimeMin を日次で返す。
+   * 欠損日は 0 埋め済み (JST 基準)。MVP は attempts GROUP BY DATE(…)。
+   */
+  trends: protectedProcedure
+    .input(z.object({ days: z.number().int().min(7).max(90).optional() }).optional())
+    .query(({ ctx, input }) => fetchTrends({ userId: ctx.user.id, days: input?.days })),
 
   /**
    * History 画面 (issue #21, docs/05 §5.5)。


### PR DESCRIPTION
## Summary
issue #33 (Phase 5+) Trends グラフ。docs/05 §5.9。3 種類の日次時系列 (出題数 / 正答率 / 学習時間) を自作 SVG で表示 (Recharts/D3 非採用、CLAUDE.md §3)。

### 実装
- `src/server/insights/trends.ts` — `fetchTrends` で attempts を `GROUP BY DATE(created_at AT TIME ZONE 'Asia/Tokyo')` で集計、7..90 日 clamp、欠損日は 0 埋め (JST)
- `insights.trends` tRPC query
- `src/features/insights/trends-screen.tsx` — 自作 SVG の LineChart / BarChart を並べる。grid + ticks + 先頭/末尾日付 x 軸表示
- `/insights/trends` ルート + Insights Dashboard から導線

### 受け入れ基準
- [x] `/insights/trends` ルート
- [ ] Recharts で最低 3 種類 → **自作 SVG で 3 種類実装** (CLAUDE.md §3 ライブラリ最小化)
- [x] daily_stats から集計 → **attempts から同等集計**: daily_stats は現在 populate 経路なし (docs 内 seed/grader/scheduler どこでも insert されていない) ため、GROUP BY DATE で同じデータを算出。将来 cron で daily_stats に rollup されたら関数内 SQL を切り替えるだけで呼び出し側の型変更なし

### Test plan
- [x] `pnpm typecheck` ✓
- [x] `pnpm test -- --run` ✓ (268/268、新規 +4: days clamp / 欠損日 0 埋め / accuracyPct ゼロ割り / studyTimeMin 丸め)
- [x] `pnpm build` ✓ (`/insights/trends` 登録確認)

closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)