### PR TITLE
feat(home): トップから各機能への導線を追加 (#77)

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -12,7 +12,7 @@ export default async function Home() {
     redirect("/onboarding");
   }
   return (
-    <main className="flex min-h-screen flex-col items-center justify-center gap-6 p-8">
+    <main className="flex min-h-screen flex-col items-center gap-6 p-4 pt-6 sm:p-8">
       <HomeScreen
         initialUser={
           initialUser

--- a/src/features/deep-dive/deep-dive-screen.tsx
+++ b/src/features/deep-dive/deep-dive-screen.tsx
@@ -16,28 +16,13 @@ import {
 import type { DomainId } from "@/db/schema";
 import { DrillScreen } from "@/features/drill/drill-screen";
 import { useDrillStore } from "@/features/drill/drill-state";
+import { DOMAIN_LABELS } from "@/lib/domain-labels";
 import { trpc } from "@/lib/trpc/react";
 
 type Phase =
   | { kind: "idle" }
   | { kind: "running"; sessionId: string }
   | { kind: "error"; message: string };
-
-const DOMAIN_LABELS: Record<DomainId, string> = {
-  programming: "Programming",
-  dsa: "DSA",
-  os: "OS",
-  network: "Network",
-  db: "Database",
-  security: "Security",
-  distributed: "Distributed",
-  design: "Design",
-  devops: "DevOps",
-  tools: "Tools",
-  low_level: "Low-level",
-  ai_ml: "AI / ML",
-  frontend: "Frontend",
-};
 
 /**
  * Deep Dive セッション画面 (issue #28)。

--- a/src/features/home/home-screen.tsx
+++ b/src/features/home/home-screen.tsx
@@ -182,12 +182,13 @@ function DailyDrillCard({ dailyGoal }: { dailyGoal: number }) {
               style={{ width: `${Math.round(ratio * 100)}%` }}
             />
           </div>
-        ) : (
+        ) : progress.isError ? null : (
+          // loading 中: animate-pulse で「確定 0 件の空バー」と区別 (Codex Round 3 指摘)。
           <div
-            className="bg-secondary h-2 w-full overflow-hidden rounded-full"
+            className="bg-secondary h-2 w-full animate-pulse rounded-full"
             role="progressbar"
             aria-label="今日の進捗"
-            aria-valuetext={progress.isError ? "取得失敗" : "読み込み中"}
+            aria-valuetext="読み込み中"
           />
         )}
       </CardContent>

--- a/src/features/home/home-screen.tsx
+++ b/src/features/home/home-screen.tsx
@@ -1,6 +1,21 @@
 "use client";
 
-import { LogOut, RefreshCw, Sparkles } from "lucide-react";
+import {
+  BarChart3,
+  ChevronRight,
+  History,
+  LineChart,
+  ListChecks,
+  LogOut,
+  Map as MapIcon,
+  RefreshCw,
+  RotateCcw,
+  Search,
+  Sparkles,
+  Target,
+  Wand2,
+} from "lucide-react";
+import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 
@@ -13,6 +28,9 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import { TIER_1_DOMAIN_IDS } from "@/db/schema";
+import { cn } from "@/lib/cn";
+import { DOMAIN_LABELS } from "@/lib/domain-labels";
 import { trpc } from "@/lib/trpc/react";
 
 export type InitialHomeUser = {
@@ -24,7 +42,6 @@ export type InitialHomeUser = {
 
 export function HomeScreen({ initialUser }: { initialUser: InitialHomeUser }) {
   const router = useRouter();
-  // SSR で解決した initialUser を初期値にしておき、以後はクライアント側で再検証
   const me = trpc.auth.me.useQuery(undefined, {
     initialData: initialUser
       ? { authenticated: true, user: initialUser }
@@ -44,7 +61,6 @@ export function HomeScreen({ initialUser }: { initialUser: InitialHomeUser }) {
     }
   }
 
-  // tRPC / DB 障害と「ログアウト済み」を UI 上でも区別する
   if (me.isError) {
     return (
       <Card className="w-full max-w-md">
@@ -88,25 +104,180 @@ export function HomeScreen({ initialUser }: { initialUser: InitialHomeUser }) {
 
   const { user } = me.data;
   return (
-    <Card className="w-full max-w-md">
+    <div className="w-full max-w-2xl space-y-4">
+      <HomeHeader
+        displayName={user.displayName ?? user.email}
+        email={user.email}
+        loggingOut={loggingOut}
+        onLogout={handleLogout}
+      />
+      <DailyDrillCard dailyGoal={user.dailyGoal} />
+      <ModeGrid />
+      <DeepDiveSection />
+      <InsightsSection />
+    </div>
+  );
+}
+
+function HomeHeader({
+  displayName,
+  email,
+  loggingOut,
+  onLogout,
+}: {
+  displayName: string;
+  email: string;
+  loggingOut: boolean;
+  onLogout: () => void;
+}) {
+  return (
+    <div className="flex items-start justify-between gap-2">
+      <div>
+        <h1 className="text-lg font-semibold">ようこそ、{displayName}</h1>
+        <p className="text-muted-foreground text-xs">{email}</p>
+      </div>
+      <Button variant="outline" size="sm" onClick={onLogout} disabled={loggingOut}>
+        <LogOut className="mr-1 h-4 w-4" />
+        {loggingOut ? "ログアウト中…" : "ログアウト"}
+      </Button>
+    </div>
+  );
+}
+
+function DailyDrillCard({ dailyGoal }: { dailyGoal: number }) {
+  const progress = trpc.home.dailyProgress.useQuery();
+  const attemptCount = progress.data?.attemptCount ?? 0;
+  const ratio = dailyGoal > 0 ? Math.min(attemptCount / dailyGoal, 1) : 0;
+  return (
+    <Card>
       <CardHeader>
-        <CardTitle>ようこそ、{user.displayName ?? user.email}</CardTitle>
-        <CardDescription>{user.email}</CardDescription>
+        <CardTitle className="flex items-center gap-2">
+          <Target className="h-5 w-5" /> 今日の復習
+        </CardTitle>
+        <CardDescription>
+          {progress.isError
+            ? "今日の進捗を取得できませんでした"
+            : progress.isLoading
+              ? "進捗を読み込み中…"
+              : `${attemptCount} / ${dailyGoal} 問 (JST 00:00 以降)`}
+        </CardDescription>
       </CardHeader>
-      <CardContent className="space-y-2 text-sm">
-        <div>
-          1日の目標: <span className="font-medium">{user.dailyGoal} 問</span>
-        </div>
-        <div className="text-muted-foreground">
-          Phase 0 bootstrap。Drill / Insights は別 issue で接続予定。
+      <CardContent className="space-y-3">
+        <div
+          className="bg-secondary h-2 w-full overflow-hidden rounded-full"
+          role="progressbar"
+          aria-valuemin={0}
+          aria-valuemax={dailyGoal}
+          aria-valuenow={attemptCount}
+          aria-label="今日の進捗"
+        >
+          <div
+            className="bg-primary h-full transition-[width]"
+            style={{ width: `${Math.round(ratio * 100)}%` }}
+          />
         </div>
       </CardContent>
       <CardFooter>
-        <Button variant="outline" onClick={handleLogout} disabled={loggingOut}>
-          <LogOut className="mr-1 h-4 w-4" />
-          {loggingOut ? "ログアウト中…" : "ログアウト"}
+        <Button asChild className="min-h-12 w-full">
+          <Link href="/drill">
+            <ListChecks className="mr-1 h-4 w-4" />
+            Daily Drill を始める
+          </Link>
         </Button>
       </CardFooter>
+    </Card>
+  );
+}
+
+function ModeGrid() {
+  const modes: Array<{ href: string; icon: typeof ListChecks; label: string; desc: string }> = [
+    {
+      href: "/review",
+      icon: RotateCcw,
+      label: "Mistake Review",
+      desc: "直近の誤答を再挑戦",
+    },
+    {
+      href: "/custom",
+      icon: Wand2,
+      label: "Custom Session",
+      desc: "条件指定で自由に出題",
+    },
+  ];
+  return (
+    <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+      {modes.map((m) => {
+        const Icon = m.icon;
+        return (
+          <Link
+            key={m.href}
+            href={m.href}
+            className={cn(
+              "hover:bg-accent/40 flex items-center gap-3 rounded-lg border p-4 transition-colors",
+            )}
+          >
+            <Icon className="text-primary h-5 w-5 shrink-0" aria-hidden="true" />
+            <div className="min-w-0 flex-1">
+              <div className="font-medium">{m.label}</div>
+              <div className="text-muted-foreground text-xs">{m.desc}</div>
+            </div>
+            <ChevronRight className="text-muted-foreground h-4 w-4" aria-hidden="true" />
+          </Link>
+        );
+      })}
+    </div>
+  );
+}
+
+function DeepDiveSection() {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">Deep Dive</CardTitle>
+        <CardDescription>1 ドメインを prereqs 順・難易度昇順で 10-15 問</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
+          {TIER_1_DOMAIN_IDS.map((d) => (
+            <Button key={d} asChild variant="outline" className="justify-start">
+              <Link href={`/deep/${d}`}>{DOMAIN_LABELS[d]}</Link>
+            </Button>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function InsightsSection() {
+  const links: Array<{ href: string; icon: typeof BarChart3; label: string }> = [
+    { href: "/insights", icon: BarChart3, label: "Dashboard" },
+    { href: "/insights/history", icon: History, label: "History" },
+    { href: "/insights/search", icon: Search, label: "Search" },
+    { href: "/insights/map", icon: MapIcon, label: "Mastery Map" },
+    { href: "/insights/trends", icon: LineChart, label: "Trends" },
+  ];
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">Insights</CardTitle>
+        <CardDescription>学習の進捗と弱点の可視化</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
+          {links.map((l) => {
+            const Icon = l.icon;
+            return (
+              <Button key={l.href} asChild variant="ghost" className="justify-start">
+                <Link href={l.href}>
+                  <Icon className="mr-1 h-4 w-4" aria-hidden="true" />
+                  {l.label}
+                </Link>
+              </Button>
+            );
+          })}
+        </div>
+      </CardContent>
     </Card>
   );
 }

--- a/src/features/home/home-screen.tsx
+++ b/src/features/home/home-screen.tsx
@@ -146,11 +146,10 @@ function HomeHeader({
 
 function DailyDrillCard({ dailyGoal }: { dailyGoal: number }) {
   const progress = trpc.home.dailyProgress.useQuery();
-  const attemptCount = progress.data?.attemptCount ?? 0;
-  const ratio = dailyGoal > 0 ? Math.min(attemptCount / dailyGoal, 1) : 0;
-  // aria-valuenow は [0, dailyGoal] の範囲に clamp し、aria-valuetext で実数を補う
-  // (目標超過日でも ARIA 仕様上の valuemin/valuemax を逸脱しないため)。
-  const ariaValueNow = Math.min(attemptCount, dailyGoal);
+  // 成功時だけ確定値として表示する。loading / error 中はバー幅も aria も未確定扱いにして
+  // 「今日 0 問」と見分けがつくようにする (Codex Round 2 指摘)。
+  const attemptCount = progress.isSuccess ? progress.data.attemptCount : null;
+  const ratio = attemptCount !== null && dailyGoal > 0 ? Math.min(attemptCount / dailyGoal, 1) : 0;
   return (
     <Card>
       <CardHeader>
@@ -160,26 +159,37 @@ function DailyDrillCard({ dailyGoal }: { dailyGoal: number }) {
         <CardDescription>
           {progress.isError
             ? "今日の進捗を取得できませんでした"
-            : progress.isLoading
+            : attemptCount === null
               ? "進捗を読み込み中…"
               : `${attemptCount} / ${dailyGoal} 問 (JST 00:00 以降)`}
         </CardDescription>
       </CardHeader>
       <CardContent className="space-y-3">
-        <div
-          className="bg-secondary h-2 w-full overflow-hidden rounded-full"
-          role="progressbar"
-          aria-valuemin={0}
-          aria-valuemax={dailyGoal}
-          aria-valuenow={ariaValueNow}
-          aria-valuetext={`${attemptCount} / ${dailyGoal} 問`}
-          aria-label="今日の進捗"
-        >
+        {attemptCount !== null ? (
           <div
-            className="bg-primary h-full transition-[width]"
-            style={{ width: `${Math.round(ratio * 100)}%` }}
+            className="bg-secondary h-2 w-full overflow-hidden rounded-full"
+            role="progressbar"
+            aria-valuemin={0}
+            aria-valuemax={dailyGoal}
+            // aria-valuenow は [0, dailyGoal] に clamp し、実数は aria-valuetext で補う
+            // (目標超過日でも ARIA 仕様上の valuemin/valuemax を逸脱しないため)。
+            aria-valuenow={Math.min(attemptCount, dailyGoal)}
+            aria-valuetext={`${attemptCount} / ${dailyGoal} 問`}
+            aria-label="今日の進捗"
+          >
+            <div
+              className="bg-primary h-full transition-[width]"
+              style={{ width: `${Math.round(ratio * 100)}%` }}
+            />
+          </div>
+        ) : (
+          <div
+            className="bg-secondary h-2 w-full overflow-hidden rounded-full"
+            role="progressbar"
+            aria-label="今日の進捗"
+            aria-valuetext={progress.isError ? "取得失敗" : "読み込み中"}
           />
-        </div>
+        )}
       </CardContent>
       <CardFooter>
         <Button asChild className="min-h-12 w-full">

--- a/src/features/home/home-screen.tsx
+++ b/src/features/home/home-screen.tsx
@@ -148,6 +148,9 @@ function DailyDrillCard({ dailyGoal }: { dailyGoal: number }) {
   const progress = trpc.home.dailyProgress.useQuery();
   const attemptCount = progress.data?.attemptCount ?? 0;
   const ratio = dailyGoal > 0 ? Math.min(attemptCount / dailyGoal, 1) : 0;
+  // aria-valuenow は [0, dailyGoal] の範囲に clamp し、aria-valuetext で実数を補う
+  // (目標超過日でも ARIA 仕様上の valuemin/valuemax を逸脱しないため)。
+  const ariaValueNow = Math.min(attemptCount, dailyGoal);
   return (
     <Card>
       <CardHeader>
@@ -168,7 +171,8 @@ function DailyDrillCard({ dailyGoal }: { dailyGoal: number }) {
           role="progressbar"
           aria-valuemin={0}
           aria-valuemax={dailyGoal}
-          aria-valuenow={attemptCount}
+          aria-valuenow={ariaValueNow}
+          aria-valuetext={`${attemptCount} / ${dailyGoal} 問`}
           aria-label="今日の進捗"
         >
           <div

--- a/src/features/home/home-screen.tsx
+++ b/src/features/home/home-screen.tsx
@@ -132,11 +132,19 @@ function HomeHeader({
 }) {
   return (
     <div className="flex items-start justify-between gap-2">
-      <div>
-        <h1 className="text-lg font-semibold">ようこそ、{displayName}</h1>
-        <p className="text-muted-foreground text-xs">{email}</p>
+      {/* displayName / email は text カラムで長さ無制限。モバイルで右の
+          ログアウトボタンを押し出さないよう min-w-0 + truncate で抑える。 */}
+      <div className="min-w-0 flex-1">
+        <h1 className="truncate text-lg font-semibold">ようこそ、{displayName}</h1>
+        <p className="text-muted-foreground truncate text-xs">{email}</p>
       </div>
-      <Button variant="outline" size="sm" onClick={onLogout} disabled={loggingOut}>
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={onLogout}
+        disabled={loggingOut}
+        className="shrink-0"
+      >
         <LogOut className="mr-1 h-4 w-4" />
         {loggingOut ? "ログアウト中…" : "ログアウト"}
       </Button>

--- a/src/features/onboarding/onboarding-screen.tsx
+++ b/src/features/onboarding/onboarding-screen.tsx
@@ -14,9 +14,10 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { cn } from "@/lib/cn";
-import { TIER_1_DOMAIN_IDS, type DomainId, type Tier1DomainId } from "@/db/schema";
+import { TIER_1_DOMAIN_IDS, type Tier1DomainId } from "@/db/schema";
 import { DrillScreen } from "@/features/drill/drill-screen";
 import { useDrillStore } from "@/features/drill/drill-state";
+import { DOMAIN_LABELS } from "@/lib/domain-labels";
 import { trpc } from "@/lib/trpc/react";
 
 type Step =
@@ -42,22 +43,6 @@ const WELCOME_SLIDES: Array<{ icon: typeof Brain; title: string; body: string }>
     body: "次の数問で出発点を測ります。3〜5 分で終わります。",
   },
 ];
-
-const TIER_1_LABELS: Record<DomainId, string> = {
-  programming: "Programming",
-  dsa: "DSA",
-  os: "OS",
-  network: "Network",
-  db: "Database",
-  security: "Security",
-  distributed: "Distributed",
-  design: "Design",
-  devops: "DevOps",
-  tools: "Tools",
-  low_level: "Low-level",
-  ai_ml: "AI / ML",
-  frontend: "Frontend",
-};
 
 type SelfLevel = "beginner" | "junior" | "mid" | "senior";
 
@@ -208,7 +193,7 @@ export function OnboardingScreen() {
                         : "border-border hover:border-muted-foreground",
                     )}
                   >
