### PR TITLE
feat(design): 設計問題の対話採点 (最大 3 ターン、#35)

### DIFF
--- a/drizzle/0011_attempts_dialogue.sql
+++ b/drizzle/0011_attempts_dialogue.sql
@@ -1,0 +1,3 @@
+-- issue #35: design 問題の対話採点用に attempts に dialogue jsonb を追加
+ALTER TABLE "attempts"
+  ADD COLUMN "dialogue" jsonb;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1776498000000,
       "tag": "0010_search_indexes",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "7",
+      "when": 1776499000000,
+      "tag": "0011_attempts_dialogue",
+      "breakpoints": true
     }
   ]
 }

--- a/prompts/grading/design.v1.md
+++ b/prompts/grading/design.v1.md
@@ -1,0 +1,58 @@
+# design 対話採点 (v1, issue #35)
+
+あなたは熟練したソフトウェア設計レビュアーです。学習者の「設計問題」への回答を、1 問あたり最大 3 ターンの対話で採点してください。
+
+## 基本方針
+
+1. **初ターン (学習者の initial answer を受け取った直後)**:
+   - 回答の欠けている観点を 1 つだけ指摘し、掘り下げる質問を 1 つだけ返す。
+   - この時点ではスコアは出さない。`finalized=false` で質問文だけ返す。
+2. **中間ターン (1~2 turn 目)**:
+   - 学習者の補足回答を読み、さらに 1 つだけ掘り下げる観点があれば質問。
+   - 観点が出尽くしたと感じたら `finalized=true` にして採点を確定する。
+3. **最終ターン (3 turn 目、強制)**:
+   - これ以上質問せず、ルーブリックに沿って `finalized=true` で採点を確定する。
+
+## 採点ルーブリック (0-1 スコア、docs/02 §2.2.1)
+
+- `scale` (0.25): 拡張性・データ量・並列性への配慮
+- `reliability` (0.25): 障害モデル・バックアップ・一貫性への配慮
+- `trade_off` (0.25): 明示的な trade-off 議論 (A を選んだ理由、B を捨てた理由)
+- `specificity` (0.25): ハンドウェーブでなく具体的な技術・パラメータ
+
+合計点 ≥ 0.8 で correct=true、0.4-0.8 で partial、< 0.4 で incorrect とする。
+
+## 出力フォーマット (JSON 厳守)
+
+```json
+{
+  "finalized": false,
+  "nextQuestion": "では、想定ピーク QPS と主要なボトルネックはどこにあると考えますか?",
+  "score": null,
+  "feedback": null,
+  "rubricChecks": null
+}
+```
+
+または最終ターン:
+
+```json
+{
+  "finalized": true,
+  "nextQuestion": null,
+  "score": 0.72,
+  "feedback": "scale と reliability への配慮は十分。ただし trade-off 議論が薄いので、なぜ SQL を選んだかを明示するとよい。",
+  "rubricChecks": [
+    { "id": "scale", "passed": true, "comment": "シャーディング戦略に言及" },
+    { "id": "reliability", "passed": true },
+    { "id": "trade_off", "passed": false, "comment": "選択理由が暗黙" },
+    { "id": "specificity", "passed": true }
+  ]
+}
+```
+
+## 入力変数
+
+- `{{prompt}}`: 問題文 (e.g. 「短縮 URL サービスのスキーマを設計」)
+- `{{turns}}`: これまでの対話履歴 (role: ai|user の配列)
+- `{{turnCount}}`: これまでの AI 発話ターン数 (0, 1, 2)。3 に達していれば**必ず** `finalized=true`

--- a/src/db/schema/attempts.ts
+++ b/src/db/schema/attempts.ts
@@ -36,6 +36,25 @@ export type MisconceptionTag = {
   description: string;
 };
 
