### PR TITLE
feat(auth): ローカル開発時の認証バイパス + vercel dev 再帰回避

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "vercel dev",
+    "dev": "./scripts/dev.sh",
     "dev:local": "next dev",
     "build": "next build",
     "start": "next start",

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# vercel dev を起動する thin wrapper。
+# Vercel CLI 51.x が package.json の "dev" script に "vercel dev" を見つけると
+# 自己再帰防止で即エラーに落とすため、スクリプト経由で起動して回避する。
+
+set -euo pipefail
+
+exec vercel dev "$@"

--- a/src/app/api/auth/authenticate/verify/route.ts
+++ b/src/app/api/auth/authenticate/verify/route.ts
@@ -2,7 +2,7 @@ import { cookies } from "next/headers";
 import { NextResponse } from "next/server";
 import { z } from "zod";
 
-import { SESSION_COOKIE_NAME } from "@/server/auth/constants";
+import { LOCAL_BYPASS_OFF_COOKIE_NAME, SESSION_COOKIE_NAME } from "@/server/auth/constants";
 import { createSession } from "@/server/auth/session";
 import { isPasskeyEnabled, verifyAuthentication } from "@/server/auth/webauthn";
 
@@ -29,6 +29,9 @@ export async function POST(req: Request) {
     const { sessionId, cookie } = await createSession(user.id);
     const store = await cookies();
     store.set({ name: SESSION_COOKIE_NAME, value: sessionId, ...cookie });
+    // 本物のログインが成立した時点で、ローカル bypass の opt-out フラグは不要。
+    // 残っていても resolveSession は実 cookie を優先するが、stale な cookie を掃除しておく。
+    store.delete(LOCAL_BYPASS_OFF_COOKIE_NAME);
     return NextResponse.json({ ok: true, user: { id: user.id, email: user.email } });
   } catch (error) {
     return NextResponse.json(

--- a/src/app/api/auth/dev-login/route.ts
+++ b/src/app/api/auth/dev-login/route.ts
@@ -2,7 +2,7 @@ import { cookies } from "next/headers";
 import { NextResponse } from "next/server";
 
 import { isDevShortcutAvailable } from "@/server/auth/capabilities";
-import { DEV_SESSION_COOKIE_NAME } from "@/server/auth/constants";
+import { DEV_SESSION_COOKIE_NAME, LOCAL_BYPASS_OFF_COOKIE_NAME } from "@/server/auth/constants";
 import { tryDevAutoLoginUser } from "@/server/auth/dev-login";
 import { createSession } from "@/server/auth/session";
 
@@ -35,5 +35,7 @@ export async function POST() {
     // __Host- prefix は使わないので Secure は HTTPS のみ必要。本番では上で 404 を返す
     secure: false,
   });
+  // 本物のログインが成立した時点で、ローカル bypass の opt-out フラグは不要。
+  store.delete(LOCAL_BYPASS_OFF_COOKIE_NAME);
   return NextResponse.json({ ok: true, user: { id: user.id, email: user.email } });
 }

--- a/src/app/api/auth/logout/route.ts
+++ b/src/app/api/auth/logout/route.ts
@@ -1,16 +1,31 @@
 import { cookies } from "next/headers";
 import { NextResponse } from "next/server";
 