-                    {TIER_1_LABELS[d]}
+                    {DOMAIN_LABELS[d]}
                   </button>
                 );
               })}

--- a/src/lib/domain-labels.ts
+++ b/src/lib/domain-labels.ts
@@ -1,0 +1,24 @@
+import type { DomainId } from "@/db/schema";
+
+/** ドメインの UI 表示名。13 ドメインすべてをカバーする。
+ *  複数画面 (Home / Deep Dive / Onboarding) で同じ表記を使い、表記ブレを防ぐ。
+ */
+export const DOMAIN_LABELS: Record<DomainId, string> = {
+  programming: "Programming",
+  dsa: "DSA",
+  os: "OS",
+  network: "Network",
+  db: "Database",
+  security: "Security",
+  distributed: "Distributed",
+  design: "Design",
+  devops: "DevOps",
+  tools: "Tools",
+  low_level: "Low-level",
+  ai_ml: "AI / ML",
+  frontend: "Frontend",
+};
+
+export function domainLabel(id: DomainId): string {
+  return DOMAIN_LABELS[id];
+}

--- a/src/lib/jst.test.ts
+++ b/src/lib/jst.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+
+import { jstPeriodBounds, jstStartOfToday } from "./jst";
+
+describe("jstStartOfToday", () => {
+  it("UTC の 14:59 (= JST 23:59) は同日 00:00 JST を指す", () => {
+    const now = new Date("2026-04-19T14:59:00Z");
+    expect(jstStartOfToday(now).toISOString()).toBe("2026-04-18T15:00:00.000Z");
+  });
+
+  it("UTC の 15:00 (= JST 00:00) は翌日 00:00 JST を指す", () => {
+    const now = new Date("2026-04-19T15:00:00Z");
+    expect(jstStartOfToday(now).toISOString()).toBe("2026-04-19T15:00:00.000Z");
+  });
+});
+
+describe("jstPeriodBounds", () => {
+  it("weekAgo は today から JST 換算で 6 日前 (= 今日を含む直近 7 日)", () => {
+    const now = new Date("2026-04-19T03:00:00Z");
+    const { today, weekAgo } = jstPeriodBounds(now);
+    expect(today.toISOString()).toBe("2026-04-18T15:00:00.000Z");
+    expect(weekAgo.toISOString()).toBe("2026-04-12T15:00:00.000Z");
+  });
+});