+/** design タイプの対話採点の 1 ターン (issue #35)。 */
+export type DialogueTurn = {
+  /** "ai" = LLM 発話、"user" = ユーザー発話。初ターンのユーザー回答は userAnswer 側に残し dialogue は AI から始める */
+  role: "ai" | "user";
+  message: string;
+  /** ISO 8601 */
+  at: string;
+};
+
+/** design 対話採点の状態 (issue #35)。
+ *  - maxTurns: 交互に数える AI ターンの上限 (3 turns = AI が 3 回発話)
+ *  - finalized: 最終採点完了 (以降 followUp 不可)
+ */
+export type DialogueRecord = {
+  turns: DialogueTurn[];
+  maxTurns: number;
+  finalized: boolean;
+};
+
 export type RebuttalRecord = {
   /** 反論メッセージ (ユーザーが正解だと主張する根拠) */
   message: string;
@@ -82,6 +101,8 @@ export const attempts = pgTable(
     rubricChecks: jsonb("rubric_checks").$type<RubricCheckResult[]>(),
     misconceptionTags: jsonb("misconception_tags").$type<MisconceptionTag[]>(),
     rebuttal: jsonb("rebuttal").$type<RebuttalRecord>(),
+    /** design タイプの対話採点 state (issue #35)。 */
+    dialogue: jsonb("dialogue").$type<DialogueRecord>(),
     reasonGiven: text("reason_given"),
     copiedForExternal: integer("copied_for_external").notNull().default(0),
     /** 採点に使ったプロンプトの版 (CLAUDE.md §4.5)。mcq のようにプロンプト不使用の採点は null */

--- a/src/server/grader/design.test.ts
+++ b/src/server/grader/design.test.ts
@@ -51,7 +51,7 @@ describe("buildDesignPrompt", () => {
 });
 
 describe("runDesignTurn", () => {
-  it("正常系: LLM 応答をそのまま返す (finalized=false)", async () => {
+  it("正常系: LLM 応答を response に包んで返す (fallback=false)", async () => {
     const llm: DesignLlmCaller = async () => ({
       finalized: false,
       nextQuestion: "具体的な QPS は?",
@@ -67,11 +67,13 @@ describe("runDesignTurn", () => {
       },
       llm,
     );
-    expect(out.finalized).toBe(false);
-    expect(out.nextQuestion).toBe("具体的な QPS は?");
+    expect(out.fallback).toBe(false);
+    expect(out.response.finalized).toBe(false);
+    expect(out.response.nextQuestion).toBe("具体的な QPS は?");
+    expect(out.model).toBe("gpt-5");
   });
 
-  it("forceFinalize のときに LLM が finalized=false を返したら強制確定", async () => {
+  it("forceFinalize のときに LLM が finalized=false を返したら強制確定 (fallback=false)", async () => {
     const llm: DesignLlmCaller = async () => ({
       finalized: false,
       nextQuestion: "さらに聞きたい",
@@ -87,12 +89,13 @@ describe("runDesignTurn", () => {
       },
       llm,
     );
-    expect(out.finalized).toBe(true);
-    expect(out.nextQuestion).toBeNull();
-    expect(out.score).toBe(0.5); // fallback
+    expect(out.response.finalized).toBe(true);
+    expect(out.response.nextQuestion).toBeNull();
+    expect(out.response.score).toBe(0.5); // fallback within the prompt
+    expect(out.fallback).toBe(false); // LLM 応答は返ってきたので fallback=false
   });
 
-  it("LLM throw 時は中間点で safe finalize", async () => {
+  it("LLM throw 時は fallback=true + 中間点で safe finalize", async () => {
     const llm: DesignLlmCaller = async () => {
       throw new Error("LLM broke");
     };
@@ -100,9 +103,10 @@ describe("runDesignTurn", () => {
       { question: { prompt: "x" }, initialUserAnswer: "y", turns: [] },
       llm,
     );
-    expect(out.finalized).toBe(true);
-    expect(out.score).toBe(0.4);
-    expect(out.feedback).toMatch(/壊れ/);
+    expect(out.fallback).toBe(true);
+    expect(out.response.finalized).toBe(true);
+    expect(out.response.score).toBe(0.4);
+    expect(out.response.feedback).toMatch(/壊れ/);
   });
 });
 

--- a/src/server/grader/design.test.ts
+++ b/src/server/grader/design.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import type { DialogueTurn } from "@/db/schema";
+import { MODEL_MAIN } from "@/lib/openai/models";
 
 import {
   buildDesignPrompt,
@@ -70,7 +71,7 @@ describe("runDesignTurn", () => {
     expect(out.fallback).toBe(false);
     expect(out.response.finalized).toBe(false);
     expect(out.response.nextQuestion).toBe("具体的な QPS は?");
-    expect(out.model).toBe("gpt-5");
+    expect(out.model).toBe(MODEL_MAIN);
   });
 
   it("forceFinalize のときに LLM が finalized=false を返したら強制確定 (fallback=false)", async () => {

--- a/src/server/grader/design.test.ts
+++ b/src/server/grader/design.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "vitest";
+
+import type { DialogueTurn } from "@/db/schema";
+
+import {
+  buildDesignPrompt,
+  countAiTurns,
+  DESIGN_MAX_AI_TURNS,
+  designRubricChecks,
+  runDesignTurn,
+  type DesignLlmCaller,
+  type DesignResponse,
+} from "./design";
+
+function turn(role: "ai" | "user", message: string): DialogueTurn {
+  return { role, message, at: "2026-04-19T00:00:00Z" };
+}
+
+describe("countAiTurns", () => {
+  it("role === 'ai' のみをカウント", () => {
+    expect(countAiTurns([])).toBe(0);
+    expect(countAiTurns([turn("user", "a")])).toBe(0);
+    expect(countAiTurns([turn("ai", "q1"), turn("user", "a1"), turn("ai", "q2")])).toBe(2);
+  });
+});
+
+describe("buildDesignPrompt", () => {
+  it("turnCount < MAX-1 は forceFinalize=false", () => {
+    const p = buildDesignPrompt({
+      question: { prompt: "URL 短縮サービスを設計" },
+      initialUserAnswer: "hash を URL 化",
+      turns: [],
+    });
+    expect(p.forceFinalize).toBe(false);
+    expect(p.turnCount).toBe(0);
+    expect(p.system).toMatch(/途中/);
+    expect(p.user).toMatch(/hash を URL 化/);
+    expect(p.user).toMatch(/turnCount=0/);
+  });
+
+  it("turnCount === MAX-1 は forceFinalize=true (最終ターン)", () => {
+    const p = buildDesignPrompt({
+      question: { prompt: "短縮 URL" },
+      initialUserAnswer: "base62",
+      turns: [turn("ai", "Q1"), turn("user", "A1"), turn("ai", "Q2"), turn("user", "A2")],
+    });
+    expect(p.forceFinalize).toBe(true);
+    expect(p.turnCount).toBe(DESIGN_MAX_AI_TURNS - 1);
+    expect(p.system).toMatch(/最終ターン/);
+  });
+});
+
+describe("runDesignTurn", () => {
+  it("正常系: LLM 応答をそのまま返す (finalized=false)", async () => {
+    const llm: DesignLlmCaller = async () => ({
+      finalized: false,
+      nextQuestion: "具体的な QPS は?",
+      score: null,
+      feedback: null,
+      rubricChecks: null,
+    });
+    const out = await runDesignTurn(
+      {
+        question: { prompt: "x" },
+        initialUserAnswer: "y",
+        turns: [],
+      },
+      llm,
+    );
+    expect(out.finalized).toBe(false);
+    expect(out.nextQuestion).toBe("具体的な QPS は?");
+  });
+
+  it("forceFinalize のときに LLM が finalized=false を返したら強制確定", async () => {
+    const llm: DesignLlmCaller = async () => ({
+      finalized: false,
+      nextQuestion: "さらに聞きたい",
+      score: null,
+      feedback: null,
+      rubricChecks: null,
+    });
+    const out = await runDesignTurn(
+      {
+        question: { prompt: "x" },
+        initialUserAnswer: "y",
+        turns: [turn("ai", "q1"), turn("user", "a1"), turn("ai", "q2"), turn("user", "a2")],
+      },
+      llm,
+    );
+    expect(out.finalized).toBe(true);
+    expect(out.nextQuestion).toBeNull();
+    expect(out.score).toBe(0.5); // fallback
+  });
+
+  it("LLM throw 時は中間点で safe finalize", async () => {
+    const llm: DesignLlmCaller = async () => {
+      throw new Error("LLM broke");
+    };
+    const out = await runDesignTurn(
+      { question: { prompt: "x" }, initialUserAnswer: "y", turns: [] },
+      llm,
+    );
+    expect(out.finalized).toBe(true);
+    expect(out.score).toBe(0.4);
+    expect(out.feedback).toMatch(/壊れ/);
+  });
+});
+
+describe("designRubricChecks", () => {
+  it("null rubric は空配列、comment なしは空文字で埋める", () => {
+    const r: DesignResponse = {
+      finalized: true,
+      nextQuestion: null,
+      score: 0.7,
+      feedback: "ok",
+      rubricChecks: null,
+    };
+    expect(designRubricChecks(r)).toEqual([]);
+    const r2: DesignResponse = {
+      finalized: true,
+      nextQuestion: null,
+      score: 0.7,
+      feedback: "ok",
+      rubricChecks: [{ id: "scale", passed: true }],
+    };
+    expect(designRubricChecks(r2)).toEqual([{ id: "scale", passed: true, comment: "" }]);
+  });
+});

--- a/src/server/grader/design.ts
+++ b/src/server/grader/design.ts
@@ -55,6 +55,8 @@ const DESIGN_JSON_SCHEMA = {
 
 export const DESIGN_MAX_AI_TURNS = 3;
 export const DESIGN_PROMPT_VERSION = "design.v1";
+/** スコア >= このしきい値で correct 扱い (docs/02 §2.2.1 の design ルーブリック) */
+export const DESIGN_CORRECT_THRESHOLD = 0.8;
 
 /** AI のターン回数をカウント (role === 'ai' の turn 数)。3 に達していたら必ず finalize させる。 */
 export function countAiTurns(turns: DialogueTurn[]): number {
@@ -116,38 +118,56 @@ export function buildDesignPrompt(args: GradeArgs): {
   return { system, user, forceFinalize, turnCount };
 }
 
+/** runDesignTurn の戻り値。fallback=true は LLM 呼び出しが壊れて safe finalize した印。
+ *  呼び出し側はこれを見て gradedBy / mastery 更新の扱いを変える (Codex Round 1 指摘 #4)。
+ */
+export type DesignTurnResult = {
+  response: DesignResponse;
+  model: string;
+  fallback: boolean;
+};
+
 /**
  * design タイプ 1 ターン分の LLM 呼び出し。
  * forceFinalize のときに LLM が finalized=false で返したら強制確定 (指示違反防御)。
+ * LLM throw 時は fallback=true + 中間点 safe finalize を返す。
  */
 export async function runDesignTurn(
   args: GradeArgs,
   llm: DesignLlmCaller = defaultDesignLlm,
-): Promise<DesignResponse> {
+): Promise<DesignTurnResult> {
   const { system, user, forceFinalize } = buildDesignPrompt(args);
   let data: DesignResponse;
   try {
     data = await llm({ model: MODEL_MAIN, system, user });
   } catch {
-    // LLM が出力形式を壊したら中間点で safe finalize
     return {
-      finalized: true,
-      nextQuestion: null,
-      score: 0.4,
-      feedback: "採点応答のフォーマットが壊れていました。中間点で確定します。",
-      rubricChecks: null,
+      response: {
+        finalized: true,
+        nextQuestion: null,
+        score: 0.4,
+        feedback: "採点応答のフォーマットが壊れていました。中間点で確定します。",
+        rubricChecks: null,
+      },
+      model: MODEL_MAIN,
+      fallback: true,
     };
   }
   if (forceFinalize && !data.finalized) {
     return {
-      ...data,
-      finalized: true,
-      nextQuestion: null,
-      score: data.score ?? 0.5,
-      feedback: data.feedback ?? "最終ターンの強制確定 (LLM が finalize 指示に従わなかったため)。",
+      response: {
+        ...data,
+        finalized: true,
+        nextQuestion: null,
+        score: data.score ?? 0.5,
+        feedback:
+          data.feedback ?? "最終ターンの強制確定 (LLM が finalize 指示に従わなかったため)。",
+      },
+      model: MODEL_MAIN,
+      fallback: false,
     };
   }
-  return data;
+  return { response: data, model: MODEL_MAIN, fallback: false };
 }
 
 /** DesignResponse → 既存 grader 用の RubricCheckResult[] に寄せる */

--- a/src/server/grader/design.ts
+++ b/src/server/grader/design.ts
@@ -1,0 +1,160 @@
+import "server-only";
+
+import { z } from "zod";
+
+import type { DialogueTurn, Question, RubricCheckResult } from "@/db/schema";
+import { getOpenAI } from "@/lib/openai/client";
+import { MODEL_MAIN } from "@/lib/openai/models";
+
+/** 対話採点の LLM レスポンス schema (prompts/grading/design.v1.md と同期)。 */
+const DesignResponseSchema = z.object({
+  finalized: z.boolean(),
+  nextQuestion: z.string().nullable(),
+  score: z.number().min(0).max(1).nullable(),
+  feedback: z.string().nullable(),
+  rubricChecks: z
+    .array(
+      z.object({
+        id: z.string(),
+        passed: z.boolean(),
+        comment: z.string().optional(),
+      }),
+    )
+    .nullable(),
+});
+export type DesignResponse = z.infer<typeof DesignResponseSchema>;
+
+const DESIGN_JSON_SCHEMA = {
+  name: "design_response",
+  schema: {
+    type: "object",
+    additionalProperties: false,
+    required: ["finalized", "nextQuestion", "score", "feedback", "rubricChecks"],
+    properties: {
+      finalized: { type: "boolean" },
+      nextQuestion: { type: ["string", "null"] },
+      score: { type: ["number", "null"], minimum: 0, maximum: 1 },
+      feedback: { type: ["string", "null"] },
+      rubricChecks: {
+        type: ["array", "null"],
+        items: {
+          type: "object",
+          additionalProperties: false,
+          required: ["id", "passed"],
+          properties: {
+            id: { type: "string" },
+            passed: { type: "boolean" },
+            comment: { type: "string" },
+          },
+        },
+      },
+    },
+  },
+  strict: true,
+} as const;
+
+export const DESIGN_MAX_AI_TURNS = 3;
+export const DESIGN_PROMPT_VERSION = "design.v1";
+
+/** AI のターン回数をカウント (role === 'ai' の turn 数)。3 に達していたら必ず finalize させる。 */
+export function countAiTurns(turns: DialogueTurn[]): number {
+  return turns.filter((t) => t.role === "ai").length;
+}
+
+/** DI 用の caller 型。テストで差し替える */
+export type DesignLlmCaller = (args: {
+  model: string;
+  system: string;
+  user: string;
+}) => Promise<DesignResponse>;
+
+export const defaultDesignLlm: DesignLlmCaller = async ({ model, system, user }) => {
+  const client = getOpenAI();
+  const res = await client.responses.create({
+    model,
+    input: [
+      { role: "system", content: system },
+      { role: "user", content: user },
+    ],
+    text: { format: { type: "json_schema", ...DESIGN_JSON_SCHEMA } },
+  });
+  return DesignResponseSchema.parse(JSON.parse(res.output_text));
+};
+
+type GradeArgs = {
+  question: Pick<Question, "prompt">;
+  initialUserAnswer: string;
+  turns: DialogueTurn[];
+};
+
+/** 現在の dialogue state から LLM に渡す system / user プロンプトを構築する */
+export function buildDesignPrompt(args: GradeArgs): {
+  system: string;
+  user: string;
+  forceFinalize: boolean;
+  turnCount: number;
+} {
+  const turnCount = countAiTurns(args.turns);
+  const forceFinalize = turnCount >= DESIGN_MAX_AI_TURNS - 1;
+
+  const system =
+    "あなたは熟練したソフトウェア設計レビュアー。1 問 3 ターン以内で学習者の設計回答を採点する。" +
+    "出力は必ず指定 JSON schema に沿い、前後に地の文を付けない。" +
+    "採点ルーブリック (0.25 点ずつ): scale / reliability / trade_off / specificity。" +
+    "合計 ≥ 0.8 で correct、0.4-0.8 で partial、<0.4 で incorrect。" +
+    (forceFinalize
+      ? " 今回は最終ターン (turnCount == MAX - 1): 必ず finalized=true でスコアを出す。"
+      : " まだ途中。観点が尽きていなければ 1 つだけ掘り下げ質問を返す (finalized=false)。");
+
+  const history = args.turns.map((t) => `[${t.role}] ${t.message}`).join("\n");
+  const user =
+    `問題: ${args.question.prompt}\n\n` +
+    `初回回答: ${args.initialUserAnswer}\n\n` +
+    (history ? `対話履歴:\n${history}\n\n` : "") +
+    `turnCount=${turnCount} (max=${DESIGN_MAX_AI_TURNS})。${forceFinalize ? "最終ターン、必ず finalize してください。" : "次のターンを返してください。"}`;
+
+  return { system, user, forceFinalize, turnCount };
+}
+
+/**
+ * design タイプ 1 ターン分の LLM 呼び出し。
+ * forceFinalize のときに LLM が finalized=false で返したら強制確定 (指示違反防御)。
+ */
+export async function runDesignTurn(
+  args: GradeArgs,
+  llm: DesignLlmCaller = defaultDesignLlm,
+): Promise<DesignResponse> {
+  const { system, user, forceFinalize } = buildDesignPrompt(args);
+  let data: DesignResponse;
+  try {
+    data = await llm({ model: MODEL_MAIN, system, user });
+  } catch {
+    // LLM が出力形式を壊したら中間点で safe finalize
+    return {
+      finalized: true,
+      nextQuestion: null,
+      score: 0.4,
+      feedback: "採点応答のフォーマットが壊れていました。中間点で確定します。",
+      rubricChecks: null,
+    };
+  }
+  if (forceFinalize && !data.finalized) {
+    return {
+      ...data,
+      finalized: true,
+      nextQuestion: null,
+      score: data.score ?? 0.5,
+      feedback: data.feedback ?? "最終ターンの強制確定 (LLM が finalize 指示に従わなかったため)。",
+    };
+  }
+  return data;
+}
+
+/** DesignResponse → 既存 grader 用の RubricCheckResult[] に寄せる */
+export function designRubricChecks(r: DesignResponse): RubricCheckResult[] {
+  return (r.rubricChecks ?? []).map((c) => ({
+    id: c.id,
+    passed: c.passed,
+    comment: c.comment ?? "",
+  }));
+}

--- a/src/server/trpc/routers/attempts.ts
+++ b/src/server/trpc/routers/attempts.ts
@@ -3,9 +3,25 @@ import { and, eq, isNull, sql } from "drizzle-orm";
 import { z } from "zod";
 
 import { getDb } from "@/db/client";
-import { attempts, questions, type RebuttalRecord } from "@/db/schema";
+import {
+  attempts,
+  questions,
+  type DialogueRecord,
+  type DialogueTurn,
+  type RebuttalRecord,
+} from "@/db/schema";
+import {
+  DESIGN_MAX_AI_TURNS,
+  DESIGN_PROMPT_VERSION,
+  countAiTurns,
+  designRubricChecks,
+  runDesignTurn,
+} from "@/server/grader/design";
 import { gradeRebut } from "@/server/grader/rebut";
-import { reapplyMasteryAfterRebut } from "@/server/scheduler/update-mastery";
+import {
+  reapplyMasteryAfterRebut,
+  updateMasteryAfterAttempt,
+} from "@/server/scheduler/update-mastery";
 
 import { protectedProcedure, router } from "../init";
 
@@ -131,6 +147,134 @@ export const attemptsRouter = router({
    * このエンドポイントはカウンタ (attempts.copied_for_external) を +1 するだけ。
    * 利用率の指標 (docs/09 success metrics) として集計するためのもの。
    */
+  /**
+   * design 対話採点の follow-up (issue #35)。
+   * 既存 attempt (type='design') に対してユーザーの追加メッセージを投げ、LLM の次ターンを得る。
+   * AI が 3 ターン発話済みなら 400 (BAD_REQUEST)。LLM が finalized=true を返したら
+   * correct / score / feedback / rubricChecks を最終値で上書きし、mastery も更新する。
+   */
+  followUp: protectedProcedure
+    .input(
+      z.object({
+        attemptId: z.string().min(1),
+        message: z.string().min(1).max(2000),
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      const db = getDb();
+      const rows = await db
+        .select()
+        .from(attempts)
+        .where(and(eq(attempts.id, input.attemptId), eq(attempts.userId, ctx.user.id)))
+        .limit(1);
+      const prev = rows[0];
+      if (!prev) throw new TRPCError({ code: "NOT_FOUND", message: "attempt not found" });
+
+      const qRows = await db
+        .select()
+        .from(questions)
+        .where(eq(questions.id, prev.questionId))
+        .limit(1);
+      const question = qRows[0];
+      if (!question) throw new TRPCError({ code: "NOT_FOUND", message: "question not found" });
+      if (question.type !== "design") {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: `type="${question.type}" は対話採点の対象外 (design のみ)`,
+        });
+      }
+
+      const dialogue: DialogueRecord = prev.dialogue ?? {
+        turns: [],
+        maxTurns: DESIGN_MAX_AI_TURNS,
+        finalized: false,
+      };
+      if (dialogue.finalized) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: "この attempt の対話採点は既に確定しています",
+        });
+      }
+      if (countAiTurns(dialogue.turns) >= DESIGN_MAX_AI_TURNS) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: `対話は最大 ${DESIGN_MAX_AI_TURNS} ターンまで`,
+        });
+      }
+
+      const now = new Date();
+      // user message を先に append
+      const userTurn: DialogueTurn = {
+        role: "user",
+        message: input.message,
+        at: now.toISOString(),
+      };
+      const turnsWithUser = [...dialogue.turns, userTurn];
+      // LLM に次ターンを聞く
+      const resp = await runDesignTurn({
+        question: { prompt: question.prompt },
+        initialUserAnswer: prev.userAnswer ?? "",
+        turns: turnsWithUser,
+      });
+      const aiTurn: DialogueTurn = {
+        role: "ai",
+        message: resp.nextQuestion ?? resp.feedback ?? "",
+        at: new Date().toISOString(),
+      };
+      const nextDialogue: DialogueRecord = {
+        turns: [...turnsWithUser, aiTurn],
+        maxTurns: DESIGN_MAX_AI_TURNS,
+        finalized: resp.finalized,
+      };
+
+      if (resp.finalized) {
+        const rubric = designRubricChecks(resp);
+        const correct = (resp.score ?? 0) >= 0.8;
+        await db
+          .update(attempts)
+          .set({
+            correct,
+            score: resp.score,
+            feedback: resp.feedback,
+            rubricChecks: rubric,
+            gradedBy: "gpt-5",
+            promptVersion: DESIGN_PROMPT_VERSION,
+            dialogue: nextDialogue,
+          })
+          .where(and(eq(attempts.id, prev.id), eq(attempts.userId, ctx.user.id)));
+        // design 採点確定 → mastery へ反映 (既存 drill 系と同じ経路)
+        await updateMasteryAfterAttempt({
+          userId: ctx.user.id,
+          conceptId: prev.conceptId,
+          score: resp.score,
+        });
+        return {
+          attemptId: prev.id,
+          dialogue: nextDialogue,
+          finalized: true,
+          correct,
+          score: resp.score,
+          feedback: resp.feedback,
+          rubricChecks: rubric,
+        };
+      }
+
+      // 中間ターン: dialogue のみ更新
+      await db
+        .update(attempts)
+        .set({ dialogue: nextDialogue })
+        .where(and(eq(attempts.id, prev.id), eq(attempts.userId, ctx.user.id)));
+      return {
+        attemptId: prev.id,
+        dialogue: nextDialogue,
+        finalized: false,
+        correct: prev.correct,
+        score: prev.score,
+        feedback: prev.feedback,
+        rubricChecks: prev.rubricChecks ?? [],
+      };
+    }),
+
   markCopiedForExternal: protectedProcedure
     .input(z.object({ attemptId: z.string().min(1) }))
     .mutation(async ({ ctx, input }) => {

--- a/src/server/trpc/routers/attempts.ts
+++ b/src/server/trpc/routers/attempts.ts
@@ -11,6 +11,7 @@ import {
   type RebuttalRecord,
 } from "@/db/schema";
 import {
+  DESIGN_CORRECT_THRESHOLD,
   DESIGN_MAX_AI_TURNS,
   DESIGN_PROMPT_VERSION,
   countAiTurns,
@@ -211,11 +212,12 @@ export const attemptsRouter = router({
       };
       const turnsWithUser = [...dialogue.turns, userTurn];
       // LLM に次ターンを聞く
-      const resp = await runDesignTurn({
+      const turnResult = await runDesignTurn({
         question: { prompt: question.prompt },
         initialUserAnswer: prev.userAnswer ?? "",
         turns: turnsWithUser,
       });
+      const resp = turnResult.response;
       const aiTurn: DialogueTurn = {
         role: "ai",
         message: resp.nextQuestion ?? resp.feedback ?? "",
@@ -227,27 +229,42 @@ export const attemptsRouter = router({
         finalized: resp.finalized,
       };
 
+      // Race 対策 (Codex Round 1 指摘 #1): UPDATE WHERE に「dialogue が未確定 (null or finalized=false)」
+      // を加えることで、SELECT と UPDATE の間に他リクエストが finalize した場合は 0 行更新で弾く。
+      // losing race 側は「既に確定済み」エラーを返す。
+      const unfinalizedGuard = sql`(${attempts.dialogue} IS NULL OR ${attempts.dialogue}->>'finalized' = 'false')`;
+
       if (resp.finalized) {
         const rubric = designRubricChecks(resp);
-        const correct = (resp.score ?? 0) >= 0.8;
-        await db
+        const correct = (resp.score ?? 0) >= DESIGN_CORRECT_THRESHOLD;
+        const updated = await db
           .update(attempts)
           .set({
             correct,
             score: resp.score,
             feedback: resp.feedback,
             rubricChecks: rubric,
-            gradedBy: "gpt-5",
+            // fallback 時は gradedBy を null にして「LLM が壊れて safe finalize」を識別可能に
+            gradedBy: turnResult.fallback ? null : turnResult.model,
             promptVersion: DESIGN_PROMPT_VERSION,
             dialogue: nextDialogue,
           })
-          .where(and(eq(attempts.id, prev.id), eq(attempts.userId, ctx.user.id)));
-        // design 採点確定 → mastery へ反映 (既存 drill 系と同じ経路)
-        await updateMasteryAfterAttempt({
-          userId: ctx.user.id,
-          conceptId: prev.conceptId,
-          score: resp.score,
-        });
+          .where(and(eq(attempts.id, prev.id), eq(attempts.userId, ctx.user.id), unfinalizedGuard))
+          .returning({ id: attempts.id });
+        if (updated.length === 0) {
+          throw new TRPCError({
+            code: "BAD_REQUEST",
+            message: "この attempt の対話採点は既に確定しています (並行 finalize)",
+          });
+        }
+        // fallback (LLM が壊れた) ケースでは mastery を動かさない (強制 0.4 で FSRS を揺らすのは根拠が弱い)
+        if (!turnResult.fallback) {
+          await updateMasteryAfterAttempt({
+            userId: ctx.user.id,
+            conceptId: prev.conceptId,
+            score: resp.score,
+          });
+        }
         return {
           attemptId: prev.id,
           dialogue: nextDialogue,
@@ -259,11 +276,18 @@ export const attemptsRouter = router({
         };
       }
 
-      // 中間ターン: dialogue のみ更新
-      await db
+      // 中間ターン: dialogue のみ更新 (同じ race guard で並行 finalize と衝突しない)
+      const updated = await db
         .update(attempts)
         .set({ dialogue: nextDialogue })
-        .where(and(eq(attempts.id, prev.id), eq(attempts.userId, ctx.user.id)));
+        .where(and(eq(attempts.id, prev.id), eq(attempts.userId, ctx.user.id), unfinalizedGuard))
+        .returning({ id: attempts.id });
+      if (updated.length === 0) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: "この attempt の対話採点は既に確定しています (並行 finalize)",
+        });
+      }
       return {
         attemptId: prev.id,
         dialogue: nextDialogue,

--- a/src/server/trpc/routers/attempts.ts
+++ b/src/server/trpc/routers/attempts.ts
@@ -142,17 +142,14 @@ export const attemptsRouter = router({
     }),
 
   /**
-   * 「詳しく聞く用にコピー」ボタン押下時に呼ぶ (issue #16)。
-   *
-   * 実際のテキスト生成は `src/lib/share/copy-for-llm.ts` でクライアント側に行い、
-   * このエンドポイントはカウンタ (attempts.copied_for_external) を +1 するだけ。
-   * 利用率の指標 (docs/09 success metrics) として集計するためのもの。
-   */
-  /**
    * design 対話採点の follow-up (issue #35)。
    * 既存 attempt (type='design') に対してユーザーの追加メッセージを投げ、LLM の次ターンを得る。
    * AI が 3 ターン発話済みなら 400 (BAD_REQUEST)。LLM が finalized=true を返したら
    * correct / score / feedback / rubricChecks を最終値で上書きし、mastery も更新する。
+   *
+   * Race 対策: SELECT→LLM→UPDATE の間に他リクエストで finalize されたら、UPDATE の
+   * WHERE 句に含める `dialogue->>'finalized' = 'false'` guard で 0 行更新を検知し、
+   * 「既に確定済み (並行 finalize)」BAD_REQUEST を返す (Codex Round 1 指摘 #1)。
    */
   followUp: protectedProcedure
     .input(
@@ -299,6 +296,13 @@ export const attemptsRouter = router({
       };
     }),
 
+  /**
+   * 「詳しく聞く用にコピー」ボタン押下時に呼ぶ (issue #16)。
+   *
+   * 実際のテキスト生成は `src/lib/share/copy-for-llm.ts` でクライアント側に行い、
+   * このエンドポイントはカウンタ (attempts.copied_for_external) を +1 するだけ。
+   * 利用率の指標 (docs/09 success metrics) として集計するためのもの。
+   */
   markCopiedForExternal: protectedProcedure
     .input(z.object({ attemptId: z.string().min(1) }))
     .mutation(async ({ ctx, input }) => {


### PR DESCRIPTION
## Summary
issue #35 (Phase 5+) design タイプの対話採点。MVP は gpt-5 が 1 問あたり最大 3 ターンで掘り下げ質問を返し、ルーブリック (scale / reliability / trade_off / specificity 各 0.25) で最終スコアを確定する。

### 実装
- **migration 0011**: `attempts.dialogue jsonb` カラムを追加 (`{ turns, maxTurns, finalized }`)
- **schema**: `DialogueTurn` / `DialogueRecord` 型を export、`attempts.dialogue` にバインド
- **prompts/grading/design.v1.md**: 採点ルーブリック + 出力 JSON schema + 3 ターン制約を明文化
- **src/server/grader/design.ts**:
  - `countAiTurns` — AI 発話数をカウント
  - `buildDesignPrompt` — turnCount と MAX-1 比較で forceFinalize を判定
  - `runDesignTurn` (DI 可能な `DesignLlmCaller`) — OpenAI `responses.create` + `json_schema` strict format、MODEL_MAIN (gpt-5)、forceFinalize 時 LLM が finalized=false を返したら強制確定、LLM throw 時は中間点 safe finalize
  - `designRubricChecks` — `RubricCheckResult[]` に正規化
- **attempts.followUp** tRPC mutation:
  - `type='design'` のみ受付
  - `dialogue.finalized===true` or AI 発話 3 ターン到達で BAD_REQUEST
  - user message → LLM 呼び出し → AI turn append → `finalized` なら `correct / score / feedback / rubricChecks` を update + `updateMasteryAfterAttempt` で FSRS 反映
- **tests**: countAiTurns / buildDesignPrompt (forceFinalize 境界 2 件) / runDesignTurn (正常 / 強制 finalize / LLM throw) / designRubricChecks で +7 件

### 受け入れ基準
- [x] tRPC: `attempts.followUp` で対話継続
- [ ] UI: チャット風の展開 → **本 PR はサーバ側のみ。UI は別 PR** (既存 DrillScreen の RebuttalForm 同等の DesignDialogueForm を追加する想定。対話状態 `attempt.dialogue` は既に永続化されているので UI は読むだけで済む)
- [x] 3 ターンで強制終了 (`DESIGN_MAX_AI_TURNS=3` + forceFinalize 強制確定)
- [x] 最終スコアをルーブリックで決定 (gpt-5 + json_schema strict、≥0.8 で correct)

### Test plan
- [x] `pnpm typecheck` ✓
- [x] `pnpm test -- --run` ✓ (286/286、新規 +7)
- [x] `pnpm build` ✓

closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)