-import { DEV_SESSION_COOKIE_NAME, SESSION_COOKIE_NAME } from "@/server/auth/constants";
+import {
+  DEV_SESSION_COOKIE_NAME,
+  LOCAL_BYPASS_OFF_COOKIE_NAME,
+  SESSION_COOKIE_NAME,
+} from "@/server/auth/constants";
 import { destroySession, resolveSession } from "@/server/auth/session";
 
 export async function POST() {
   const store = await cookies();
   const resolved = await resolveSession(store);
-  if (resolved) {
+  // bypass 由来 (issue #71 着地までの暫定) は sessions_auth に行が無いので DELETE を飛ばす。
+  if (resolved && resolved.kind !== "bypass") {
     await destroySession(resolved.sessionId);
   }
   store.delete(SESSION_COOKIE_NAME);
   store.delete(DEV_SESSION_COOKIE_NAME);
+  // ローカル bypass 有効時でも次回リクエストで即再認証されないよう opt-out cookie を発行する。
+  // cookie を消せば bypass が戻る (開発者が手動で削除できる)。
+  store.set({
+    name: LOCAL_BYPASS_OFF_COOKIE_NAME,
+    value: "1",
+    httpOnly: true,
+    sameSite: "lax",
+    path: "/",
+    secure: process.env.NODE_ENV === "production",
+  });
   return NextResponse.json({ ok: true });
 }

--- a/src/server/auth/capabilities.test.ts
+++ b/src/server/auth/capabilities.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { isDevShortcutAvailable } from "./capabilities";
+import { isDevShortcutAvailable, isLocalAuthBypassEnabled } from "./capabilities";
 
 function setEnv(partial: Record<string, string | undefined>) {
   for (const [key, value] of Object.entries(partial)) {
@@ -66,5 +66,41 @@ describe("isDevShortcutAvailable", () => {
       NODE_ENV: "development",
     });
     expect(isDevShortcutAvailable()).toBe(true);
+  });
+});
+
+describe("isLocalAuthBypassEnabled", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("ローカル dev (NODE_ENV=development, VERCEL_ENV 未設定) は true", () => {
+    setEnv({ VERCEL_ENV: undefined, NODE_ENV: "development" });
+    expect(isLocalAuthBypassEnabled()).toBe(true);
+  });
+
+  it("vercel dev (VERCEL_ENV=development, NODE_ENV=development) は true", () => {
+    setEnv({ VERCEL_ENV: "development", NODE_ENV: "development" });
+    expect(isLocalAuthBypassEnabled()).toBe(true);
+  });
+
+  it("Vercel preview は false (認証バイパス防止)", () => {
+    setEnv({ VERCEL_ENV: "preview", NODE_ENV: "production" });
+    expect(isLocalAuthBypassEnabled()).toBe(false);
+  });
+
+  it("Vercel production は false", () => {
+    setEnv({ VERCEL_ENV: "production", NODE_ENV: "production" });
+    expect(isLocalAuthBypassEnabled()).toBe(false);
+  });
+
+  it("self-host next start (VERCEL_ENV 未設定, NODE_ENV=production) は false", () => {
+    setEnv({ VERCEL_ENV: undefined, NODE_ENV: "production" });
+    expect(isLocalAuthBypassEnabled()).toBe(false);
+  });
+
+  it("vitest 環境 (NODE_ENV=test) は false", () => {
+    setEnv({ VERCEL_ENV: undefined, NODE_ENV: "test" });
+    expect(isLocalAuthBypassEnabled()).toBe(false);
   });
 });

--- a/src/server/auth/capabilities.ts
+++ b/src/server/auth/capabilities.ts
@@ -25,3 +25,17 @@ export function isDevShortcutAvailable(): boolean {
   // VERCEL_ENV が立っていない場合 (ローカル / self-host) は NODE_ENV のみで判断
   return nodeEnv !== "production";
 }
+
+/**
+ * ローカル開発時 (pnpm dev / vercel dev / next dev) の認証丸ごとバイパス。
+ * GitHub OAuth 移行 (issue #71) 完了までの暫定処置として、
+ * `NODE_ENV === "development"` かつ `VERCEL_ENV` が preview/production でない時のみ有効化する。
+ * Passkey 有効・無効と独立に働く点で `isDevShortcutAvailable` と異なる。
+ *
+ * preview / production では絶対に有効化してはいけない (認証バイパスになる)。
+ */
+export function isLocalAuthBypassEnabled(): boolean {
+  const vercelEnv = process.env.VERCEL_ENV;
+  if (vercelEnv === "production" || vercelEnv === "preview") return false;
+  return process.env.NODE_ENV === "development";
+}