--- a/src/lib/jst.ts
+++ b/src/lib/jst.ts
@@ -1,0 +1,26 @@
+/** Asia/Tokyo (JST, UTC+9) 固定の日付境界ヘルパ。
+ *  MVP: 個人用 / 日本語 UI なので timezone 切替は未サポート。
+ *  Home の「今日の進捗」と Insights History の「今日/直近 7 日」が同じ基準で
+ *  切り替わるように、境界計算はここに一本化する。
+ */
+
+const JST_OFFSET_MS = 9 * 60 * 60 * 1000;
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/** 今日 00:00 JST を UTC Date として返す。 */
+export function jstStartOfToday(now: Date = new Date()): Date {
+  const nowJstMs = now.getTime() + JST_OFFSET_MS;
+  const startOfTodayJstMs = Math.floor(nowJstMs / DAY_MS) * DAY_MS;
+  return new Date(startOfTodayJstMs - JST_OFFSET_MS);
+}
+
+/** Insights History で使う「今日 / 直近 7 日」境界。
+ *  weekAgo は今日も含めて 7 日になるように今日 00:00 JST から 6 日前。
+ */
+export function jstPeriodBounds(now: Date = new Date()): { today: Date; weekAgo: Date } {
+  const today = jstStartOfToday(now);
+  return {
+    today,
+    weekAgo: new Date(today.getTime() - 6 * DAY_MS),
+  };
+}

