### PR TITLE
feat(notify): Weekly Digest メール配信 (Resend + Vercel Cron、#36)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,9 +43,13 @@ SENTRY_PROJECT=
 # Phase 3+ で追加
 # ──────────────────────────────────────────
 
-# --- Resend (メール通知) ---
+# --- Resend (メール通知、Weekly Digest issue #36) ---
+# 未設定なら /api/cron/weekly-digest は 501 で no-op
 # RESEND_API_KEY=
 # RESEND_FROM_EMAIL=tanren@example.com
+# Vercel Cron が /api/cron/* を叩く際の Authorization: Bearer ヘッダ
+# 未設定なら誰でも叩ける (本番では必須)
+# CRON_SECRET=
 
 # ──────────────────────────────────────────
 # Phase 5+ で追加 (公開時 / 並列ユーザー発生時)

--- a/drizzle/0012_weekly_digest_enabled.sql
+++ b/drizzle/0012_weekly_digest_enabled.sql
@@ -1,0 +1,3 @@
+-- issue #36: Weekly Digest on/off の opt-out フラグを追加 (デフォルト true)
+ALTER TABLE "users"
+  ADD COLUMN "weekly_digest_enabled" boolean NOT NULL DEFAULT true;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -85,6 +85,13 @@
       "when": 1776499000000,
       "tag": "0011_attempts_dialogue",
       "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "7",
+      "when": 1776500000000,
+      "tag": "0012_weekly_digest_enabled",
+      "breakpoints": true
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "openai": "^6.34.0",
     "react": "19.2.4",
     "react-dom": "19.2.4",
+    "resend": "^6.12.0",
     "server-only": "^0.0.1",
     "tailwind-merge": "^3.5.0",
     "ts-fsrs": "^5.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,6 +68,9 @@ importers:
       react-dom:
         specifier: 19.2.4
         version: 19.2.4(react@19.2.4)
+      resend:
+        specifier: ^6.12.0
+        version: 6.12.0
       server-only:
         specifier: ^0.0.1
         version: 0.0.1
@@ -1656,6 +1659,9 @@ packages:
     resolution: {integrity: sha512-MLHYFrYG8/wK2i+86XMhiecK72nMaHKKt4bo+7Q1TbuG9iGjlSdfkPWKO5ZFE/BX+ygCJ7pr8H/AJeyAj1EaTQ==}
     engines: {node: '>=20.0.0'}
 
+  '@stablelib/base64@1.0.1':
+    resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
+
   '@standard-schema/spec@1.0.0':
     resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
 
@@ -2761,6 +2767,9 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
+  fast-sha256@1.3.0:
+    resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
+
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
 
@@ -3520,6 +3529,9 @@ packages:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
 
+  postal-mime@2.7.4:
+    resolution: {integrity: sha512-0WdnFQYUrPGGTFu1uOqD2s7omwua8xaeYGdO6rb88oD5yJ/4pPHDA4sdWqfD8wQVfCny563n/HQS7zTFft+f/g==}
+
   postcss@8.4.31:
     resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
     engines: {node: ^10 || ^12 || >=14}
@@ -3670,6 +3682,15 @@ packages:
     resolution: {integrity: sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==}
     engines: {node: '>=9.3.0 || >=8.10.0 <9.0.0'}
 
+  resend@6.12.0:
+    resolution: {integrity: sha512-CaxEvX1z+/MGbgnhsM/bvmkbnZd1v1sEXELAjBNSDBQNMaB7MgqOyrBgI27CYikEgdaDnBrXghAXYWTBs/h5Bw==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@react-email/render': '*'
+    peerDependenciesMeta:
+      '@react-email/render':
+        optional: true
+
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
@@ -3794,6 +3815,9 @@ packages:
     resolution: {integrity: sha512-WjlahMgHmCJpqzU8bIBy4qtsZdU9lRlcZE3Lvyej6t4tuOuv1vk57OW3MBrj6hXBFx/nNoC9MPMTcr5YA7NQbg==}
     engines: {node: '>=6'}
 
+  standardwebhooks@1.0.0:
+    resolution: {integrity: sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==}
+
   std-env@4.1.0:
     resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
@@ -3856,6 +3880,9 @@ packages:
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
+
+  svix@1.90.0:
+    resolution: {integrity: sha512-ljkZuyy2+IBEoESkIpn8sLM+sxJHQcPxlZFxU+nVDhltNfUMisMBzWX/UR8SjEnzoI28ZjCzMbmYAPwSTucoMw==}
 
   tailwind-merge@3.5.0:
     resolution: {integrity: sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A==}
@@ -3992,6 +4019,10 @@ packages:
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  uuid@10.0.0:
+    resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
+    hasBin: true
 
   vite@8.0.8:
     resolution: {integrity: sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==}
@@ -5526,6 +5557,8 @@ snapshots:
       '@peculiar/asn1-x509': 2.6.1
       '@peculiar/x509': 1.14.3
 
+  '@stablelib/base64@1.0.1': {}
+
   '@standard-schema/spec@1.0.0': {}
 
   '@standard-schema/spec@1.1.0': {}
@@ -6778,6 +6811,8 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
+  fast-sha256@1.3.0: {}
+
   fast-uri@3.1.0: {}
 
   fastq@1.20.1:
@@ -7475,6 +7510,8 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
+  postal-mime@2.7.4: {}
+
   postcss@8.4.31:
     dependencies:
       nanoid: 3.3.11
@@ -7572,6 +7609,11 @@ snapshots:
       module-details-from-path: 1.0.4
     transitivePeerDependencies:
       - supports-color
+
+  resend@6.12.0:
+    dependencies:
+      postal-mime: 2.7.4
+      svix: 1.90.0
 
   resolve-from@4.0.0: {}
 
@@ -7785,6 +7827,11 @@ snapshots:
     dependencies:
       type-fest: 0.7.1
 
+  standardwebhooks@1.0.0:
+    dependencies:
+      '@stablelib/base64': 1.0.1
+      fast-sha256: 1.3.0
+
   std-env@4.1.0: {}
 
   stop-iteration-iterator@1.1.0:
@@ -7862,6 +7909,11 @@ snapshots:
       has-flag: 4.0.0
 
   supports-preserve-symlinks-flag@1.0.0: {}
+
+  svix@1.90.0:
+    dependencies:
+      standardwebhooks: 1.0.0
+      uuid: 10.0.0
 
   tailwind-merge@3.5.0: {}
 
@@ -8025,6 +8077,8 @@ snapshots:
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
+
+  uuid@10.0.0: {}
 
   vite@8.0.8(@types/node@20.19.39)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:

--- a/src/app/api/cron/weekly-digest/route.ts
+++ b/src/app/api/cron/weekly-digest/route.ts
@@ -1,0 +1,60 @@
+import { NextResponse } from "next/server";
+
+import { getResend, resendFromEmail } from "@/lib/email/resend-client";
+import { collectWeeklyDigestTargets, renderDigestHtml } from "@/server/digest/weekly-digest";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * Weekly Digest cron エンドポイント (issue #36)。
+ * Vercel Cron で日曜 09:00 JST = 00:00 UTC に叩く想定 (vercel.ts 側で schedule 設定)。
+ *
+ * セキュリティ:
+ *   - Vercel Cron は同プロジェクトから呼ばれる際 `Authorization: Bearer ${CRON_SECRET}`
+ *     を付けるので、未設定 / 不一致なら 401。外部からの re-trigger を防ぐ。
+ *   - RESEND_API_KEY / RESEND_FROM_EMAIL 未設定なら 501 (メール送信無効)。
+ *
+ * 戻り値: { sent: number, skipped: number, errors: Array<{userId, error}> }
+ */
+export async function GET(req: Request) {
+  const cronSecret = process.env.CRON_SECRET;
+  if (cronSecret) {
+    const auth = req.headers.get("authorization");
+    if (auth !== `Bearer ${cronSecret}`) {
+      return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+    }
+  }
+
+  const resend = getResend();
+  const from = resendFromEmail();
+  if (!resend || !from) {
+    return NextResponse.json(
+      { error: "RESEND_API_KEY / RESEND_FROM_EMAIL が未設定" },
+      { status: 501 },
+    );
+  }
+
+  const targets = await collectWeeklyDigestTargets();
+  const errors: Array<{ userId: string; error: string }> = [];
+  let sent = 0;
+  let skipped = 0;
+  for (const t of targets) {
+    // 先週 0 問のユーザーには送らない (空の digest は逆効果)
+    if (t.attemptCount === 0) {
+      skipped += 1;
+      continue;
+    }
+    try {
+      await resend.emails.send({
+        from,
+        to: t.email,
+        subject: "Tanren Weekly Digest",
+        html: renderDigestHtml(t),
+      });
+      sent += 1;
+    } catch (err) {
+      errors.push({ userId: t.userId, error: err instanceof Error ? err.message : String(err) });
+    }
+  }
+  return NextResponse.json({ sent, skipped, errors });
+}

--- a/src/app/api/cron/weekly-digest/route.ts
+++ b/src/app/api/cron/weekly-digest/route.ts
@@ -17,12 +17,16 @@ export const dynamic = "force-dynamic";
  * 戻り値: { sent: number, skipped: number, errors: Array<{userId, error}> }
  */
 export async function GET(req: Request) {
+  // CRON_SECRET 認可。
+  // - production: 必ず設定されていないと 500 (fail-closed、Codex Round 1 指摘 C)
+  // - preview / dev: 未設定ならスキップ (ローカル動作を楽にする)
   const cronSecret = process.env.CRON_SECRET;
-  if (cronSecret) {
-    const auth = req.headers.get("authorization");
-    if (auth !== `Bearer ${cronSecret}`) {
-      return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  if (!cronSecret) {
+    if (process.env.VERCEL_ENV === "production") {
+      return NextResponse.json({ error: "CRON_SECRET not configured" }, { status: 500 });
     }
+  } else if (req.headers.get("authorization") !== `Bearer ${cronSecret}`) {
+    return NextResponse.json({ error: "unauthorized" }, { status: 401 });
   }
 
   const resend = getResend();

--- a/src/app/api/cron/weekly-digest/route.ts
+++ b/src/app/api/cron/weekly-digest/route.ts
@@ -49,13 +49,19 @@ export async function GET(req: Request) {
       continue;
     }
     try {
-      await resend.emails.send({
+      // Resend SDK は API エラー時に throw せず { data, error } を返すことがあるので、
+      // error を明示的に受け取って判定する (Codex Round 2 指摘 #1)。
+      const result = await resend.emails.send({
         from,
         to: t.email,
         subject: "Tanren Weekly Digest",
         html: renderDigestHtml(t),
       });
-      sent += 1;
+      if (result.error) {
+        errors.push({ userId: t.userId, error: result.error.message ?? String(result.error) });
+      } else {
+        sent += 1;
+      }
     } catch (err) {
       errors.push({ userId: t.userId, error: err instanceof Error ? err.message : String(err) });
     }

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1,0 +1,17 @@
+import { redirect } from "next/navigation";
+
+import { SettingsScreen } from "@/features/settings/settings-screen";
+import { getCurrentUser } from "@/server/auth/session";
+
+export const dynamic = "force-dynamic";
+
+export default async function SettingsPage() {
+  const user = await getCurrentUser();
+  if (!user) redirect("/login");
+  if (!user.onboardingCompletedAt) redirect("/onboarding");
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center gap-6 p-6">
+      <SettingsScreen />
+    </main>
+  );
+}

--- a/src/db/schema/users.ts
+++ b/src/db/schema/users.ts
@@ -1,5 +1,5 @@
 import { sql } from "drizzle-orm";
-import { integer, jsonb, pgTable, text, timestamp } from "drizzle-orm/pg-core";
+import { boolean, integer, jsonb, pgTable, text, timestamp } from "drizzle-orm/pg-core";
 
 import type { DifficultyLevel, DomainId } from "./_constants";
 
@@ -21,6 +21,8 @@ export const users = pgTable("users", {
     .default(sql`'[]'::jsonb`),
   /** オンボーディングでの自己申告レベル */
   selfLevel: text("self_level").$type<DifficultyLevel>(),
+  /** Weekly Digest メール (issue #36) の送信を受け取るか。デフォルト true (opt-out 方式) */
+  weeklyDigestEnabled: boolean("weekly_digest_enabled").notNull().default(true),
   createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
 });
 

--- a/src/features/settings/settings-screen.tsx
+++ b/src/features/settings/settings-screen.tsx
@@ -13,9 +13,12 @@ export function SettingsScreen() {
   const utils = trpc.useUtils();
   const [error, setError] = useState<string | null>(null);
 
-  const enabled = settings.data?.weeklyDigestEnabled ?? true;
+  // 取得失敗 / ロード中は null を区別、誤操作を防ぐ (Codex Round 2 指摘 #2)
+  const enabled = settings.data?.weeklyDigestEnabled ?? null;
+  const canToggle = enabled !== null && !settings.isError;
 
   async function onToggle() {
+    if (enabled === null) return;
     setError(null);
     try {
       await setWeekly.mutateAsync({ enabled: !enabled });
@@ -42,15 +45,20 @@ export function SettingsScreen() {
             </div>
           </div>
           <Button
-            variant={enabled ? "default" : "outline"}
+            variant={enabled === true ? "default" : "outline"}
             size="sm"
             onClick={onToggle}
-            disabled={settings.isLoading || setWeekly.isPending}
-            aria-pressed={enabled}
+            disabled={!canToggle || setWeekly.isPending}
+            aria-pressed={enabled === true}
           >
-            {enabled ? "ON" : "OFF"}
+            {settings.isLoading ? "…" : enabled === true ? "ON" : "OFF"}
           </Button>
         </div>
+        {settings.isError && (
+          <p className="text-destructive text-xs">
+            設定の読み込みに失敗しました: {settings.error.message}
+          </p>
+        )}
         {error && <p className="text-destructive text-xs">{error}</p>}
       </CardContent>
     </Card>

--- a/src/features/settings/settings-screen.tsx
+++ b/src/features/settings/settings-screen.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { Mail } from "lucide-react";
+import { useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { trpc } from "@/lib/trpc/react";
+
+export function SettingsScreen() {
+  const settings = trpc.settings.get.useQuery();
+  const setWeekly = trpc.settings.setWeeklyDigestEnabled.useMutation();
+  const utils = trpc.useUtils();
+  const [error, setError] = useState<string | null>(null);
+
+  const enabled = settings.data?.weeklyDigestEnabled ?? true;
+
+  async function onToggle() {
+    setError(null);
+    try {
+      await setWeekly.mutateAsync({ enabled: !enabled });
+      await utils.settings.get.invalidate();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "設定の更新に失敗しました");
+    }
+  }
+
+  return (
+    <Card className="w-full max-w-md">
+      <CardHeader>
+        <CardTitle>設定</CardTitle>
+        <CardDescription>通知とアカウント</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4 text-sm">
+        <div className="flex items-center justify-between gap-3">
+          <div>
+            <div className="flex items-center gap-2 font-medium">
+              <Mail className="h-4 w-4" /> Weekly Digest
+            </div>
+            <div className="text-muted-foreground text-xs">
+              毎週日曜 09:00 JST に先週の学習サマリをメール配信 (issue #36)
+            </div>
+          </div>
+          <Button
+            variant={enabled ? "default" : "outline"}
+            size="sm"
+            onClick={onToggle}
+            disabled={settings.isLoading || setWeekly.isPending}
+            aria-pressed={enabled}
+          >
+            {enabled ? "ON" : "OFF"}
+          </Button>
+        </div>
+        {error && <p className="text-destructive text-xs">{error}</p>}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/lib/email/resend-client.ts
+++ b/src/lib/email/resend-client.ts
@@ -1,0 +1,20 @@
+import "server-only";
+
+import { Resend } from "resend";
+
+/** Resend クライアントのシングルトン (issue #36)。
+ *  RESEND_API_KEY 未設定なら null (メール送信は no-op)。
+ */
+let cached: Resend | null | undefined;
+
+export function getResend(): Resend | null {
+  if (cached !== undefined) return cached;
+  const key = process.env.RESEND_API_KEY;
+  cached = key ? new Resend(key) : null;
+  return cached;
+}
+
+/** `from` アドレス (RESEND_FROM_EMAIL 未設定なら null = 送信不可) */
+export function resendFromEmail(): string | null {
+  return process.env.RESEND_FROM_EMAIL ?? null;
+}

--- a/src/server/digest/weekly-digest.test.ts
+++ b/src/server/digest/weekly-digest.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+
+import { renderDigestHtml, type DigestMetrics } from "./weekly-digest";
+
+function metrics(over: Partial<DigestMetrics> = {}): DigestMetrics {
+  return {
+    userId: "u-1",
+    email: "x@y.z",
+    displayName: "Kanato",
+    attemptCount: 12,
+    correctCount: 9,
+    studyTimeMin: 45.2,
+    conceptsTouched: 5,
+    ...over,
+  };
+}
+
+describe("renderDigestHtml", () => {
+  it("displayName / 出題数 / 正答率 / 学習時間 / concept 数を含む", () => {
+    const html = renderDigestHtml(metrics());
+    expect(html).toMatch(/Kanato/);
+    expect(html).toMatch(/12 問/);
+    expect(html).toMatch(/75%/); // 9/12
+    expect(html).toMatch(/45\.2 分/);
+    expect(html).toMatch(/<strong>5<\/strong>/);
+  });
+
+  it("attemptCount=0 のときは accuracy '-' を表示", () => {
+    const html = renderDigestHtml(metrics({ attemptCount: 0, correctCount: 0 }));
+    expect(html).toMatch(/<td>正答率<\/td><td><strong>-<\/strong>/);
+  });
+
+  it("displayName が null の時は email で代替", () => {
+    const html = renderDigestHtml(metrics({ displayName: null }));
+    expect(html).toMatch(/x@y\.z/);
+  });
+
+  it("HTML エスケープ: <script> などを &lt; に", () => {
+    const html = renderDigestHtml(metrics({ displayName: "<script>alert(1)</script>" }));
+    expect(html).not.toMatch(/<script>/);
+    expect(html).toMatch(/&lt;script&gt;/);
+  });
+});

--- a/src/server/digest/weekly-digest.ts
+++ b/src/server/digest/weekly-digest.ts
@@ -4,6 +4,7 @@ import { and, eq, gte, sql } from "drizzle-orm";
 
 import { getDb } from "@/db/client";
 import { attempts, sessionsAuth, users } from "@/db/schema";
+import { appUrl } from "@/lib/env";
 
 // sessionsAuth は直接 JOIN で引くと 1 user × N デバイスの fan-out で
 // attempt 集計が N 倍に水増しされる (Codex Round 1 指摘 A)。
@@ -99,7 +100,7 @@ export function renderDigestHtml(m: DigestMetrics): string {
       </tbody>
     </table>
     <p style="margin-top:16px;">
-      <a href="${escapeHtml(process.env.NEXT_PUBLIC_APP_URL ?? "https://tanren.vercel.app")}/insights/trends">Trends で詳細を見る →</a>
+      <a href="${escapeHtml(appUrl)}/insights/trends">Trends で詳細を見る →</a>
     </p>
     <p style="color:#64748b; font-size:12px; margin-top:24px;">
       このメールを止めるには設定画面から「Weekly Digest」を OFF にしてください。

--- a/src/server/digest/weekly-digest.ts
+++ b/src/server/digest/weekly-digest.ts
@@ -1,0 +1,118 @@
+import "server-only";
+
+import { and, eq, gte, sql } from "drizzle-orm";
+
+import { getDb } from "@/db/client";
+import { attempts, sessionsAuth, users } from "@/db/schema";
+
+/** Weekly Digest 対象者の条件 (issue #36):
+ *  - onboarding 完了済み
+ *  - 直近 14 日以内にログイン活動あり (= sessions_auth に lastActiveAt >= now - 14d が存在)
+ *  未ログイン 2 週間以上のユーザーには送らない (受け入れ基準)。
+ */
+const INACTIVE_DAYS_THRESHOLD = 14;
+export const WEEKLY_WINDOW_DAYS = 7;
+
+export type DigestMetrics = {
+  userId: string;
+  email: string;
+  displayName: string | null;
+  /** 直近 1 週間の attempt 数 */
+  attemptCount: number;
+  /** 直近 1 週間の正答数 */
+  correctCount: number;
+  /** 直近 1 週間の学習時間 (分、elapsedMs 合計を 60000 で割って小数 1 桁丸め) */
+  studyTimeMin: number;
+  /** 直近 1 週間で扱った concept のユニーク数 */
+  conceptsTouched: number;
+};
+
+/** 送信対象ユーザー + 先週の集計を返す (issue #36) */
+export async function collectWeeklyDigestTargets(now: Date = new Date()): Promise<DigestMetrics[]> {
+  const db = getDb();
+  const activeSince = new Date(now.getTime() - INACTIVE_DAYS_THRESHOLD * 24 * 60 * 60 * 1000);
+  const windowStart = new Date(now.getTime() - WEEKLY_WINDOW_DAYS * 24 * 60 * 60 * 1000);
+
+  // 2 週間以内にログインしたユーザー (sessionsAuth.lastActiveAt で近似) のみ対象。
+  // JOIN で絞るのは集計コストを下げるため。
+  const rows = await db
+    .select({
+      userId: users.id,
+      email: users.email,
+      displayName: users.displayName,
+      attemptCount: sql<number>`count(${attempts.id})::int`.as("attempt_count"),
+      correctCount:
+        sql<number>`sum(case when ${attempts.correct} = true then 1 else 0 end)::int`.as(
+          "correct_count",
+        ),
+      studyTimeMs: sql<number>`coalesce(sum(${attempts.elapsedMs}), 0)::bigint`.as("study_time_ms"),
+      conceptsTouched: sql<number>`count(distinct ${attempts.conceptId})::int`.as(
+        "concepts_touched",
+      ),
+    })
+    .from(users)
+    .innerJoin(sessionsAuth, eq(sessionsAuth.userId, users.id))
+    // attempts は LEFT JOIN で、先週 attempt 0 件のユーザーも対象に含める判定余地を残す。
+    // 実際の判定は呼び出し側 (attemptCount >= 1 なら送る 等) に委ねる。
+    .leftJoin(attempts, and(eq(attempts.userId, users.id), gte(attempts.createdAt, windowStart)))
+    .where(
+      and(
+        gte(sessionsAuth.lastActiveAt, activeSince),
+        // onboarding 済み
+        sql`${users.onboardingCompletedAt} IS NOT NULL`,
+        // opt-out 設定が ON のユーザーのみ (issue #36 受け入れ基準)
+        eq(users.weeklyDigestEnabled, true),
+      ),
+    )
+    .groupBy(users.id, users.email, users.displayName);
+
+  return rows.map((r) => {
+    const ms = typeof r.studyTimeMs === "string" ? Number(r.studyTimeMs) : r.studyTimeMs;
+    return {
+      userId: r.userId,
+      email: r.email,
+      displayName: r.displayName,
+      attemptCount: r.attemptCount ?? 0,
+      correctCount: r.correctCount ?? 0,
+      studyTimeMin: Math.round((ms / 60000) * 10) / 10,
+      conceptsTouched: r.conceptsTouched ?? 0,
+    };
+  });
+}
+
+/** Digest 本文 HTML を生成 (issue #36)。MVP はテンプレベタ書き、Phase 6+ で gpt-5 要約に拡張 */
+export function renderDigestHtml(m: DigestMetrics): string {
+  const name = m.displayName ?? m.email;
+  const accuracy =
+    m.attemptCount > 0 ? `${Math.round((m.correctCount / m.attemptCount) * 100)}%` : "-";
+  return `<!doctype html>
+<html lang="ja">
+  <body style="font-family: system-ui, -apple-system, sans-serif; color:#0f172a;">
+    <h1 style="font-size:18px;">Tanren Weekly Digest</h1>
+    <p>${escapeHtml(name)} さん、先週もお疲れさまでした。</p>
+    <table style="border-collapse:collapse; font-size:14px;">
+      <tbody>
+        <tr><td>出題数</td><td><strong>${m.attemptCount} 問</strong></td></tr>
+        <tr><td>正答率</td><td><strong>${accuracy}</strong></td></tr>
+        <tr><td>学習時間</td><td><strong>${m.studyTimeMin} 分</strong></td></tr>
+        <tr><td>触れた concept</td><td><strong>${m.conceptsTouched}</strong></td></tr>
+      </tbody>
+    </table>
+    <p style="margin-top:16px;">
+      <a href="${escapeHtml(process.env.NEXT_PUBLIC_APP_URL ?? "https://tanren.vercel.app")}/insights/trends">Trends で詳細を見る →</a>
+    </p>
+    <p style="color:#64748b; font-size:12px; margin-top:24px;">
+      このメールを止めるには設定画面から「Weekly Digest」を OFF にしてください。
+    </p>
+  </body>
+</html>`;
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}

--- a/src/server/digest/weekly-digest.ts
+++ b/src/server/digest/weekly-digest.ts
@@ -5,6 +5,10 @@ import { and, eq, gte, sql } from "drizzle-orm";
 import { getDb } from "@/db/client";
 import { attempts, sessionsAuth, users } from "@/db/schema";
 
+// sessionsAuth は直接 JOIN で引くと 1 user × N デバイスの fan-out で
+// attempt 集計が N 倍に水増しされる (Codex Round 1 指摘 A)。
+// EXISTS サブクエリで活性判定だけ行い、JOIN は users ↔ attempts のみに保つ。
+
 /** Weekly Digest 対象者の条件 (issue #36):
  *  - onboarding 完了済み
  *  - 直近 14 日以内にログイン活動あり (= sessions_auth に lastActiveAt >= now - 14d が存在)
@@ -33,8 +37,8 @@ export async function collectWeeklyDigestTargets(now: Date = new Date()): Promis
   const activeSince = new Date(now.getTime() - INACTIVE_DAYS_THRESHOLD * 24 * 60 * 60 * 1000);
   const windowStart = new Date(now.getTime() - WEEKLY_WINDOW_DAYS * 24 * 60 * 60 * 1000);
 
-  // 2 週間以内にログインしたユーザー (sessionsAuth.lastActiveAt で近似) のみ対象。
-  // JOIN で絞るのは集計コストを下げるため。
+  // 活性ユーザー判定は EXISTS で (JOIN にしない → fan-out 回避、Codex Round 1 指摘 A)。
+  // attempts を LEFT JOIN し、attempt 0 件のユーザーも 1 行で返す (後段で attemptCount=0 をスキップ)。
   const rows = await db
     .select({
       userId: users.id,
@@ -51,16 +55,12 @@ export async function collectWeeklyDigestTargets(now: Date = new Date()): Promis
       ),
     })
     .from(users)
-    .innerJoin(sessionsAuth, eq(sessionsAuth.userId, users.id))
-    // attempts は LEFT JOIN で、先週 attempt 0 件のユーザーも対象に含める判定余地を残す。
-    // 実際の判定は呼び出し側 (attemptCount >= 1 なら送る 等) に委ねる。
     .leftJoin(attempts, and(eq(attempts.userId, users.id), gte(attempts.createdAt, windowStart)))
     .where(
       and(
-        gte(sessionsAuth.lastActiveAt, activeSince),
-        // onboarding 済み
+        // 活性チェック: EXISTS (SELECT 1 FROM sessions_auth ...) で JOIN 重複を避ける
+        sql`EXISTS (SELECT 1 FROM ${sessionsAuth} AS sa WHERE sa.user_id = ${users.id} AND sa.last_active_at >= ${activeSince})`,
         sql`${users.onboardingCompletedAt} IS NOT NULL`,
-        // opt-out 設定が ON のユーザーのみ (issue #36 受け入れ基準)
         eq(users.weeklyDigestEnabled, true),
       ),
     )

--- a/src/server/trpc/routers/index.ts
+++ b/src/server/trpc/routers/index.ts
@@ -8,6 +8,7 @@ import { onboardingRouter } from "./onboarding";
 import { pingRouter } from "./ping";
 import { questionsRouter } from "./questions";
 import { sessionRouter } from "./session";
+import { settingsRouter } from "./settings";
 
 export const appRouter = router({
   ping: pingRouter.ping,
@@ -19,6 +20,7 @@ export const appRouter = router({
   onboarding: onboardingRouter,
   questions: questionsRouter,
   session: sessionRouter,
+  settings: settingsRouter,
 });
 
 export type AppRouter = typeof appRouter;

--- a/src/server/trpc/routers/settings.ts
+++ b/src/server/trpc/routers/settings.ts
@@ -1,0 +1,25 @@
+import { eq } from "drizzle-orm";
+import { z } from "zod";
+
+import { getDb } from "@/db/client";
+import { users } from "@/db/schema";
+
+import { protectedProcedure, router } from "../init";
+
+export const settingsRouter = router({
+  /** 現在の設定値を返す (issue #36: 通知 on/off) */
+  get: protectedProcedure.query(({ ctx }) => ({
+    weeklyDigestEnabled: ctx.user.weeklyDigestEnabled,
+  })),
+
+  /** Weekly Digest on/off (issue #36) */
+  setWeeklyDigestEnabled: protectedProcedure
+    .input(z.object({ enabled: z.boolean() }))
+    .mutation(async ({ ctx, input }) => {
+      await getDb()
+        .update(users)
+        .set({ weeklyDigestEnabled: input.enabled })
+        .where(eq(users.id, ctx.user.id));
+      return { ok: true as const, enabled: input.enabled };
+    }),
+});

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": "nextjs",
+  "crons": [
+    {
+      "path": "/api/cron/weekly-digest",
+      "schedule": "0 0 * * 0"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
issue #36 (Phase 5+) Weekly Digest。毎週日曜 JST 09:00 に先週の学習サマリを Resend 経由で HTML メール配信。

### 実装
- **DB**: migration 0012 で `users.weekly_digest_enabled` (bool, default=true) を追加
- **Server**:
  - `src/lib/email/resend-client.ts` — Resend シングルトン、`RESEND_API_KEY` 未設定で null (no-op)
  - `src/server/digest/weekly-digest.ts` — `collectWeeklyDigestTargets`: onboarding 済み × `sessionsAuth.lastActiveAt >= now-14d` × `weeklyDigestEnabled=true` のユーザーを SQL で絞り、`attempts` を LEFT JOIN で先週 7 日間の attemptCount/correctCount/studyTimeMs/conceptsTouched を集計。`renderDigestHtml` は XSS escape + `NEXT_PUBLIC_APP_URL` 経由の Trends リンク
  - `src/app/api/cron/weekly-digest/route.ts` — Vercel Cron endpoint。`CRON_SECRET` 一致を `Authorization: Bearer` で検証、未設定 env は 501、`attemptCount=0` はスキップ、`{ sent, skipped, errors }` を返す
- **tRPC**: `settings.get` / `settings.setWeeklyDigestEnabled` を追加
- **UI**: `/settings` ページ + `SettingsScreen` で ON/OFF トグル
- **Infra**: `vercel.json` の `crons` に `/api/cron/weekly-digest` (日曜 00:00 UTC = 09:00 JST) を登録
- **env**: `.env.example` を `RESEND_API_KEY` / `RESEND_FROM_EMAIL` / `CRON_SECRET` で整理

### 受け入れ基準
- [x] Vercel Cron で日曜 09:00 JST 実行 (`0 0 * * 0` in UTC = 09:00 JST)
- [x] Resend SDK で HTML メール
- [x] 未ログイン 2 週間以上のユーザーには送らない (`lastActiveAt >= now-14d`)
- [x] on/off 設定画面 (`/settings`)

### Test plan
- [x] `pnpm typecheck` ✓
- [x] `pnpm test -- --run` ✓ (290/290、新規 +4: XSS escape / attemptCount=0 / displayName null / 表示項目)
- [x] `pnpm build` ✓ (`/api/cron/weekly-digest`, `/settings` 登録確認)

### 注意
- RESEND_API_KEY / RESEND_FROM_EMAIL / CRON_SECRET の登録は Vercel ダッシュボード側の手動操作 (本 PR 対象外)
- 未設定でも cron は 501 で safe skip

closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)