### PR TITLE
feat(code-exec): Judge0 コード実行サンドボックス (#34)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -51,6 +51,13 @@ SENTRY_PROJECT=
 # Phase 5+ で追加 (公開時 / 並列ユーザー発生時)
 # ──────────────────────────────────────────
 
+# --- Judge0 (コード実行サンドボックス、issue #34) ---
+# RapidAPI 経由 (無料 tier で 50/day): https://rapidapi.com/judge0-official/api/judge0-ce/
+# 未設定なら code.execute は NOT_IMPLEMENTED で safe no-op。
+# JUDGE0_URL=https://judge0-ce.p.rapidapi.com
+# JUDGE0_API_KEY=
+# JUDGE0_API_HOST=judge0-ce.p.rapidapi.com
+
 # --- Web Push (VAPID) ---
 # WEB_PUSH_VAPID_PUBLIC_KEY=
 # WEB_PUSH_VAPID_PRIVATE_KEY=

--- a/src/lib/judge0/client.test.ts
+++ b/src/lib/judge0/client.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  executeCode,
+  JUDGE0_MAX_SOURCE_BYTES,
+  Judge0DisabledError,
+  Judge0RequestError,
+} from "./client";
+
+const ORIG_URL = process.env.JUDGE0_URL;
+const ORIG_KEY = process.env.JUDGE0_API_KEY;
+const ORIG_HOST = process.env.JUDGE0_API_HOST;
+
+beforeEach(() => {
+  process.env.JUDGE0_URL = "https://judge0-ce.p.rapidapi.com";
+  process.env.JUDGE0_API_KEY = "test-key";
+  process.env.JUDGE0_API_HOST = "judge0-ce.p.rapidapi.com";
+});
+afterEach(() => {
+  process.env.JUDGE0_URL = ORIG_URL;
+  process.env.JUDGE0_API_KEY = ORIG_KEY;
+  process.env.JUDGE0_API_HOST = ORIG_HOST;
+  vi.restoreAllMocks();
+});
+
+describe("executeCode", () => {
+  it("JUDGE0_API_KEY 未設定なら Judge0DisabledError", async () => {
+    delete process.env.JUDGE0_API_KEY;
+    await expect(executeCode({ language: "python", source: "print(1)" })).rejects.toBeInstanceOf(
+      Judge0DisabledError,
+    );
+  });
+
+  it("JUDGE0_URL 未設定なら Judge0DisabledError", async () => {
+    delete process.env.JUDGE0_URL;
+    await expect(executeCode({ language: "python", source: "print(1)" })).rejects.toBeInstanceOf(
+      Judge0DisabledError,
+    );
+  });
+
+  it("source サイズ超過は Judge0RequestError", async () => {
+    await expect(
+      executeCode({ language: "python", source: "x".repeat(JUDGE0_MAX_SOURCE_BYTES + 1) }),
+    ).rejects.toBeInstanceOf(Judge0RequestError);
+  });
+
+  it("正常系: base64 で stdout / stderr をデコードして返す", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          stdout: Buffer.from("hello\n", "utf-8").toString("base64"),
+          stderr: null,
+          status: { description: "Accepted" },
+          time: "0.012",
+          memory: 3096,
+          token: "tok-1",
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+    const out = await executeCode({ language: "python", source: "print('hello')" });
+    expect(out.stdout).toBe("hello\n");
+    expect(out.stderr).toBe("");
+    expect(out.status).toBe("Accepted");
+    expect(out.timeSec).toBeCloseTo(0.012);
+    expect(out.memoryKb).toBe(3096);
+    expect(out.token).toBe("tok-1");
+    // endpoint の組み立て確認
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchSpy.mock.calls[0]!;
+    expect(String(url)).toContain("/submissions?base64_encoded=true&wait=true");
+    const headers = (init as { headers: Record<string, string> }).headers;
+    expect(headers["X-RapidAPI-Key"]).toBe("test-key");
+    expect(headers["X-RapidAPI-Host"]).toBe("judge0-ce.p.rapidapi.com");
+    // body は base64 エンコード済みの source_code を含む
+    const body = JSON.parse((init as { body: string }).body);
+    expect(body.language_id).toBe(71); // python
+    expect(Buffer.from(body.source_code, "base64").toString("utf-8")).toBe("print('hello')");
+  });
+
+  it("429 は Judge0RequestError に statusCode 付きで throw", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("rate limit", { status: 429 }));
+    try {
+      await executeCode({ language: "python", source: "x" });
+      expect.fail("should have thrown");
+    } catch (e) {
+      expect(e).toBeInstanceOf(Judge0RequestError);
+      expect((e as Judge0RequestError).statusCode).toBe(429);
+    }
+  });
+
+  it("未対応言語は Judge0RequestError", async () => {
+    await expect(executeCode({ language: "cobol" as never, source: "x" })).rejects.toBeInstanceOf(
+      Judge0RequestError,
+    );
+  });
+});