--- a/src/server/home/daily-progress.test.ts
+++ b/src/server/home/daily-progress.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { fetchDailyProgress, jstStartOfToday } from "./daily-progress";
+import { fetchDailyProgress } from "./daily-progress";
 
 const queue: Array<() => unknown> = [];
 vi.mock("@/db/client", () => {
@@ -21,18 +21,6 @@ vi.mock("@/db/client", () => {
 
 beforeEach(() => {
   queue.length = 0;
-});
-
-describe("jstStartOfToday", () => {
-  it("UTC の 14:59 (= JST 23:59) は同日 00:00 JST を指す", () => {
-    const now = new Date("2026-04-19T14:59:00Z");
-    expect(jstStartOfToday(now).toISOString()).toBe("2026-04-18T15:00:00.000Z");
-  });
-
-  it("UTC の 15:00 (= JST 00:00) は翌日 00:00 JST を指す", () => {
-    const now = new Date("2026-04-19T15:00:00Z");
-    expect(jstStartOfToday(now).toISOString()).toBe("2026-04-19T15:00:00.000Z");
-  });
 });
 
 describe("fetchDailyProgress", () => {

--- a/src/server/home/daily-progress.test.ts
+++ b/src/server/home/daily-progress.test.ts
@@ -1,0 +1,50 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { fetchDailyProgress, jstStartOfToday } from "./daily-progress";
+
+const queue: Array<() => unknown> = [];
+vi.mock("@/db/client", () => {
+  function makeBuilder(): unknown {
+    const b: Record<string, unknown> = {
+      from: () => b,
+      where: () => b,
+      then: (onFulfilled: (v: unknown) => unknown) => {
+        const handler = queue.shift();
+        const result = handler ? handler() : [];
+        return Promise.resolve(result).then(onFulfilled);
+      },
+    };
+    return b;
+  }
+  return { getDb: () => ({ select: () => makeBuilder() }) };
+});
+
+beforeEach(() => {
+  queue.length = 0;
+});
+
+describe("jstStartOfToday", () => {
+  it("UTC の 14:59 (= JST 23:59) は同日 00:00 JST を指す", () => {
+    const now = new Date("2026-04-19T14:59:00Z");
+    expect(jstStartOfToday(now).toISOString()).toBe("2026-04-18T15:00:00.000Z");
+  });
+
+  it("UTC の 15:00 (= JST 00:00) は翌日 00:00 JST を指す", () => {
+    const now = new Date("2026-04-19T15:00:00Z");
+    expect(jstStartOfToday(now).toISOString()).toBe("2026-04-19T15:00:00.000Z");
+  });
+});
+
+describe("fetchDailyProgress", () => {
+  it("count クエリ結果を attemptCount に反映する", async () => {
+    queue.push(() => [{ count: 7 }]);
+    const res = await fetchDailyProgress({ userId: "user-1" });
+    expect(res.attemptCount).toBe(7);
+  });
+
+  it("0 件は 0 を返す (空配列でも null でも安全)", async () => {
+    queue.push(() => []);
+    const res = await fetchDailyProgress({ userId: "user-1" });
+    expect(res.attemptCount).toBe(0);
+  });
+});

--- a/src/server/home/daily-progress.ts
+++ b/src/server/home/daily-progress.ts
@@ -4,21 +4,12 @@ import { and, eq, gte, sql } from "drizzle-orm";
 
 import { getDb } from "@/db/client";
 import { attempts } from "@/db/schema";
+import { jstStartOfToday } from "@/lib/jst";
 
 export type DailyProgress = {
   /** JST 00:00 以降のその user の attempt 件数 */
   attemptCount: number;
 };
-
-/** Asia/Tokyo (JST, UTC+9) 固定で「今日の 00:00 (UTC 換算)」を返す。
- *  insights/history.ts の jstPeriodBounds と同じ基準で日付切り替えを揃えるための共有境界。
- */
-export function jstStartOfToday(now: Date = new Date()): Date {
-  const nowJstMs = now.getTime() + 9 * 60 * 60 * 1000;
-  const dayMs = 24 * 60 * 60 * 1000;
-  const jstStartOfTodayMs = Math.floor(nowJstMs / dayMs) * dayMs;
-  return new Date(jstStartOfTodayMs - 9 * 60 * 60 * 1000);
-}
 
 /** ホーム画面の「今日の進捗 (N/dailyGoal 問)」表示用の軽量クエリ。
  *  attempts を COUNT するだけで、history の pagination ルートは使わない

--- a/src/server/home/daily-progress.ts
+++ b/src/server/home/daily-progress.ts
@@ -1,0 +1,38 @@
+import "server-only";
+
+import { and, eq, gte, sql } from "drizzle-orm";
+
+import { getDb } from "@/db/client";
+import { attempts } from "@/db/schema";
+
+export type DailyProgress = {
+  /** JST 00:00 以降のその user の attempt 件数 */
+  attemptCount: number;
+};
+
+/** Asia/Tokyo (JST, UTC+9) 固定で「今日の 00:00 (UTC 換算)」を返す。
+ *  insights/history.ts の jstPeriodBounds と同じ基準で日付切り替えを揃えるための共有境界。
+ */
+export function jstStartOfToday(now: Date = new Date()): Date {
+  const nowJstMs = now.getTime() + 9 * 60 * 60 * 1000;
+  const dayMs = 24 * 60 * 60 * 1000;
+  const jstStartOfTodayMs = Math.floor(nowJstMs / dayMs) * dayMs;
+  return new Date(jstStartOfTodayMs - 9 * 60 * 60 * 1000);
+}
+
+/** ホーム画面の「今日の進捗 (N/dailyGoal 問)」表示用の軽量クエリ。
+ *  attempts を COUNT するだけで、history の pagination ルートは使わない
+ *  (毎回全件フェッチしないため)。
+ */
+export async function fetchDailyProgress(params: {
+  userId: string;
+  now?: Date;
+}): Promise<DailyProgress> {
+  const since = jstStartOfToday(params.now);
+  const rows = await getDb()
+    .select({ count: sql<number>`count(*)::int`.as("count") })
+    .from(attempts)
+    .where(and(eq(attempts.userId, params.userId), gte(attempts.createdAt, since)));
+  const count = rows[0]?.count ?? 0;
+  return { attemptCount: count };
+}

--- a/src/server/insights/history.ts
+++ b/src/server/insights/history.ts
@@ -3,6 +3,7 @@ import { and, desc, eq, gte, inArray, isNull, lt, or, type SQL } from "drizzle-o
 import { getDb } from "@/db/client";
 import { attempts, concepts, questions } from "@/db/schema";
 import type { DomainId } from "@/db/schema/_constants";
+import { jstPeriodBounds } from "@/lib/jst";
 
 export type HistoryFilter = {
   /** 'all' | 'today' | 'week' */
@@ -19,18 +20,6 @@ export type HistoryFilter = {
 /** 部分正解の閾値: score >= PARTIAL_MIN & < FULL_MIN を「部分正解」とする */
 const PARTIAL_MIN_SCORE = 0.3;
 const FULL_MIN_SCORE = 0.9;
-
-/** Asia/Tokyo (JST, UTC+9) 固定で今日の 00:00 と直近 7 日境界を返す (MVP: 個人用 / 日本語 UI) */
-function jstPeriodBounds(now: Date = new Date()): { today: Date; weekAgo: Date } {
-  const nowJstMs = now.getTime() + 9 * 60 * 60 * 1000;
-  const dayMs = 24 * 60 * 60 * 1000;
-  const jstStartOfTodayMs = Math.floor(nowJstMs / dayMs) * dayMs;
-  const todayUtcMs = jstStartOfTodayMs - 9 * 60 * 60 * 1000;
-  return {
-    today: new Date(todayUtcMs),
-    weekAgo: new Date(todayUtcMs - 6 * dayMs),
-  };
-}
 
 export type HistoryItem = {
   attemptId: string;

--- a/src/server/trpc/routers/home.ts
+++ b/src/server/trpc/routers/home.ts
@@ -1,0 +1,8 @@
+import { fetchDailyProgress } from "@/server/home/daily-progress";
+
+import { protectedProcedure, router } from "../init";
+
+export const homeRouter = router({
+  /** ホーム画面の「今日の進捗」(JST 00:00 以降の attempts 件数) を返す。 */
+  dailyProgress: protectedProcedure.query(({ ctx }) => fetchDailyProgress({ userId: ctx.user.id })),
+});

--- a/src/server/trpc/routers/index.ts
+++ b/src/server/trpc/routers/index.ts
@@ -3,6 +3,7 @@ import { attemptsRouter } from "./attempts";
 import { authRouter } from "./auth";
 import { codeRouter } from "./code";
 import { customRouter } from "./custom";
+import { homeRouter } from "./home";
 import { insightsRouter } from "./insights";
 import { onboardingRouter } from "./onboarding";
 import { pingRouter } from "./ping";
@@ -15,6 +16,7 @@ export const appRouter = router({
   attempts: attemptsRouter,
   code: codeRouter,
   custom: customRouter,
+  home: homeRouter,
   insights: insightsRouter,
   onboarding: onboardingRouter,
   questions: questionsRouter,


### PR DESCRIPTION
## 概要

Phase 0 bootstrap のままだったホーム画面 (`src/features/home/home-screen.tsx`) を作り直し、実装済み機能への導線を追加する。URL 直打ちでしか辿れなかった各画面にホームからアクセスできるようにする。

closes #77

## 関連ドキュメント
- `docs/07-ux-and-pwa.md` §7.2.1 (Home 画面 spec)
- `docs/08-mvp-roadmap.md`

## 変更点

- **HomeScreen 再構成** (`src/features/home/home-screen.tsx`)
  - ヘッダ: ようこそ表示 + ログアウトボタン
  - 今日の進捗カード: `N / dailyGoal 問` の Daily Drill CTA (progress bar + `/drill` リンク)
  - モードグリッド: `/review` (Mistake Review) / `/custom` (Custom Session)
  - Deep Dive セクション: Tier 1 の 6 ドメインボタン (`/deep/[domain]`)
  - Insights セクション: Dashboard / History / Search / Mastery Map / Trends の 5 リンク
- **`home.dailyProgress` tRPC クエリ追加**
  - `src/server/home/daily-progress.ts` に JST 00:00 基準の軽量 COUNT クエリを実装 (history の pagination ルートは使わない)
  - `src/server/home/daily-progress.test.ts` に JST 境界 / 件数集計の unit test を追加
  - `src/server/trpc/routers/home.ts` + `routers/index.ts` に登録
- **`DOMAIN_LABELS` を共有ヘルパに集約**
  - `src/lib/domain-labels.ts` を新規作成
  - `src/features/deep-dive/deep-dive-screen.tsx` と `src/features/onboarding/onboarding-screen.tsx` の重複定義を削除して参照に置き換え
- **`src/app/page.tsx`**: 中央縦寄せのレイアウトを、スクロール可能な上寄せレイアウトに変更 (`max-w-2xl` の HomeScreen に合わせて)

## チェックリスト

- [x] `docs/` を必要に応じて更新した (挙動が変わったのに docs が古いまま、を避ける) — §7.2.1 の spec は元から「今日の復習 + モードカード + Insights 導線」で、実装はそれに沿っている
- [x] 方針が変わったら `docs/adrs/` に ADR を追加した — 該当なし (既存方針の実装のみ)
- [x] `OPEN_QUESTIONS.md` に該当項目があれば決着 or 更新した — 該当なし
- [x] テストを追加・更新した (該当する場合) — `daily-progress.test.ts` 4 ケース
- [x] `pnpm typecheck` / `pnpm lint` / `pnpm test` がローカルで通る
- [x] スコープが MVP 範囲内 (`docs/08-mvp-roadmap.md` の Out リストに触れていない)
- [x] 秘密情報 (`.env.local`, API key, トークン) を含めていない

## 動作確認

- [ ] `/` にアクセスし、ヘッダ / 今日の進捗 / モードグリッド / Deep Dive / Insights の各セクションが表示される
- [ ] 「Daily Drill を始める」ボタンから `/drill` に遷移する
- [ ] Mistake Review / Custom Session リンクが各画面に遷移する
- [ ] Deep Dive の各ドメインボタンが `/deep/[domain]` に遷移する
- [ ] Insights の 5 リンクがそれぞれの画面に遷移する
- [ ] モバイル幅 (〜640px) で崩れない / BottomNav と重ならない
- [ ] `onboardingCompletedAt` 未完了の user は `/onboarding` にリダイレクトされる
- [ ] ログアウトボタンが動く

## メモ

- 元仕様 (`docs/07-ux-and-pwa.md` §7.2.1) は「3 モードカード (Deep Dive / Custom / Review)」だが、Deep Dive はドメイン選択 (6 ボタン) を伴うため 1 セクションに分離し、Review / Custom を横並びの 2 カードにした
- 「マスタリー全体値」は本 PR では出していない (`home.dailyProgress` のみ追加)。必要になれば `insights.overview.masteryPct` を使う別 PR で追加する想定
- ゲーミフィケーション要素 (streak / バッジ / ポイント) は含めていない