--- a/src/server/auth/constants.ts
+++ b/src/server/auth/constants.ts
@@ -3,6 +3,12 @@
 export const SESSION_COOKIE_NAME = "__Host-tanren_session";
 /** dev ショートカット用の cookie。passkey 無効 Preview などで使用 */
 export const DEV_SESSION_COOKIE_NAME = "tanren_dev_session";
+/**
+ * ローカル bypass (issue #71 着地までの暫定) を user が明示的に無効化したことを示す cookie。
+ * `/api/auth/logout` で set し、`resolveSession()` 側で検出したら bypass を skip する。
+ * preview / production では `isLocalAuthBypassEnabled` が常に false なので意味を持たない。
+ */
+export const LOCAL_BYPASS_OFF_COOKIE_NAME = "tanren_local_bypass_off";
 
 /** 30 日 sliding expiry */
 export const SESSION_MAX_AGE_MS = 30 * 24 * 60 * 60 * 1000;

--- a/src/server/auth/dev-login.ts
+++ b/src/server/auth/dev-login.ts
@@ -36,15 +36,10 @@ export async function findUserByEmail(email: string) {
  * `onConflictDoNothing` + 再読込で吸収する (losing race 側は再 select で勝者の行を拾う)。
  */
 export async function ensureLocalDevUser(): Promise<User> {
-  const db = getDb();
+  const existing = await findUserByEmail(LOCAL_DEV_USER_EMAIL);
+  if (existing) return existing;
 
-  const fetchExisting = () =>
-    db.select().from(users).where(eq(users.email, LOCAL_DEV_USER_EMAIL)).limit(1);
-
-  const existing = await fetchExisting();
-  if (existing[0]) return existing[0];
-
-  const inserted = await db
+  const inserted = await getDb()
     .insert(users)
     .values({
       email: LOCAL_DEV_USER_EMAIL,
@@ -58,9 +53,9 @@ export async function ensureLocalDevUser(): Promise<User> {
   if (inserted[0]) return inserted[0];
 
   // 並列 insert で負けた側は row が返らないので勝者の行を再読込する。
-  const refetched = await fetchExisting();
-  if (!refetched[0]) {
+  const refetched = await findUserByEmail(LOCAL_DEV_USER_EMAIL);
+  if (!refetched) {
     throw new Error("failed to ensure local dev user: race lost and row still missing");
   }
-  return refetched[0];
+  return refetched;
 }

--- a/src/server/auth/dev-login.ts
+++ b/src/server/auth/dev-login.ts
@@ -31,17 +31,20 @@ export async function findUserByEmail(email: string) {
  * ローカル bypass 用の dev user を idempotent に確保する。
  * onboarding 完了済みで作成して /onboarding への強制リダイレクトを回避。
  * 興味分野は Tier 1 全ドメイン、self_level は "mid"。
+ *
+ * users.email は unique 制約付きなので、初回並列リクエストでの race は
+ * `onConflictDoNothing` + 再読込で吸収する (losing race 側は再 select で勝者の行を拾う)。
  */
 export async function ensureLocalDevUser(): Promise<User> {
   const db = getDb();
-  const existing = await db
-    .select()
-    .from(users)
-    .where(eq(users.email, LOCAL_DEV_USER_EMAIL))
-    .limit(1);
+
+  const fetchExisting = () =>
+    db.select().from(users).where(eq(users.email, LOCAL_DEV_USER_EMAIL)).limit(1);
+
+  const existing = await fetchExisting();
   if (existing[0]) return existing[0];
 
-  const [inserted] = await db
+  const inserted = await db
     .insert(users)
     .values({
       email: LOCAL_DEV_USER_EMAIL,
@@ -50,9 +53,14 @@ export async function ensureLocalDevUser(): Promise<User> {
       interestDomains: [...TIER_1_DOMAIN_IDS],
       selfLevel: "mid",
     })
+    .onConflictDoNothing({ target: users.email })
     .returning();
-  if (!inserted) {
-    throw new Error("failed to create local dev user");
+  if (inserted[0]) return inserted[0];
+
+  // 並列 insert で負けた側は row が返らないので勝者の行を再読込する。
+  const refetched = await fetchExisting();
+  if (!refetched[0]) {
+    throw new Error("failed to ensure local dev user: race lost and row still missing");
   }
-  return inserted;
+  return refetched[0];
 }

--- a/src/server/auth/dev-login.ts
+++ b/src/server/auth/dev-login.ts
@@ -1,9 +1,13 @@
 import { eq } from "drizzle-orm";
 
 import { getDb } from "@/db/client";
-import { users } from "@/db/schema";
+import { TIER_1_DOMAIN_IDS } from "@/db/schema/_constants";
+import { users, type User } from "@/db/schema";
 
 import { isPasskeyEnabled } from "./webauthn";
+
+/** ローカル bypass 用の固定 user (isLocalAuthBypassEnabled=true 時のみ発行) */
+export const LOCAL_DEV_USER_EMAIL = "dev@local.tanren";
 
 /**
  * Passkey を使えない環境 (Preview で RP_ID 未設定など) で「作者 1 名」の個人プロダクトとして動かすための fallback。
@@ -21,4 +25,34 @@ export async function tryDevAutoLoginUser() {
 export async function findUserByEmail(email: string) {
   const rows = await getDb().select().from(users).where(eq(users.email, email)).limit(1);
   return rows[0] ?? null;
+}
+
+/**
+ * ローカル bypass 用の dev user を idempotent に確保する。
+ * onboarding 完了済みで作成して /onboarding への強制リダイレクトを回避。
+ * 興味分野は Tier 1 全ドメイン、self_level は "mid"。
+ */
+export async function ensureLocalDevUser(): Promise<User> {
+  const db = getDb();
+  const existing = await db
+    .select()
+    .from(users)
+    .where(eq(users.email, LOCAL_DEV_USER_EMAIL))
+    .limit(1);
+  if (existing[0]) return existing[0];
+
+  const [inserted] = await db
+    .insert(users)
+    .values({
+      email: LOCAL_DEV_USER_EMAIL,
+      displayName: "Local Dev",
+      onboardingCompletedAt: new Date(),
+      interestDomains: [...TIER_1_DOMAIN_IDS],
+      selfLevel: "mid",
+    })
+    .returning();
+  if (!inserted) {
+    throw new Error("failed to create local dev user");
+  }
+  return inserted;
 }

--- a/src/server/auth/session.test.ts
+++ b/src/server/auth/session.test.ts
@@ -22,7 +22,12 @@ vi.mock("@/db/client", () => ({
   getDb: () => builders,
 }));
 
-import { DEV_SESSION_COOKIE_NAME, SESSION_COOKIE_NAME, SESSION_MAX_AGE_MS } from "./constants";
+import {
+  DEV_SESSION_COOKIE_NAME,
+  LOCAL_BYPASS_OFF_COOKIE_NAME,
+  SESSION_COOKIE_NAME,
+  SESSION_MAX_AGE_MS,
+} from "./constants";
 import { resolveSession } from "./session";
 
 function mockCookieStore(values: Record<string, string>) {
@@ -116,5 +121,15 @@ describe("resolveSession", () => {
     );
     expect(result).toBeNull();
     expect(builders.select).not.toHaveBeenCalled();
+  });
+
+  it("ローカル bypass 有効でも LOCAL_BYPASS_OFF cookie があれば null (ログアウト維持)", async () => {
+    vi.stubEnv("VERCEL_ENV", "");
+    vi.stubEnv("NODE_ENV", "development");
+    const result = await resolveSession(mockCookieStore({ [LOCAL_BYPASS_OFF_COOKIE_NAME]: "1" }));
+    // bypass を skip して通常フローに落ちる。cookie が無いので null。
+    expect(result).toBeNull();
+    expect(builders.select).not.toHaveBeenCalled();
+    expect(builders.insert).not.toHaveBeenCalled();
   });
 });

--- a/src/server/auth/session.test.ts
+++ b/src/server/auth/session.test.ts
@@ -127,9 +127,36 @@ describe("resolveSession", () => {
     vi.stubEnv("VERCEL_ENV", "");
     vi.stubEnv("NODE_ENV", "development");
     const result = await resolveSession(mockCookieStore({ [LOCAL_BYPASS_OFF_COOKIE_NAME]: "1" }));
-    // bypass を skip して通常フローに落ちる。cookie が無いので null。
+    // bypass を skip、実 cookie も無いので null。DB には触れない。
     expect(result).toBeNull();
     expect(builders.select).not.toHaveBeenCalled();
+    expect(builders.insert).not.toHaveBeenCalled();
+  });
+
+  it("ローカル bypass 有効 + 実 passkey cookie あり → 実 session を優先 (bypass 巻き込みなし)", async () => {
+    vi.stubEnv("VERCEL_ENV", "");
+    vi.stubEnv("NODE_ENV", "development");
+    const fakeUser = { id: "u1", email: "x@example.com" };
+    builders.select.mockReturnValue(
+      fluentSelect([{ session: { id: "s1", userId: "u1" }, user: fakeUser }]),
+    );
+    const capture: { set?: { expiresAt?: Date; lastActiveAt?: Date } } = {};
+    builders.update.mockReturnValue(fluentUpdateCapture(capture));
+
+    const result = await resolveSession(mockCookieStore({ [SESSION_COOKIE_NAME]: "s1" }));
+    // bypass ではなく passkey として返る。insert (ensureLocalDevUser) は呼ばれない。
+    expect(result?.user).toEqual(fakeUser);
+    expect(result?.kind).toBe("passkey");
+    expect(builders.insert).not.toHaveBeenCalled();
+  });
+
+  it("ローカル bypass 有効 + 実 passkey cookie あるが session 無し → null (bypass 救済しない)", async () => {
+    vi.stubEnv("VERCEL_ENV", "");
+    vi.stubEnv("NODE_ENV", "development");
+    builders.select.mockReturnValue(fluentSelect([]));
+    const result = await resolveSession(mockCookieStore({ [SESSION_COOKIE_NAME]: "expired" }));
+    // cookie が invalid なときは再ログインを促す (誤爆 bypass で足元を見失わないため)。
+    expect(result).toBeNull();
     expect(builders.insert).not.toHaveBeenCalled();
   });
 });

--- a/src/server/auth/session.ts
+++ b/src/server/auth/session.ts
@@ -8,8 +8,9 @@ import { cookies } from "next/headers";
 import { getDb } from "@/db/client";
 import { sessionsAuth, users, type User } from "@/db/schema";
 
-import { isDevShortcutAvailable } from "./capabilities";
+import { isDevShortcutAvailable, isLocalAuthBypassEnabled } from "./capabilities";
 import { DEV_SESSION_COOKIE_NAME, SESSION_COOKIE_NAME, SESSION_MAX_AGE_MS } from "./constants";
+import { ensureLocalDevUser } from "./dev-login";
 
 export type CookieStore = ReadonlyRequestCookies | Awaited<ReturnType<typeof cookies>>;
 
@@ -56,6 +57,18 @@ export async function createSession(userId: string): Promise<{
  * 呼び出し元は返却された `expiresAt` を使って cookie を再発行すること。
  */
 export async function resolveSession(store: CookieStore): Promise<SessionResolution | null> {
+  // issue #71 着地までの暫定: ローカル dev では cookie を見ずに固定 dev user を返す。
+  // preview / production では isLocalAuthBypassEnabled が必ず false になり通常フローへ落ちる。
+  if (isLocalAuthBypassEnabled()) {
+    const user = await ensureLocalDevUser();
+    return {
+      user,
+      sessionId: "local-dev-bypass",
+      expiresAt: new Date(Date.now() + SESSION_MAX_AGE_MS),
+      kind: "dev",
+    };
+  }
+
   const passkeyId = store.get(SESSION_COOKIE_NAME)?.value ?? null;
   // dev cookie は「dev ショートカットが許可された環境」でのみ受理する。
   // pre-production で発行された cookie を self-host 本番に持ち込まれるバイパス対策。

--- a/src/server/auth/session.ts
+++ b/src/server/auth/session.ts
@@ -66,14 +66,48 @@ export async function createSession(userId: string): Promise<{
  * 呼び出し元は返却された `expiresAt` を使って cookie を再発行すること。
  */
 export async function resolveSession(store: CookieStore): Promise<SessionResolution | null> {
-  // issue #71 着地までの暫定: ローカル dev では cookie を見ずに固定 dev user を返す。
-  // preview / production では isLocalAuthBypassEnabled が必ず false になり通常フローへ落ちる。
-  if (isLocalAuthBypassEnabled()) {
-    // `/api/auth/logout` が立てた opt-out cookie がある間は bypass を skip し、
-    // 「ログアウト直後は未認証状態でいられる」体験を保つ。cookie を削除すれば bypass が戻る。
-    if (store.get(LOCAL_BYPASS_OFF_COOKIE_NAME)?.value) {
-      return null;
-    }
+  // 1. 実 session cookie を最優先で解決する。これで logout → 再ログインや sessions_auth の
+  //    後片付けが bypass に巻き込まれずに動く (Codex review Round 2 指摘)。
+  const passkeyId = store.get(SESSION_COOKIE_NAME)?.value ?? null;
+  // dev cookie は「dev ショートカットが許可された環境」でのみ受理する。
+  // pre-production で発行された cookie を self-host 本番に持ち込まれるバイパス対策。
+  const devId = isDevShortcutAvailable()
+    ? (store.get(DEV_SESSION_COOKIE_NAME)?.value ?? null)
+    : null;
+  const sessionId = passkeyId ?? devId;
+
+  if (sessionId) {
+    const kind: "passkey" | "dev" = passkeyId ? "passkey" : "dev";
+
+    const db = getDb();
+    const rows = await db
+      .select({ session: sessionsAuth, user: users })
+      .from(sessionsAuth)
+      .innerJoin(users, eq(users.id, sessionsAuth.userId))
+      .where(and(eq(sessionsAuth.id, sessionId), gt(sessionsAuth.expiresAt, new Date())))
+      .limit(1);
+
+    const row = rows[0];
+    // cookie はあるが session 行が見つからない / 期限切れの場合は null。bypass で救済しない
+    // (再ログインを促す。誤爆での自動 bypass で足元を見失わないため)。
+    if (!row) return null;
+
+    // 30 日 sliding: アクセス毎に expiresAt を押し出し、cookie も後続で同期延長する
+    const now = new Date();
+    const newExpiresAt = new Date(now.getTime() + SESSION_MAX_AGE_MS);
+    await db
+      .update(sessionsAuth)
+      .set({ lastActiveAt: now, expiresAt: newExpiresAt })
+      .where(eq(sessionsAuth.id, sessionId));
+
+    return { user: row.user, sessionId, expiresAt: newExpiresAt, kind };
+  }
+
+  // 2. 実 cookie が無いときだけローカル bypass を検討する (issue #71 着地までの暫定)。
+  //    preview / production では isLocalAuthBypassEnabled が必ず false になり到達しない。
+  //    `/api/auth/logout` が立てた opt-out cookie がある間は bypass を skip し、
+  //    「ログアウト直後は未認証状態でいられる」体験を保つ。
+  if (isLocalAuthBypassEnabled() && !store.get(LOCAL_BYPASS_OFF_COOKIE_NAME)?.value) {
     const user = await ensureLocalDevUser();
     return {
       user,
@@ -83,36 +117,7 @@ export async function resolveSession(store: CookieStore): Promise<SessionResolut
     };
   }
 
-  const passkeyId = store.get(SESSION_COOKIE_NAME)?.value ?? null;
-  // dev cookie は「dev ショートカットが許可された環境」でのみ受理する。
-  // pre-production で発行された cookie を self-host 本番に持ち込まれるバイパス対策。
-  const devId = isDevShortcutAvailable()
-    ? (store.get(DEV_SESSION_COOKIE_NAME)?.value ?? null)
-    : null;
-  const sessionId = passkeyId ?? devId;
-  if (!sessionId) return null;
-  const kind: "passkey" | "dev" = passkeyId ? "passkey" : "dev";
-
-  const db = getDb();
-  const rows = await db
-    .select({ session: sessionsAuth, user: users })
-    .from(sessionsAuth)
-    .innerJoin(users, eq(users.id, sessionsAuth.userId))
-    .where(and(eq(sessionsAuth.id, sessionId), gt(sessionsAuth.expiresAt, new Date())))
-    .limit(1);
-
-  const row = rows[0];
-  if (!row) return null;
-
-  // 30 日 sliding: アクセス毎に expiresAt を押し出し、cookie も後続で同期延長する
-  const now = new Date();
-  const newExpiresAt = new Date(now.getTime() + SESSION_MAX_AGE_MS);
-  await db
-    .update(sessionsAuth)
-    .set({ lastActiveAt: now, expiresAt: newExpiresAt })
-    .where(eq(sessionsAuth.id, sessionId));
-
-  return { user: row.user, sessionId, expiresAt: newExpiresAt, kind };
+  return null;
 }
 
 /** cookie の破棄とテーブル削除 */

--- a/src/server/auth/session.ts
+++ b/src/server/auth/session.ts
@@ -9,7 +9,12 @@ import { getDb } from "@/db/client";
 import { sessionsAuth, users, type User } from "@/db/schema";
 
 import { isDevShortcutAvailable, isLocalAuthBypassEnabled } from "./capabilities";
-import { DEV_SESSION_COOKIE_NAME, SESSION_COOKIE_NAME, SESSION_MAX_AGE_MS } from "./constants";
+import {
+  DEV_SESSION_COOKIE_NAME,
+  LOCAL_BYPASS_OFF_COOKIE_NAME,
+  SESSION_COOKIE_NAME,
+  SESSION_MAX_AGE_MS,
+} from "./constants";
 import { ensureLocalDevUser } from "./dev-login";
 
 export type CookieStore = ReadonlyRequestCookies | Awaited<ReturnType<typeof cookies>>;
@@ -19,8 +24,12 @@ type SessionResolution = {
   sessionId: string;
   /** resolve 時に延長された expiresAt。cookie の再発行に使う */
   expiresAt: Date;
-  /** dev (non __Host-) セッションか、Passkey (__Host-) セッションか */
-  kind: "passkey" | "dev";
+  /**
+   * - `passkey`: __Host- cookie 経由の Passkey セッション
+   * - `dev`: dev ショートカット由来の non-__Host- cookie セッション
+   * - `bypass`: ローカル bypass (issue #71 着地までの暫定、cookie なし)
+   */
+  kind: "passkey" | "dev" | "bypass";
 };
 
 /** `sessions_auth` に新しい行を作り、cookie attribute を返す */
@@ -60,12 +69,17 @@ export async function resolveSession(store: CookieStore): Promise<SessionResolut
   // issue #71 着地までの暫定: ローカル dev では cookie を見ずに固定 dev user を返す。
   // preview / production では isLocalAuthBypassEnabled が必ず false になり通常フローへ落ちる。
   if (isLocalAuthBypassEnabled()) {
+    // `/api/auth/logout` が立てた opt-out cookie がある間は bypass を skip し、
+    // 「ログアウト直後は未認証状態でいられる」体験を保つ。cookie を削除すれば bypass が戻る。
+    if (store.get(LOCAL_BYPASS_OFF_COOKIE_NAME)?.value) {
+      return null;
+    }
     const user = await ensureLocalDevUser();
     return {
       user,
       sessionId: "local-dev-bypass",
       expiresAt: new Date(Date.now() + SESSION_MAX_AGE_MS),
-      kind: "dev",
+      kind: "bypass",
     };
   }
 
@@ -115,6 +129,8 @@ export function refreshSessionCookie(
   store: CookieStore,
   resolution: Pick<SessionResolution, "sessionId" | "expiresAt" | "kind">,
 ): void {
+  // bypass 由来は cookie を持たない (DB にも sessions_auth 行が無い)。書き込まない。
+  if (resolution.kind === "bypass") return;
   try {
     if (resolution.kind === "passkey") {
       store.set({

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": "nextjs",
+  "devCommand": "next dev --port $PORT"
+}


### PR DESCRIPTION
## Summary

- issue #71 (Passkey → GitHub OAuth 移行) の着地までの**暫定**として、ローカル dev でのみ認証を飛ばして固定 user `dev@local.tanren` でログイン済み扱いにする
- 加えて、Vercel CLI 51.x で `vercel dev` が自己再帰検知で即落ちする問題を thin shell wrapper + `vercel.json` で回避
- `preview` / `production` / self-host `next start` ではバイパス無効。従来の Passkey フローが走る (= セキュリティは保たれる)

## Motivation

Passkey 初回登録の UI がリポジトリ内に存在せず、`/api/auth/register/*` はログイン済みを要求 ( `src/app/api/auth/register/options/route.ts:11-14` )、dev ショートカットは `isPasskeyEnabled()===true` の環境で常に false のため、作者自身が自分の dev 環境に入れない状態だった。issue #71 で GitHub OAuth に差し替える方針だが、それが終わるまで毎日触れないので先にバイパスを入れる。

## Changes

### 認証バイパス
- \`src/server/auth/capabilities.ts\`: \`isLocalAuthBypassEnabled()\` 追加
  - true になる条件: \`NODE_ENV === "development"\` かつ \`VERCEL_ENV\` が \`preview\` / \`production\` のどちらでもない
  - それ以外 (Vercel Preview / Production, self-host \`next start\` 含む) は必ず false
- \`src/server/auth/dev-login.ts\`: \`LOCAL_DEV_USER_EMAIL\` 定数と \`ensureLocalDevUser()\` を追加
  - \`dev@local.tanren\` を idempotent に upsert
  - 作成時は onboarding 完了済み扱い (onboardingCompletedAt=now, interestDomains=Tier1 全ドメイン, selfLevel="mid") で \`/onboarding\` への強制リダイレクトを回避
- \`src/server/auth/session.ts\`: \`resolveSession()\` の先頭に bypass 有効時の短絡を追加 (cookie を読まず dev user を返す)

### vercel dev 再帰回避
- \`vercel.json\` 新規 (\`framework: nextjs\`, \`devCommand: "next dev --port \$PORT"\`)
- \`scripts/dev.sh\` 新規 — \`vercel dev\` を thin wrapper 経由で起動し、CLI の \`npm_lifecycle_script\` ベース再帰検知を通過させる
- \`package.json\` の \`"dev": "vercel dev"\` → \`"./scripts/dev.sh"\`

## 安全性

- \`isLocalAuthBypassEnabled\` は Vercel \`preview\` / \`production\` で必ず false (単体判定 + 明示 return)
- self-host (\`next start\`, NODE_ENV=production) でも false
- バイパス中は固定 user が返るだけで cookie を書かない → Preview/Prod で誤って cookie が持ち込まれる経路がない
- コメントに \`issue #71 着地までの暫定\` と明記、supersede 時に削除する前提

## Test plan

- [x] \`pnpm typecheck\` 通過
- [x] \`pnpm lint\` 通過
- [x] \`pnpm vitest run src/server/auth/\` 通過 (既存 11 tests green)
- [x] \`pnpm dev\` で http://localhost:3000 に HTTP 200
- [x] \`/\` に "ようこそ、Local Dev" が表示され、\`auth.me\` tRPC が \`authenticated: true\` を返す
- [x] cookie 無しで \`/drill\`, \`/insights\` も 200
- [ ] Preview デプロイで \`authenticated: false\` になることを確認 (Passkey 無効 env なら dev ショートカット経路、有効 env なら未ログイン)

## Related

- issue #71 (Passkey → GitHub OAuth への移行): このバイパスは同 issue の着地時に削除する