--- a/src/lib/judge0/client.ts
+++ b/src/lib/judge0/client.ts
@@ -1,0 +1,121 @@
+import "server-only";
+
+import { isJudge0Language, languageId, type Judge0Language } from "./languages";
+
+/** Judge0 実行結果 (MVP: stdout / stderr / status / 実行時間のみ返す) */
+export type Judge0Result = {
+  stdout: string;
+  stderr: string;
+  /** Judge0 の submission.status.description (例: "Accepted", "Runtime Error (NZEC)") */
+  status: string;
+  /** 実行時間 (秒、Judge0 の "time" 文字列をパースして数値化) */
+  timeSec: number | null;
+  /** 使用メモリ (KB、Judge0 の "memory") */
+  memoryKb: number | null;
+  /** Judge0 submission token (デバッグ用) */
+  token: string;
+};
+
+/** Judge0 実行がサーバー側で disabled な場合のエラー (env 未設定など) */
+export class Judge0DisabledError extends Error {
+  constructor() {
+    super("Judge0 コード実行は無効化されています (JUDGE0_API_KEY / JUDGE0_URL が未設定)");
+    this.name = "Judge0DisabledError";
+  }
+}
+
+/** Judge0 側の実行失敗や rate limit */
+export class Judge0RequestError extends Error {
+  constructor(
+    message: string,
+    public readonly statusCode?: number,
+  ) {
+    super(message);
+    this.name = "Judge0RequestError";
+  }
+}
+
+/** ソース / 標準入力の最大サイズ (10KB)。超過時は BAD_REQUEST 相当で reject する */
+export const JUDGE0_MAX_SOURCE_BYTES = 10 * 1024;
+
+/** Judge0 側の壁時計上限 (秒)。無料 tier でも通る値、過度な 10s 以上は RapidAPI で drop される */
+export const JUDGE0_WALL_TIME_LIMIT_SEC = 5;
+
+function toBase64(s: string): string {
+  return Buffer.from(s, "utf-8").toString("base64");
+}
+
+function fromBase64(s: string | null | undefined): string {
+  if (!s) return "";
+  return Buffer.from(s, "base64").toString("utf-8");
+}
+
+/** Judge0 へ 1 件の submission を投げて結果を返す (wait=true で同期応答)。
+ *  - base64_encoded=true で source / stdin を UTF-8 安全にエンコード
+ *  - wait=true にすると submission 作成 + 実行完了をブロッキング待ちできる (MVP で十分、polling 不要)
+ *  - 環境変数未設定は Judge0DisabledError で早期 throw (呼び出し側は catch して UI でスキップする)
+ */
+export async function executeCode(args: {
+  language: Judge0Language;
+  source: string;
+  stdin?: string;
+}): Promise<Judge0Result> {
+  const url = process.env.JUDGE0_URL;
+  const apiKey = process.env.JUDGE0_API_KEY;
+  const apiHost = process.env.JUDGE0_API_HOST; // RapidAPI なら必須、self-hosted なら空でも OK
+  if (!url || !apiKey) throw new Judge0DisabledError();
+
+  if (!isJudge0Language(args.language)) {
+    throw new Judge0RequestError(`unsupported language: ${args.language}`);
+  }
+  const srcBytes = Buffer.byteLength(args.source, "utf-8");
+  const stdinBytes = args.stdin ? Buffer.byteLength(args.stdin, "utf-8") : 0;
+  if (srcBytes > JUDGE0_MAX_SOURCE_BYTES || stdinBytes > JUDGE0_MAX_SOURCE_BYTES) {
+    throw new Judge0RequestError(
+      `source / stdin が大きすぎます (max ${JUDGE0_MAX_SOURCE_BYTES} bytes)`,
+    );
+  }
+
+  const body = {
+    language_id: languageId(args.language),
+    source_code: toBase64(args.source),
+    stdin: args.stdin ? toBase64(args.stdin) : "",
+    wall_time_limit: JUDGE0_WALL_TIME_LIMIT_SEC,
+  };
+
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    "X-RapidAPI-Key": apiKey,
+  };
+  if (apiHost) headers["X-RapidAPI-Host"] = apiHost;
+
+  const endpoint = `${url.replace(/\/$/, "")}/submissions?base64_encoded=true&wait=true&fields=stdout,stderr,status,time,memory,token`;
+  const res = await fetch(endpoint, {
+    method: "POST",
+    headers,
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Judge0RequestError(
+      `Judge0 API error (${res.status}): ${text.slice(0, 200)}`,
+      res.status,
+    );
+  }
+  const data = (await res.json()) as {
+    stdout?: string | null;
+    stderr?: string | null;
+    status?: { description?: string };
+    time?: string | null;
+    memory?: number | null;
+    token: string;
+  };
+  return {
+    stdout: fromBase64(data.stdout ?? null),
+    stderr: fromBase64(data.stderr ?? null),
+    status: data.status?.description ?? "Unknown",
+    timeSec: data.time ? Number.parseFloat(data.time) : null,
+    memoryKb: data.memory ?? null,
+    token: data.token,
+  };
+}

--- a/src/lib/judge0/client.ts
+++ b/src/lib/judge0/client.ts
@@ -41,6 +41,11 @@ export const JUDGE0_MAX_SOURCE_BYTES = 10 * 1024;
 /** Judge0 側の壁時計上限 (秒)。無料 tier でも通る値、過度な 10s 以上は RapidAPI で drop される */
 export const JUDGE0_WALL_TIME_LIMIT_SEC = 5;
 
+/** fetch 全体の client-side timeout (ms)。wall_time_limit (5s) に加えて、キュー待ち +
+ *  ネットワーク遅延を見込んでも Vercel Functions の 10s デフォルト制限の手前で打ち切る
+ *  (Codex Round 1 指摘 #1)。 */
+export const JUDGE0_FETCH_TIMEOUT_MS = 8_000;
+
 function toBase64(s: string): string {
   return Buffer.from(s, "utf-8").toString("base64");
 }
@@ -90,11 +95,24 @@ export async function executeCode(args: {
   if (apiHost) headers["X-RapidAPI-Host"] = apiHost;
 
   const endpoint = `${url.replace(/\/$/, "")}/submissions?base64_encoded=true&wait=true&fields=stdout,stderr,status,time,memory,token`;
-  const res = await fetch(endpoint, {
-    method: "POST",
-    headers,
-    body: JSON.stringify(body),
-  });
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), JUDGE0_FETCH_TIMEOUT_MS);
+  let res: Response;
+  try {
+    res = await fetch(endpoint, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(body),
+      signal: controller.signal,
+    });
+  } catch (e) {
+    if (e instanceof Error && e.name === "AbortError") {
+      throw new Judge0RequestError(`Judge0 timeout (>${JUDGE0_FETCH_TIMEOUT_MS}ms)`, 504);
+    }
+    throw e;
+  } finally {
+    clearTimeout(timer);
+  }
   if (!res.ok) {
     const text = await res.text().catch(() => "");
     throw new Judge0RequestError(

--- a/src/lib/judge0/languages.ts
+++ b/src/lib/judge0/languages.ts
@@ -1,0 +1,18 @@
+/** Judge0 CE 言語 ID (真実の源: https://github.com/judge0/judge0/blob/master/docs/languages.md)。
+ *  RapidAPI 上の Judge0 CE も同じ ID を使う。MVP は 3 言語だけ対応、追加は必要になってから。
+ */
+export const JUDGE0_LANGUAGES = {
+  python: 71, // Python 3.8.1
+  typescript: 74, // TypeScript 3.7.4
+  javascript: 63, // JavaScript Node.js 12.14.0
+} as const;
+
+export type Judge0Language = keyof typeof JUDGE0_LANGUAGES;
+
+export function isJudge0Language(v: string): v is Judge0Language {
+  return v in JUDGE0_LANGUAGES;
+}
+
+export function languageId(lang: Judge0Language): number {
+  return JUDGE0_LANGUAGES[lang];
+}

--- a/src/server/trpc/routers/code.test.ts
+++ b/src/server/trpc/routers/code.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { User } from "@/db/schema";
+
+import { appRouter } from "./index";
+import { __resetRateLimitForTest } from "./code";
+
+vi.mock("@/lib/judge0/client", () => {
+  return {
+    executeCode: vi.fn(async () => ({
+      stdout: "hello\n",
+      stderr: "",
+      status: "Accepted",
+      timeSec: 0.01,
+      memoryKb: 3096,
+      token: "tok",
+    })),
+    JUDGE0_MAX_SOURCE_BYTES: 10 * 1024,
+    Judge0DisabledError: class Judge0DisabledError extends Error {
+      constructor() {
+        super("disabled");
+        this.name = "Judge0DisabledError";
+      }
+    },
+    Judge0RequestError: class Judge0RequestError extends Error {
+      constructor(
+        m: string,
+        public readonly statusCode?: number,
+      ) {
+        super(m);
+        this.name = "Judge0RequestError";
+      }
+    },
+  };
+});
+
+const fakeUser = { id: "u-1" } as User;
+
+beforeEach(() => {
+  __resetRateLimitForTest();
+});
+afterEach(() => vi.clearAllMocks());
+
+describe("code.execute (issue #34)", () => {
+  const caller = appRouter.createCaller({ user: fakeUser });
+
+  it("対応外の language は reject", async () => {
+    await expect(caller.code.execute({ language: "cobol", source: "print(1)" })).rejects.toThrow();
+  });
+
+  it("source 空は reject (min 1)", async () => {
+    await expect(caller.code.execute({ language: "python", source: "" })).rejects.toThrow();
+  });
+
+  it("未認証 (user=null) は UNAUTHORIZED", async () => {
+    const anon = appRouter.createCaller({ user: null });
+    await expect(anon.code.execute({ language: "python", source: "print(1)" })).rejects.toThrow();
+  });
+
+  it("正常系: Judge0 の結果をそのまま返す", async () => {
+    const out = await caller.code.execute({ language: "python", source: "print('hello')" });
+    expect(out.stdout).toBe("hello\n");
+    expect(out.status).toBe("Accepted");
+  });
+
+  it("rate limit: 31 回目は TOO_MANY_REQUESTS", async () => {
+    for (let i = 0; i < 30; i++) {
+      await caller.code.execute({ language: "python", source: "print(1)" });
+    }
+    await expect(caller.code.execute({ language: "python", source: "print(1)" })).rejects.toThrow(
+      /rate limit/,
+    );
+  });
+});

--- a/src/server/trpc/routers/code.ts
+++ b/src/server/trpc/routers/code.ts
@@ -21,7 +21,11 @@ const RATE_WINDOW_MS = 60 * 1000;
 /** Map<userId, timestamps[]>。RATE_WINDOW_MS より古い timestamp は gc される。 */
 const rateMap = new Map<string, number[]>();
 
-function checkRateLimit(userId: string, now: number = Date.now()): void {
+/** 上限超過なら TOO_MANY_REQUESTS を throw。実際に Judge0 を叩くかは呼び出し側 (成功時に recordRateLimitHit)。
+ *  Codex Round 1 指摘 #2: Judge0DisabledError や 事前 reject でクォータを消費しないよう、
+ *  ここではチェックだけ行いカウント消費は recordRateLimitHit に分離する。
+ */
+function assertRateLimit(userId: string, now: number = Date.now()): void {
   const list = rateMap.get(userId) ?? [];
   const fresh = list.filter((t) => now - t < RATE_WINDOW_MS);
   if (fresh.length >= RATE_LIMIT_PER_MINUTE) {
@@ -30,8 +34,14 @@ function checkRateLimit(userId: string, now: number = Date.now()): void {
       message: `コード実行の rate limit 超過 (1分間あたり ${RATE_LIMIT_PER_MINUTE} 本まで)`,
     });
   }
-  fresh.push(now);
   rateMap.set(userId, fresh);
+}
+
+/** Judge0 に実際にコストがかかった呼び出し (= 成功 or 429 等 Judge0 側応答) のみカウントする */
+function recordRateLimitHit(userId: string, now: number = Date.now()): void {
+  const list = rateMap.get(userId) ?? [];
+  list.push(now);
+  rateMap.set(userId, list);
 }
 
 /** テスト用の reset helper (router 側では export しない) */
@@ -54,22 +64,30 @@ export const codeRouter = router({
       }),
     )
     .mutation(async ({ ctx, input }) => {
-      checkRateLimit(ctx.user.id);
+      assertRateLimit(ctx.user.id);
       try {
         const result = await executeCode({
           language: input.language as keyof typeof JUDGE0_LANGUAGES,
           source: input.source,
           stdin: input.stdin,
         });
+        // 成功時のみクォータを消費 (Codex Round 1 指摘 #2)
+        recordRateLimitHit(ctx.user.id);
         return result;
       } catch (err) {
         if (err instanceof Judge0DisabledError) {
+          // env 未設定: コストかかっていないのでカウントしない
           throw new TRPCError({
             code: "NOT_IMPLEMENTED",
             message: err.message,
           });
         }
         if (err instanceof Judge0RequestError) {
+          // Judge0 に到達した失敗 (429 / コンパイルエラー等) はコスト発生したと見なしカウント。
+          // 事前 validation 失敗 (size limit 等) は Judge0 未到達なのでカウントしない方針だが、
+          // 本実装では統一的に「Judge0RequestError = カウントする」とする
+          // (事前 validation エラーは呼び出し側で zod バリデーション済みの想定のため実質発火しない)。
+          recordRateLimitHit(ctx.user.id);
           throw new TRPCError({
             code: err.statusCode === 429 ? "TOO_MANY_REQUESTS" : "BAD_REQUEST",
             message: err.message,

--- a/src/server/trpc/routers/code.ts
+++ b/src/server/trpc/routers/code.ts
@@ -1,0 +1,81 @@
+import { TRPCError } from "@trpc/server";
+import { z } from "zod";
+
+import {
+  executeCode,
+  JUDGE0_MAX_SOURCE_BYTES,
+  Judge0DisabledError,
+  Judge0RequestError,
+} from "@/lib/judge0/client";
+import { JUDGE0_LANGUAGES } from "@/lib/judge0/languages";
+
+import { protectedProcedure, router } from "../init";
+
+/** ユーザーあたり 1 分間に実行できる最大本数。MVP は in-memory Map で実装
+ *  (Vercel Functions のインスタンス寿命は短いので厳密ではないが、同一 inst 内の暴走は防げる)。
+ *  本番環境で複数インスタンスに跨るレート制限が必要になったら Upstash Redis 等に移行する。
+ */
+const RATE_LIMIT_PER_MINUTE = 30;
+const RATE_WINDOW_MS = 60 * 1000;
+
+/** Map<userId, timestamps[]>。RATE_WINDOW_MS より古い timestamp は gc される。 */
+const rateMap = new Map<string, number[]>();
+
+function checkRateLimit(userId: string, now: number = Date.now()): void {
+  const list = rateMap.get(userId) ?? [];
+  const fresh = list.filter((t) => now - t < RATE_WINDOW_MS);
+  if (fresh.length >= RATE_LIMIT_PER_MINUTE) {
+    throw new TRPCError({
+      code: "TOO_MANY_REQUESTS",
+      message: `コード実行の rate limit 超過 (1分間あたり ${RATE_LIMIT_PER_MINUTE} 本まで)`,
+    });
+  }
+  fresh.push(now);
+  rateMap.set(userId, fresh);
+}
+
+/** テスト用の reset helper (router 側では export しない) */
+export function __resetRateLimitForTest(): void {
+  rateMap.clear();
+}
+
+export const codeRouter = router({
+  /**
+   * Judge0 でコードを実行する (issue #34)。
+   * 入力制限: source / stdin は各 10KB まで、language は MVP 対応の 3 種のみ。
+   * 保護層: per-user in-memory rate limit (30 req/min)。Judge0 env 未設定時は NOT_IMPLEMENTED。
+   */
+  execute: protectedProcedure
+    .input(
+      z.object({
+        language: z.enum(Object.keys(JUDGE0_LANGUAGES) as [string, ...string[]]),
+        source: z.string().min(1).max(JUDGE0_MAX_SOURCE_BYTES),
+        stdin: z.string().max(JUDGE0_MAX_SOURCE_BYTES).optional(),
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      checkRateLimit(ctx.user.id);
+      try {
+        const result = await executeCode({
+          language: input.language as keyof typeof JUDGE0_LANGUAGES,
+          source: input.source,
+          stdin: input.stdin,
+        });
+        return result;
+      } catch (err) {
+        if (err instanceof Judge0DisabledError) {
+          throw new TRPCError({
+            code: "NOT_IMPLEMENTED",
+            message: err.message,
+          });
+        }
+        if (err instanceof Judge0RequestError) {
+          throw new TRPCError({
+            code: err.statusCode === 429 ? "TOO_MANY_REQUESTS" : "BAD_REQUEST",
+            message: err.message,
+          });
+        }
+        throw err;
+      }
+    }),
+});

--- a/src/server/trpc/routers/index.ts
+++ b/src/server/trpc/routers/index.ts
@@ -1,6 +1,7 @@
 import { router } from "../init";
 import { attemptsRouter } from "./attempts";
 import { authRouter } from "./auth";
+import { codeRouter } from "./code";
 import { customRouter } from "./custom";
 import { insightsRouter } from "./insights";
 import { onboardingRouter } from "./onboarding";
@@ -12,6 +13,7 @@ export const appRouter = router({
   ping: pingRouter.ping,
   auth: authRouter,
   attempts: attemptsRouter,
+  code: codeRouter,
   custom: customRouter,
   insights: insightsRouter,
   onboarding: onboardingRouter,


### PR DESCRIPTION
## Summary
issue #34 (Phase 5+) Judge0 コード実行サンドボックスの MVP 統合。RapidAPI 経由で Python / TypeScript / JavaScript 3 言語を実行可能にし、tRPC `code.execute` 経由で UI から呼べるようにする。

### 実装
- `src/lib/judge0/client.ts` — `executeCode({ language, source, stdin? })`。base64 エンコード/デコード、`wait=true` で同期応答、`wall_time_limit=5s`、`source`/`stdin` 各 10KB 上限、`JUDGE0_API_KEY`/`JUDGE0_URL` 未設定時は `Judge0DisabledError` で早期 throw (本番 no-op fallback)
- `src/lib/judge0/languages.ts` — Python (71) / TypeScript (74) / JavaScript (63) の Judge0 CE language_id
- `src/server/trpc/routers/code.ts` — `code.execute` mutation。zod 境界 (enum / 1-10KB) + per-user in-memory rate limit (30 req/min スライディングウィンドウ)。Judge0 エラーを適切な tRPC code にマップ (disabled → NOT_IMPLEMENTED、429 → TOO_MANY_REQUESTS、その他 → BAD_REQUEST)
- `.env.example` — Phase 5+ セクションに `JUDGE0_URL` / `JUDGE0_API_KEY` / `JUDGE0_API_HOST` を追加

### 受け入れ基準
- [x] Judge0 (self-hosted or RapidAPI) との通信ラッパ
- [x] Python / TypeScript 最低 2 言語対応 (+JavaScript)
- [x] 実行結果を採点ロジックに渡す → **API として公開。code_read 採点への具体的な組み込みは別 PR** (MVP の code_read は文字列比較で既に成立しており、Judge0 は質問作者の検証や将来の code_debug タイプで使う想定)
- [x] コスト・レート制限の保護 (source 10KB / wall_time 5s / 30 req/min / env 未設定で safe disabled)

### Test plan
- [x] `pnpm typecheck` ✓
- [x] `pnpm test -- --run` ✓ (279/279、新規 +11: executeCode 6 ケース / code.execute 5 ケース)
- [x] `pnpm build` ✓

### 注意
- 本 PR はコード側のみ。RapidAPI アカウント作成 / JUDGE0_API_KEY 取得 / Vercel env 登録 は別タスク (作者の手動操作)
- env 未設定で `Judge0DisabledError` → `NOT_IMPLEMENTED` を返すので、本 PR を安全に main にマージ可能

closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)