### PR TITLE
feat(notify): Web Push 通知 (subscribe / SW push handler、#37)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -62,10 +62,14 @@ SENTRY_PROJECT=
 # JUDGE0_API_KEY=
 # JUDGE0_API_HOST=judge0-ce.p.rapidapi.com
 
-# --- Web Push (VAPID) ---
+# --- Web Push (VAPID, issue #37) ---
+# 生成: `npx web-push generate-vapid-keys` → public / private キーペアを得る
+# Vercel env には 3 件とも登録 (public はクライアント bundle にも露出)
+# 未設定なら push.subscribe は NOT_IMPLEMENTED、sendPushNotification は 501 で safe no-op
 # WEB_PUSH_VAPID_PUBLIC_KEY=
 # WEB_PUSH_VAPID_PRIVATE_KEY=
 # NEXT_PUBLIC_WEB_PUSH_VAPID_PUBLIC_KEY=
+# WEB_PUSH_SUBJECT=mailto:noreply@tanren.vercel.app
 
 # --- Upstash Redis (rate limit) ---
 # UPSTASH_REDIS_URL=

--- a/drizzle/0013_push_subscriptions.sql
+++ b/drizzle/0013_push_subscriptions.sql
@@ -1,0 +1,18 @@
+-- issue #37: Web Push 購読情報を保存するテーブル
+CREATE TABLE "push_subscriptions" (
+  "id" text PRIMARY KEY DEFAULT gen_random_uuid()::text,
+  "user_id" text NOT NULL REFERENCES "users"("id") ON DELETE CASCADE,
+  "endpoint" text NOT NULL UNIQUE,
+  "p256dh" text NOT NULL,
+  "auth" text NOT NULL,
+  "user_agent" text,
+  "created_at" timestamp with time zone NOT NULL DEFAULT now(),
+  "last_success_at" timestamp with time zone,
+  "last_error" text
+);
+
+CREATE INDEX "idx_push_subscriptions_user" ON "push_subscriptions" ("user_id");
+
+-- users に Web Push on/off フラグ (opt-in 方式、デフォルト false)
+ALTER TABLE "users"
+  ADD COLUMN "web_push_enabled" boolean NOT NULL DEFAULT false;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -92,6 +92,13 @@
       "when": 1776500000000,
       "tag": "0012_weekly_digest_enabled",
       "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "7",
+      "when": 1776501000000,
+      "tag": "0013_push_subscriptions",
+      "breakpoints": true
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "server-only": "^0.0.1",
     "tailwind-merge": "^3.5.0",
     "ts-fsrs": "^5.3.2",
+    "web-push": "^3.6.7",
     "yaml": "^2.8.3",
     "zod": "^4.3.6",
     "zustand": "^5.0.12"
@@ -54,6 +55,7 @@
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "@types/web-push": "^3.6.4",
     "@vitejs/plugin-react": "^6.0.1",
     "@vitest/coverage-v8": "^4.1.4",
     "drizzle-kit": "^0.31.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,6 +80,9 @@ importers:
       ts-fsrs:
         specifier: ^5.3.2
         version: 5.3.2
+      web-push:
+        specifier: ^3.6.7
+        version: 3.6.7
       yaml:
         specifier: ^2.8.3
         version: 2.8.3
@@ -108,6 +111,9 @@ importers:
       '@types/react-dom':
         specifier: ^19
         version: 19.2.3(@types/react@19.2.14)
+      '@types/web-push':
+        specifier: ^3.6.4
+        version: 3.6.4
       '@vitejs/plugin-react':
         specifier: ^6.0.1
         version: 6.0.1(vite@8.0.8(@types/node@20.19.39)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
@@ -1885,6 +1891,9 @@ packages:
   '@types/tedious@4.0.14':
     resolution: {integrity: sha512-KHPsfX/FoVbUGbyYvk1q9MMQHLPeRZhRJZdO45Q4YjvFkv4hMNghCWTvy7rdKessBsmtz4euWCWAB6/tVpI1Iw==}
 
+  '@types/web-push@3.6.4':
+    resolution: {integrity: sha512-GnJmSr40H3RAnj0s34FNTcJi1hmWFV5KXugE0mYWnYhgTAHLJ/dJKAwDmvPJYMke0RplY2XE9LnM4hqSqKIjhQ==}
+
   '@typescript-eslint/eslint-plugin@8.58.2':
     resolution: {integrity: sha512-aC2qc5thQahutKjP+cl8cgN9DWe3ZUqVko30CMSZHnFEHyhOYoZSzkGtAI2mcwZ38xeImDucI4dnqsHiOYuuCw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -2166,6 +2175,10 @@ packages:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
 
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
+
   ajv-formats@2.1.1:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
     peerDependencies:
@@ -2239,6 +2252,9 @@ packages:
     resolution: {integrity: sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==}
     engines: {node: '>= 0.4'}
 
+  asn1.js@5.4.1:
+    resolution: {integrity: sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==}
+
   asn1js@3.0.7:
     resolution: {integrity: sha512-uLvq6KJu04qoQM6gvBfKFjlh6Gl0vOKQuR5cJMDHQkmwfMOQeN3F3SHCv9SNYSL+CRoHvOGFfllDlVz03GQjvQ==}
     engines: {node: '>=12.0.0'}
@@ -2281,6 +2297,9 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
+  bn.js@4.12.3:
+    resolution: {integrity: sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==}
+
   brace-expansion@1.1.14:
     resolution: {integrity: sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==}
 
@@ -2296,6 +2315,9 @@ packages:
     resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
+
+  buffer-equal-constant-time@1.0.1:
+    resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
 
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
@@ -2537,6 +2559,9 @@ packages:
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
+
+  ecdsa-sig-formatter@1.0.11:
+    resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
 
   electron-to-chromium@1.5.340:
     resolution: {integrity: sha512-908qahOGocRMinT2nM3ajCEM99H4iPdv84eagPP3FfZy/1ZGeOy2CZYzjhms81ckOPCXPlW7LkY4XpxD8r1DrA==}
@@ -2919,9 +2944,17 @@ packages:
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
+  http_ece@1.2.0:
+    resolution: {integrity: sha512-JrF8SSLVmcvc5NducxgyOrKXe3EsyHMgBFgSaIUGmArKe+rwr0uphRkRXvwiom3I+fpIfoItveHrfudL8/rxuA==}
+    engines: {node: '>=16'}
+
   https-proxy-agent@5.0.1:
     resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
     engines: {node: '>= 6'}
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
@@ -2945,6 +2978,9 @@ packages:
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
@@ -3125,6 +3161,12 @@ packages:
   jsx-ast-utils@3.3.5:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
     engines: {node: '>=4.0'}
+
+  jwa@2.0.1:
+    resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
+
+  jws@4.0.1:
+    resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
@@ -3323,6 +3365,9 @@ packages:
   mime-db@1.54.0:
     resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
     engines: {node: '>= 0.6'}
+
+  minimalistic-assert@1.0.1:
+    resolution: {integrity: sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==}
 
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
@@ -3724,6 +3769,9 @@ packages:
     resolution: {integrity: sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==}
     engines: {node: '>=0.4'}
 
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
   safe-push-apply@1.0.0:
     resolution: {integrity: sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==}
     engines: {node: '>= 0.4'}
@@ -3731,6 +3779,9 @@ packages:
   safe-regex-test@1.1.0:
     resolution: {integrity: sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==}
     engines: {node: '>= 0.4'}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
@@ -4111,6 +4162,11 @@ packages:
   watchpack@2.5.1:
     resolution: {integrity: sha512-Zn5uXdcFNIA1+1Ei5McRd+iRzfhENPCe7LeABkJtNulSxjma+l7ltNx55BWZkRlwRnpOgHqxnjyaDgJnNXnqzg==}
     engines: {node: '>=10.13.0'}
+
+  web-push@3.6.7:
+    resolution: {integrity: sha512-OpiIUe8cuGjrj3mMBFWY+e4MMIkW3SVT+7vEIjvD9kejGUypv8GPDf84JdPWskK8zMRIJ6xYGm+Kxr8YkPyA0A==}
+    engines: {node: '>= 16'}
+    hasBin: true
 
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
@@ -5761,6 +5817,10 @@ snapshots:
     dependencies:
       '@types/node': 20.19.39
 
+  '@types/web-push@3.6.4':
+    dependencies:
+      '@types/node': 20.19.39
+
   '@typescript-eslint/eslint-plugin@8.58.2(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
@@ -6071,6 +6131,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  agent-base@7.1.4: {}
+
   ajv-formats@2.1.1(ajv@8.18.0):
     optionalDependencies:
       ajv: 8.18.0
@@ -6177,6 +6239,13 @@ snapshots:
       get-intrinsic: 1.3.0
       is-array-buffer: 3.0.5
 
+  asn1.js@5.4.1:
+    dependencies:
+      bn.js: 4.12.3
+      inherits: 2.0.4
+      minimalistic-assert: 1.0.1
+      safer-buffer: 2.1.2
+
   asn1js@3.0.7:
     dependencies:
       pvtsutils: 1.3.6
@@ -6209,6 +6278,8 @@ snapshots:
 
   baseline-browser-mapping@2.10.19: {}
 
+  bn.js@4.12.3: {}
+
   brace-expansion@1.1.14:
     dependencies:
       balanced-match: 1.0.2
@@ -6229,6 +6300,8 @@ snapshots:
       electron-to-chromium: 1.5.340
       node-releases: 2.0.37
       update-browserslist-db: 1.2.3(browserslist@4.28.2)
+
+  buffer-equal-constant-time@1.0.1: {}
 
   buffer-from@1.1.2: {}
 
@@ -6371,6 +6444,10 @@ snapshots:
       call-bind-apply-helpers: 1.0.2
       es-errors: 1.3.0
       gopd: 1.2.0
+
+  ecdsa-sig-formatter@1.0.11:
+    dependencies:
+      safe-buffer: 5.2.1
 
   electron-to-chromium@1.5.340: {}
 
@@ -6956,9 +7033,18 @@ snapshots:
 
   html-escaper@2.0.2: {}
 
+  http_ece@1.2.0: {}
+
   https-proxy-agent@5.0.1:
     dependencies:
       agent-base: 6.0.2
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
@@ -6987,6 +7073,8 @@ snapshots:
       module-details-from-path: 1.0.4
 
   imurmurhash@0.1.4: {}
+
+  inherits@2.0.4: {}
 
   internal-slot@1.1.0:
     dependencies:
@@ -7175,6 +7263,17 @@ snapshots:
       object.assign: 4.1.7
       object.values: 1.2.1
 
+  jwa@2.0.1:
+    dependencies:
+      buffer-equal-constant-time: 1.0.1
+      ecdsa-sig-formatter: 1.0.11
+      safe-buffer: 5.2.1
+
+  jws@4.0.1:
+    dependencies:
+      jwa: 2.0.1
+      safe-buffer: 5.2.1
+
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
@@ -7332,6 +7431,8 @@ snapshots:
       picomatch: 2.3.2
 
   mime-db@1.54.0: {}
+
+  minimalistic-assert@1.0.1: {}
 
   minimatch@10.2.5:
     dependencies:
@@ -7694,6 +7795,8 @@ snapshots:
       has-symbols: 1.1.0
       isarray: 2.0.5
 
+  safe-buffer@5.2.1: {}
+
   safe-push-apply@1.0.0:
     dependencies:
       es-errors: 1.3.0
@@ -7704,6 +7807,8 @@ snapshots:
       call-bound: 1.0.4
       es-errors: 1.3.0
       is-regex: 1.2.1
+
+  safer-buffer@2.1.2: {}
 
   scheduler@0.27.0: {}
 
@@ -8129,6 +8234,16 @@ snapshots:
     dependencies:
       glob-to-regexp: 0.4.1
       graceful-fs: 4.2.11
+
+  web-push@3.6.7:
+    dependencies:
+      asn1.js: 5.4.1
+      http_ece: 1.2.0
+      https-proxy-agent: 7.0.6
+      jws: 4.0.1
+      minimist: 1.2.8
+    transitivePeerDependencies:
+      - supports-color
 
   webidl-conversions@3.0.1: {}
 

--- a/public/sw.js
+++ b/public/sw.js
@@ -87,3 +87,36 @@ async function cacheFirst(request) {
   if (response.ok) await cache.put(request, response.clone());
   return response;
 }
+
+// Web Push (issue #37): push 受信 → notification を表示
+self.addEventListener("push", (event) => {
+  if (!event.data) return;
+  let payload;
+  try {
+    payload = event.data.json();
+  } catch {
+    payload = { title: "Tanren", body: event.data.text() };
+  }
+  const title = payload.title || "Tanren";
+  const options = {
+    body: payload.body ?? "",
+    icon: "/icon-192.png",
+    badge: "/icon-192.png",
+    data: { url: payload.url ?? "/" },
+  };
+  event.waitUntil(self.registration.showNotification(title, options));
+});
+
+// 通知タップ時にアプリを開く
+self.addEventListener("notificationclick", (event) => {
+  event.notification.close();
+  const url = event.notification.data?.url ?? "/";
+  event.waitUntil(
+    self.clients.matchAll({ type: "window", includeUncontrolled: true }).then((clients) => {
+      for (const c of clients) {
+        if (c.url.endsWith(url) && "focus" in c) return c.focus();
+      }
+      if (self.clients.openWindow) return self.clients.openWindow(url);
+    }),
+  );
+});

--- a/src/app/api/cron/daily-reminder/route.ts
+++ b/src/app/api/cron/daily-reminder/route.ts
@@ -1,0 +1,67 @@
+import { NextResponse } from "next/server";
+import { and, eq } from "drizzle-orm";
+
+import { getDb } from "@/db/client";
+import { pushSubscriptions, users } from "@/db/schema";
+import { appUrl } from "@/lib/env";
+import { sendPushNotification } from "@/lib/push/web-push-client";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * Daily reminder を Web Push で配信する cron endpoint (issue #37)。
+ * 対象: `users.webPushEnabled = true` かつ `push_subscriptions` を持つユーザー。
+ * 410 Gone / 404 の subscription は DB から削除して以降の送信から除外する。
+ *
+ * セキュリティ: Vercel Cron からの呼び出しは `Authorization: Bearer ${CRON_SECRET}` 付き。
+ * 本番で CRON_SECRET 未設定は fail-closed で 500 (Weekly Digest と同じ方針)。
+ */
+export async function GET(req: Request) {
+  const cronSecret = process.env.CRON_SECRET;
+  if (!cronSecret) {
+    if (process.env.VERCEL_ENV === "production") {
+      return NextResponse.json({ error: "CRON_SECRET not configured" }, { status: 500 });
+    }
+  } else if (req.headers.get("authorization") !== `Bearer ${cronSecret}`) {
+    return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  }
+
+  const db = getDb();
+  const rows = await db
+    .select({
+      id: pushSubscriptions.id,
+      endpoint: pushSubscriptions.endpoint,
+      p256dh: pushSubscriptions.p256dh,
+      auth: pushSubscriptions.auth,
+    })
+    .from(pushSubscriptions)
+    .innerJoin(users, eq(users.id, pushSubscriptions.userId))
+    .where(eq(users.webPushEnabled, true));
+
+  let sent = 0;
+  const errors: Array<{ endpoint: string; statusCode: number; message: string }> = [];
+  for (const sub of rows) {
+    const result = await sendPushNotification({
+      endpoint: sub.endpoint,
+      p256dh: sub.p256dh,
+      auth: sub.auth,
+      payload: {
+        title: "今日の Daily Drill",
+        body: "5 問 2 分で今日の復習を始めましょう。",
+        url: `${appUrl}/drill`,
+      },
+    });
+    if (result.ok) {
+      sent += 1;
+      continue;
+    }
+    errors.push({ endpoint: sub.endpoint, statusCode: result.statusCode, message: result.message });
+    // 410 Gone / 404 Not Found は subscription が失効しているので DB から削除
+    if (result.statusCode === 410 || result.statusCode === 404) {
+      await db
+        .delete(pushSubscriptions)
+        .where(and(eq(pushSubscriptions.id, sub.id), eq(pushSubscriptions.endpoint, sub.endpoint)));
+    }
+  }
+  return NextResponse.json({ sent, errors });
+}

--- a/src/db/schema/index.ts
+++ b/src/db/schema/index.ts
@@ -12,3 +12,4 @@ export * from "./attempts";
 export * from "./mastery";
 export * from "./misconceptions";
 export * from "./daily-stats";
+export * from "./push-subscriptions";

--- a/src/db/schema/push-subscriptions.ts
+++ b/src/db/schema/push-subscriptions.ts
@@ -1,0 +1,33 @@
+import { sql } from "drizzle-orm";
+import { index, pgTable, text, timestamp } from "drizzle-orm/pg-core";
+
+import { users } from "./users";
+
+/** Web Push 購読情報 (issue #37, docs/07 §7.5.5)。
+ *  1 user × 複数デバイス (endpoint 単位で unique)。
+ */
+export const pushSubscriptions = pgTable(
+  "push_subscriptions",
+  {
+    id: text("id")
+      .primaryKey()
+      .default(sql`gen_random_uuid()::text`),
+    userId: text("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    /** Push Service の endpoint URL (unique) */
+    endpoint: text("endpoint").notNull().unique(),
+    /** 暗号化公開鍵 (base64url) */
+    p256dh: text("p256dh").notNull(),
+    /** 認証シークレット (base64url) */
+    auth: text("auth").notNull(),
+    userAgent: text("user_agent"),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    lastSuccessAt: timestamp("last_success_at", { withTimezone: true }),
+    lastError: text("last_error"),
+  },
+  (table) => [index("idx_push_subscriptions_user").on(table.userId)],
+);
+
+export type PushSubscription = typeof pushSubscriptions.$inferSelect;
+export type NewPushSubscription = typeof pushSubscriptions.$inferInsert;

--- a/src/db/schema/users.ts
+++ b/src/db/schema/users.ts
@@ -23,6 +23,9 @@ export const users = pgTable("users", {
   selfLevel: text("self_level").$type<DifficultyLevel>(),
   /** Weekly Digest メール (issue #36) の送信を受け取るか。デフォルト true (opt-out 方式) */
   weeklyDigestEnabled: boolean("weekly_digest_enabled").notNull().default(true),
+  /** Web Push (issue #37) を使うか。デフォルト false (opt-in)。
+   *  ブラウザ側で Notification.requestPermission() + subscription 作成してから ON にする想定。 */
+  webPushEnabled: boolean("web_push_enabled").notNull().default(false),
   createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
 });
 

--- a/src/features/settings/settings-screen.tsx
+++ b/src/features/settings/settings-screen.tsx
@@ -7,6 +7,8 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { trpc } from "@/lib/trpc/react";
 
+import { WebPushToggle } from "./web-push-toggle";
+
 export function SettingsScreen() {
   const settings = trpc.settings.get.useQuery();
   const setWeekly = trpc.settings.setWeeklyDigestEnabled.useMutation();
@@ -60,6 +62,11 @@ export function SettingsScreen() {
           </p>
         )}
         {error && <p className="text-destructive text-xs">{error}</p>}
+        <WebPushToggle />
+        <p className="text-muted-foreground text-xs">
+          二重配信抑止: Weekly Digest はメール専用、Daily reminder は Web Push 専用なので同じ通知は
+          1 経路のみ配信されます。
+        </p>
       </CardContent>
     </Card>
   );

--- a/src/features/settings/web-push-toggle.tsx
+++ b/src/features/settings/web-push-toggle.tsx
@@ -6,6 +6,13 @@ import { useCallback, useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { trpc } from "@/lib/trpc/react";
 
+type ServerSubscribeInput = {
+  endpoint: string;
+  p256dh: string;
+  auth: string;
+  userAgent: string;
+};
+
 /** base64url 文字列を ArrayBuffer に変換 (PushManager.subscribe の applicationServerKey 用)。
  *  DOM 型定義の都合で Uint8Array<ArrayBufferLike> ではなく純粋 ArrayBuffer を返す。 */
 function urlBase64ToArrayBuffer(base64Url: string): ArrayBuffer {
@@ -26,6 +33,7 @@ export function WebPushToggle() {
   });
   const subscribeMut = trpc.push.subscribe.useMutation();
   const unsubscribeMut = trpc.push.unsubscribe.useMutation();
+  const setEnabledMut = trpc.push.setEnabled.useMutation();
 
   const [status, setStatus] = useState<Status>("unsubscribed");
   const [error, setError] = useState<string | null>(null);
@@ -70,21 +78,33 @@ export function WebPushToggle() {
       const p256dh = json.keys?.p256dh;
       const auth = json.keys?.auth;
       if (!json.endpoint || !p256dh || !auth) {
+        // subscription 形式が不正: push 側を unsubscribe して orphan を残さない
+        await sub.unsubscribe().catch(() => undefined);
         throw new Error("subscription の形式が不正です");
       }
-      await subscribeMut.mutateAsync({
+      const serverInput: ServerSubscribeInput = {
         endpoint: json.endpoint,
         p256dh,
         auth,
         userAgent: navigator.userAgent,
-      });
+      };
+      try {
+        await subscribeMut.mutateAsync(serverInput);
+      } catch (e) {
+        // server 側保存失敗で pushManager.subscribe() だけ生き残る orphan を防止
+        // (Codex Round 1 指摘 #2)
+        await sub.unsubscribe().catch(() => undefined);
+        throw e;
+      }
+      // 購読と設定フラグの責務分離 (Codex Round 1 指摘 #3)。購読成功したら明示的に ON にする。
+      await setEnabledMut.mutateAsync({ enabled: true });
       setStatus("subscribed");
     } catch (e) {
       setError(e instanceof Error ? e.message : "購読に失敗しました");
     } finally {
       setBusy(false);
     }
-  }, [publicKeyQuery.isError, publicKeyQuery.data, subscribeMut]);
+  }, [publicKeyQuery.isError, publicKeyQuery.data, subscribeMut, setEnabledMut]);
 
   const onUnsubscribe = useCallback(async () => {
     setError(null);

--- a/src/features/settings/web-push-toggle.tsx
+++ b/src/features/settings/web-push-toggle.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import { Bell } from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { trpc } from "@/lib/trpc/react";
+
+/** base64url 文字列を ArrayBuffer に変換 (PushManager.subscribe の applicationServerKey 用)。
+ *  DOM 型定義の都合で Uint8Array<ArrayBufferLike> ではなく純粋 ArrayBuffer を返す。 */
+function urlBase64ToArrayBuffer(base64Url: string): ArrayBuffer {
+  const padding = "=".repeat((4 - (base64Url.length % 4)) % 4);
+  const base64 = (base64Url + padding).replace(/-/g, "+").replace(/_/g, "/");
+  const raw = atob(base64);
+  const buffer = new ArrayBuffer(raw.length);
+  const view = new Uint8Array(buffer);
+  for (let i = 0; i < raw.length; i++) view[i] = raw.charCodeAt(i);
+  return buffer;
+}
+
+type Status = "unsupported" | "denied" | "unsubscribed" | "subscribed";
+
+export function WebPushToggle() {
+  const publicKeyQuery = trpc.push.getPublicKey.useQuery(undefined, {
+    retry: false,
+  });
+  const subscribeMut = trpc.push.subscribe.useMutation();
+  const unsubscribeMut = trpc.push.unsubscribe.useMutation();
+
+  const [status, setStatus] = useState<Status>("unsubscribed");
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  // 初回: 現在の permission / subscription 状態を把握
+  useEffect(() => {
+    void (async () => {
+      if (typeof window === "undefined") return;
+      if (!("serviceWorker" in navigator) || !("PushManager" in window)) {
+        setStatus("unsupported");
+        return;
+      }
+      if (Notification.permission === "denied") {
+        setStatus("denied");
+        return;
+      }
+      const reg = await navigator.serviceWorker.getRegistration();
+      const sub = reg ? await reg.pushManager.getSubscription() : null;
+      setStatus(sub ? "subscribed" : "unsubscribed");
+    })();
+  }, []);
+
+  const onSubscribe = useCallback(async () => {
+    setError(null);
+    setBusy(true);
+    try {
+      if (publicKeyQuery.isError || !publicKeyQuery.data) {
+        throw new Error("VAPID public key がサーバー側で未設定です");
+      }
+      const permission = await Notification.requestPermission();
+      if (permission !== "granted") {
+        setStatus(permission === "denied" ? "denied" : "unsubscribed");
+        return;
+      }
+      const reg = await navigator.serviceWorker.ready;
+      const sub = await reg.pushManager.subscribe({
+        userVisibleOnly: true,
+        applicationServerKey: urlBase64ToArrayBuffer(publicKeyQuery.data.publicKey),
+      });
+      const json = sub.toJSON();
+      const p256dh = json.keys?.p256dh;
+      const auth = json.keys?.auth;
+      if (!json.endpoint || !p256dh || !auth) {
+        throw new Error("subscription の形式が不正です");
+      }
+      await subscribeMut.mutateAsync({
+        endpoint: json.endpoint,
+        p256dh,
+        auth,
+        userAgent: navigator.userAgent,
+      });
+      setStatus("subscribed");
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "購読に失敗しました");
+    } finally {
+      setBusy(false);
+    }
+  }, [publicKeyQuery.isError, publicKeyQuery.data, subscribeMut]);
+
+  const onUnsubscribe = useCallback(async () => {
+    setError(null);
+    setBusy(true);
+    try {
+      const reg = await navigator.serviceWorker.getRegistration();
+      const sub = reg ? await reg.pushManager.getSubscription() : null;
+      if (sub) {
+        await unsubscribeMut.mutateAsync({ endpoint: sub.endpoint });
+        await sub.unsubscribe();
+      }
+      setStatus("unsubscribed");
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "解除に失敗しました");
+    } finally {
+      setBusy(false);
+    }
+  }, [unsubscribeMut]);
+
+  return (
+    <div className="flex items-center justify-between gap-3">
+      <div>
+        <div className="flex items-center gap-2 font-medium">
+          <Bell className="h-4 w-4" /> Web Push
+        </div>
+        <div className="text-muted-foreground text-xs">
+          Daily reminder をブラウザ通知で受け取る (iOS は A2HS 後のみ動作、docs/07 §7.5.5)
+        </div>
+        {status === "unsupported" && (
+          <div className="text-destructive mt-1 text-xs">このブラウザは Web Push 非対応</div>
+        )}
+        {status === "denied" && (
+          <div className="text-destructive mt-1 text-xs">
+            通知が拒否されています。ブラウザ設定から許可してください
+          </div>
+        )}
+        {error && <div className="text-destructive mt-1 text-xs">{error}</div>}
+      </div>
+      <Button
+        variant={status === "subscribed" ? "default" : "outline"}
+        size="sm"
+        disabled={busy || status === "unsupported" || status === "denied"}
+        onClick={status === "subscribed" ? onUnsubscribe : onSubscribe}
+      >
+        {status === "subscribed" ? "ON" : "OFF"}
+      </Button>
+    </div>
+  );
+}

--- a/src/features/settings/web-push-toggle.tsx
+++ b/src/features/settings/web-push-toggle.tsx
@@ -31,6 +31,8 @@ export function WebPushToggle() {
   const publicKeyQuery = trpc.push.getPublicKey.useQuery(undefined, {
     retry: false,
   });
+  const settingsQuery = trpc.settings.get.useQuery();
+  const utils = trpc.useUtils();
   const subscribeMut = trpc.push.subscribe.useMutation();
   const unsubscribeMut = trpc.push.unsubscribe.useMutation();
   const setEnabledMut = trpc.push.setEnabled.useMutation();
@@ -39,7 +41,10 @@ export function WebPushToggle() {
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
 
-  // 初回: 現在の permission / subscription 状態を把握
+  // 初回: 現在の permission / subscription 状態を把握。
+  // UI の ON/OFF は「この端末で subscription あり」AND「サーバー側 webPushEnabled=true」の AND
+  // (Codex Round 2 指摘 A: 責務分離後の UI 整合)。
+  const webPushEnabled = settingsQuery.data?.webPushEnabled ?? false;
   useEffect(() => {
     void (async () => {
       if (typeof window === "undefined") return;
@@ -53,9 +58,10 @@ export function WebPushToggle() {
       }
       const reg = await navigator.serviceWorker.getRegistration();
       const sub = reg ? await reg.pushManager.getSubscription() : null;
-      setStatus(sub ? "subscribed" : "unsubscribed");
+      const subscribedHere = Boolean(sub);
+      setStatus(subscribedHere && webPushEnabled ? "subscribed" : "unsubscribed");
     })();
-  }, []);
+  }, [webPushEnabled]);
 
   const onSubscribe = useCallback(async () => {
     setError(null);
@@ -98,13 +104,14 @@ export function WebPushToggle() {
       }
       // 購読と設定フラグの責務分離 (Codex Round 1 指摘 #3)。購読成功したら明示的に ON にする。
       await setEnabledMut.mutateAsync({ enabled: true });
+      await utils.settings.get.invalidate();
       setStatus("subscribed");
     } catch (e) {
       setError(e instanceof Error ? e.message : "購読に失敗しました");
     } finally {
       setBusy(false);
     }
-  }, [publicKeyQuery.isError, publicKeyQuery.data, subscribeMut, setEnabledMut]);
+  }, [publicKeyQuery.isError, publicKeyQuery.data, subscribeMut, setEnabledMut, utils]);
 
   const onUnsubscribe = useCallback(async () => {
     setError(null);
@@ -116,13 +123,18 @@ export function WebPushToggle() {
         await unsubscribeMut.mutateAsync({ endpoint: sub.endpoint });
         await sub.unsubscribe();
       }
+      // onSubscribe と対称に、機能全体の送信 gate も OFF にする (Codex Round 2 指摘 B)。
+      // push.unsubscribe は最後の 1 件削除時のみ web_push_enabled=false にするので、
+      // 複数デバイスで購読していても、このデバイスで OFF を押したら配信 gate も切る意図を尊重。
+      await setEnabledMut.mutateAsync({ enabled: false });
+      await utils.settings.get.invalidate();
       setStatus("unsubscribed");
     } catch (e) {
       setError(e instanceof Error ? e.message : "解除に失敗しました");
     } finally {
       setBusy(false);
     }
-  }, [unsubscribeMut]);
+  }, [unsubscribeMut, setEnabledMut, utils]);
 
   return (
     <div className="flex items-center justify-between gap-3">

--- a/src/features/settings/web-push-toggle.tsx
+++ b/src/features/settings/web-push-toggle.tsx
@@ -75,6 +75,13 @@ export function WebPushToggle() {
         setStatus(permission === "denied" ? "denied" : "unsubscribed");
         return;
       }
+      // RegisterServiceWorker (src/features/pwa/register-sw.tsx) は production のみ
+      // register する。dev で Web Push トグルを押すと serviceWorker.ready が永遠に解決せず
+      // ハングするため、未登録ならここで明示的に register する (Codex Round 3 指摘 #2)。
+      const existing = await navigator.serviceWorker.getRegistration();
+      if (!existing) {
+        await navigator.serviceWorker.register("/sw.js", { scope: "/" });
+      }
       const reg = await navigator.serviceWorker.ready;
       const sub = await reg.pushManager.subscribe({
         userVisibleOnly: true,

--- a/src/lib/push/web-push-client.test.ts
+++ b/src/lib/push/web-push-client.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("web-push", () => ({
+  default: {
+    setVapidDetails: vi.fn(),
+    sendNotification: vi.fn(),
+  },
+}));
+
+import webpush from "web-push";
+
+import { sendPushNotification, webPushPublicKey } from "./web-push-client";
+
+const ORIG_PUB = process.env.WEB_PUSH_VAPID_PUBLIC_KEY;
+const ORIG_PRIV = process.env.WEB_PUSH_VAPID_PRIVATE_KEY;
+const ORIG_NPUB = process.env.NEXT_PUBLIC_WEB_PUSH_VAPID_PUBLIC_KEY;
+
+beforeEach(() => {
+  process.env.WEB_PUSH_VAPID_PUBLIC_KEY = "pub-key";
+  process.env.WEB_PUSH_VAPID_PRIVATE_KEY = "priv-key";
+  process.env.NEXT_PUBLIC_WEB_PUSH_VAPID_PUBLIC_KEY = "npub-key";
+});
+afterEach(() => {
+  process.env.WEB_PUSH_VAPID_PUBLIC_KEY = ORIG_PUB;
+  process.env.WEB_PUSH_VAPID_PRIVATE_KEY = ORIG_PRIV;
+  process.env.NEXT_PUBLIC_WEB_PUSH_VAPID_PUBLIC_KEY = ORIG_NPUB;
+  vi.clearAllMocks();
+});
+
+describe("sendPushNotification", () => {
+  it("VAPID 未設定なら ok:false / statusCode 501", async () => {
+    delete process.env.WEB_PUSH_VAPID_PUBLIC_KEY;
+    const out = await sendPushNotification({
+      endpoint: "https://push.example/abc",
+      p256dh: "p",
+      auth: "a",
+      payload: { title: "hi", body: "b" },
+    });
+    expect(out).toEqual({ ok: false, statusCode: 501, message: "VAPID keys not configured" });
+  });
+
+  it("正常系: webpush.sendNotification を呼ぶ", async () => {
+    vi.mocked(webpush.sendNotification).mockResolvedValueOnce({} as never);
+    const out = await sendPushNotification({
+      endpoint: "https://push.example/abc",
+      p256dh: "p",
+      auth: "a",
+      payload: { title: "hi", body: "b", url: "/drill" },
+    });
+    expect(out).toEqual({ ok: true });
+    expect(webpush.sendNotification).toHaveBeenCalledTimes(1);
+    const call = vi.mocked(webpush.sendNotification).mock.calls[0]!;
+    expect(call[0]).toEqual({
+      endpoint: "https://push.example/abc",
+      keys: { p256dh: "p", auth: "a" },
+    });
+    expect(JSON.parse(call[1] as string)).toEqual({ title: "hi", body: "b", url: "/drill" });
+  });
+
+  it("410 Gone は ok:false / statusCode 410", async () => {
+    vi.mocked(webpush.sendNotification).mockRejectedValueOnce({
+      statusCode: 410,
+      body: "Gone",
+    });
+    const out = await sendPushNotification({
+      endpoint: "https://push.example/dead",
+      p256dh: "p",
+      auth: "a",
+      payload: { title: "x", body: "y" },
+    });
+    expect(out).toEqual({ ok: false, statusCode: 410, message: "Gone" });
+  });
+});
+
+describe("webPushPublicKey", () => {
+  it("NEXT_PUBLIC_WEB_PUSH_VAPID_PUBLIC_KEY の値を返す", () => {
+    expect(webPushPublicKey()).toBe("npub-key");
+  });
+
+  it("未設定なら null", () => {
+    delete process.env.NEXT_PUBLIC_WEB_PUSH_VAPID_PUBLIC_KEY;
+    expect(webPushPublicKey()).toBeNull();
+  });
+});

--- a/src/lib/push/web-push-client.ts
+++ b/src/lib/push/web-push-client.ts
@@ -1,0 +1,62 @@
+import "server-only";
+
+import webpush from "web-push";
+
+/** Web Push サービス (issue #37)。
+ *  VAPID 鍵未設定なら null (送信 no-op)。本番では生成した VAPID 鍵を Vercel env に登録する。
+ *  `NEXT_PUBLIC_WEB_PUSH_VAPID_PUBLIC_KEY` はクライアントが subscribe() で使う。
+ */
+
+let initialized = false;
+
+function configure(): boolean {
+  if (initialized) return true;
+  const pub = process.env.WEB_PUSH_VAPID_PUBLIC_KEY;
+  const priv = process.env.WEB_PUSH_VAPID_PRIVATE_KEY;
+  const subject = process.env.WEB_PUSH_SUBJECT ?? "mailto:noreply@tanren.vercel.app";
+  if (!pub || !priv) return false;
+  webpush.setVapidDetails(subject, pub, priv);
+  initialized = true;
+  return true;
+}
+
+export type PushPayload = {
+  title: string;
+  body: string;
+  url?: string;
+};
+
+/** 1 件の subscription に対して push を送信。410/404 は「subscription が失効」なので
+ *  呼び出し側で DB から delete する判断材料として statusCode を含む Error を throw する。 */
+export async function sendPushNotification(args: {
+  endpoint: string;
+  p256dh: string;
+  auth: string;
+  payload: PushPayload;
+}): Promise<{ ok: true } | { ok: false; statusCode: number; message: string }> {
+  if (!configure()) {
+    return { ok: false, statusCode: 501, message: "VAPID keys not configured" };
+  }
+  try {
+    await webpush.sendNotification(
+      {
+        endpoint: args.endpoint,
+        keys: { p256dh: args.p256dh, auth: args.auth },
+      },
+      JSON.stringify(args.payload),
+    );
+    return { ok: true };
+  } catch (err) {
+    const e = err as { statusCode?: number; body?: string; message?: string };
+    return {
+      ok: false,
+      statusCode: e.statusCode ?? 500,
+      message: e.body ?? e.message ?? "unknown push error",
+    };
+  }
+}
+
+/** クライアント側 subscribe() 用の public key (base64url) */
+export function webPushPublicKey(): string | null {
+  return process.env.NEXT_PUBLIC_WEB_PUSH_VAPID_PUBLIC_KEY ?? null;
+}

--- a/src/server/trpc/routers/index.ts
+++ b/src/server/trpc/routers/index.ts
@@ -6,6 +6,7 @@ import { customRouter } from "./custom";
 import { insightsRouter } from "./insights";
 import { onboardingRouter } from "./onboarding";
 import { pingRouter } from "./ping";
+import { pushRouter } from "./push";
 import { questionsRouter } from "./questions";
 import { sessionRouter } from "./session";
 import { settingsRouter } from "./settings";
@@ -18,6 +19,7 @@ export const appRouter = router({
   custom: customRouter,
   insights: insightsRouter,
   onboarding: onboardingRouter,
+  push: pushRouter,
   questions: questionsRouter,
   session: sessionRouter,
   settings: settingsRouter,

--- a/src/server/trpc/routers/push.ts
+++ b/src/server/trpc/routers/push.ts
@@ -9,7 +9,11 @@ import { protectedProcedure, router } from "../init";
 
 /** Web Push subscription 登録 / 解除 (issue #37) */
 export const pushRouter = router({
-  /** Service Worker 登録 → navigator.pushManager.subscribe() の結果を DB に upsert */
+  /** Service Worker 登録 → navigator.pushManager.subscribe() の結果を DB に upsert。
+   *  既存 endpoint が別ユーザー所有なら FORBIDDEN で弾く (乗っ取り防止、Codex Round 1 指摘 #1)。
+   *  web_push_enabled は自動で切り替えない。UI 側が明示的に setEnabled を呼ぶ
+   *  (Codex Round 1 指摘 #3: 購読と配信設定の責務分離)。
+   */
   subscribe: protectedProcedure
     .input(
       z.object({
@@ -21,7 +25,18 @@ export const pushRouter = router({
     )
     .mutation(async ({ ctx, input }) => {
       const db = getDb();
-      // endpoint UNIQUE なので onConflictDoUpdate で多端末対応 + 再登録 OK
+      const existing = await db
+        .select({ userId: pushSubscriptions.userId })
+        .from(pushSubscriptions)
+        .where(eq(pushSubscriptions.endpoint, input.endpoint))
+        .limit(1);
+      if (existing[0] && existing[0].userId !== ctx.user.id) {
+        throw new TRPCError({
+          code: "FORBIDDEN",
+          message: "別ユーザーが所有する endpoint です",
+        });
+      }
+      // 同一ユーザーが再 subscribe した or 初回: 鍵だけ upsert する。conflict 時に userId は触らない。
       await db
         .insert(pushSubscriptions)
         .values({
@@ -34,14 +49,11 @@ export const pushRouter = router({
         .onConflictDoUpdate({
           target: pushSubscriptions.endpoint,
           set: {
-            userId: ctx.user.id,
             p256dh: input.p256dh,
             auth: input.auth,
             userAgent: input.userAgent ?? null,
           },
         });
-      // 初回 subscribe で web_push_enabled も ON にしておく (opt-in 簡略化)
-      await db.update(users).set({ webPushEnabled: true }).where(eq(users.id, ctx.user.id));
       return { ok: true as const };
     }),
 

--- a/src/server/trpc/routers/push.ts
+++ b/src/server/trpc/routers/push.ts
@@ -1,0 +1,89 @@
+import { TRPCError } from "@trpc/server";
+import { and, eq } from "drizzle-orm";
+import { z } from "zod";
+
+import { getDb } from "@/db/client";
+import { pushSubscriptions, users } from "@/db/schema";
+
+import { protectedProcedure, router } from "../init";
+
+/** Web Push subscription 登録 / 解除 (issue #37) */
+export const pushRouter = router({
+  /** Service Worker 登録 → navigator.pushManager.subscribe() の結果を DB に upsert */
+  subscribe: protectedProcedure
+    .input(
+      z.object({
+        endpoint: z.string().url().min(1),
+        p256dh: z.string().min(1),
+        auth: z.string().min(1),
+        userAgent: z.string().optional(),
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      const db = getDb();
+      // endpoint UNIQUE なので onConflictDoUpdate で多端末対応 + 再登録 OK
+      await db
+        .insert(pushSubscriptions)
+        .values({
+          userId: ctx.user.id,
+          endpoint: input.endpoint,
+          p256dh: input.p256dh,
+          auth: input.auth,
+          userAgent: input.userAgent ?? null,
+        })
+        .onConflictDoUpdate({
+          target: pushSubscriptions.endpoint,
+          set: {
+            userId: ctx.user.id,
+            p256dh: input.p256dh,
+            auth: input.auth,
+            userAgent: input.userAgent ?? null,
+          },
+        });
+      // 初回 subscribe で web_push_enabled も ON にしておく (opt-in 簡略化)
+      await db.update(users).set({ webPushEnabled: true }).where(eq(users.id, ctx.user.id));
+      return { ok: true as const };
+    }),
+
+  /** 明示的な unsubscribe (endpoint 単位、設定フラグは最後の 1 件削除で OFF にする) */
+  unsubscribe: protectedProcedure
+    .input(z.object({ endpoint: z.string().url().min(1) }))
+    .mutation(async ({ ctx, input }) => {
+      const db = getDb();
+      await db
+        .delete(pushSubscriptions)
+        .where(
+          and(
+            eq(pushSubscriptions.endpoint, input.endpoint),
+            eq(pushSubscriptions.userId, ctx.user.id),
+          ),
+        );
+      const remaining = await db
+        .select({ id: pushSubscriptions.id })
+        .from(pushSubscriptions)
+        .where(eq(pushSubscriptions.userId, ctx.user.id))
+        .limit(1);
+      if (remaining.length === 0) {
+        await db.update(users).set({ webPushEnabled: false }).where(eq(users.id, ctx.user.id));
+      }
+      return { ok: true as const };
+    }),
+
+  /** Web Push 機能全体の on/off (subscription を消すわけではない、送信 gate だけ切る) */
+  setEnabled: protectedProcedure
+    .input(z.object({ enabled: z.boolean() }))
+    .mutation(async ({ ctx, input }) => {
+      await getDb()
+        .update(users)
+        .set({ webPushEnabled: input.enabled })
+        .where(eq(users.id, ctx.user.id));
+      return { ok: true as const, enabled: input.enabled };
+    }),
+
+  /** UI が public key を取得するための endpoint (client bundle に直接埋めない設計) */
+  getPublicKey: protectedProcedure.query(() => {
+    const pk = process.env.NEXT_PUBLIC_WEB_PUSH_VAPID_PUBLIC_KEY ?? null;
+    if (!pk) throw new TRPCError({ code: "NOT_IMPLEMENTED", message: "VAPID public key unset" });
+    return { publicKey: pk };
+  }),
+});

--- a/src/server/trpc/routers/settings.ts
+++ b/src/server/trpc/routers/settings.ts
@@ -7,9 +7,10 @@ import { users } from "@/db/schema";
 import { protectedProcedure, router } from "../init";
 
 export const settingsRouter = router({
-  /** 現在の設定値を返す (issue #36: 通知 on/off) */
+  /** 現在の設定値を返す (issue #36 / #37: 通知 on/off) */
   get: protectedProcedure.query(({ ctx }) => ({
     weeklyDigestEnabled: ctx.user.weeklyDigestEnabled,
+    webPushEnabled: ctx.user.webPushEnabled,
   })),
 
   /** Weekly Digest on/off (issue #36) */

--- a/vercel.json
+++ b/vercel.json
@@ -5,6 +5,10 @@
     {
       "path": "/api/cron/weekly-digest",
       "schedule": "0 0 * * 0"
+    },
+    {
+      "path": "/api/cron/daily-reminder",
+      "schedule": "0 23 * * *"
     }
   ]
 }


### PR DESCRIPTION
## Summary
issue #37 (Phase 5+) Web Push の **コード側 MVP**。VAPID 鍵認可、DB 購読保存、SW 受信ハンドラ、settings UI を実装。iOS 実機での到達率検証は本番デプロイ後の手動タスクに委譲する。

### 実装
- **deps**: `web-push` + `@types/web-push`
- **DB**: migration 0013 で `push_subscriptions` テーブル (endpoint UNIQUE) + `users.web_push_enabled` (opt-in、default=false)
- **lib**: `src/lib/push/web-push-client.ts` — `sendPushNotification` (VAPID 未設定で safe 501、410 Gone は statusCode で通知 = 呼び出し側が DB から削除する判断材料)
- **tRPC**: `push.subscribe` / `unsubscribe` / `setEnabled` / `getPublicKey`。endpoint UNIQUE で upsert、最後の 1 件削除で `webPushEnabled=false` 自動 OFF
- **SW**: `public/sw.js` に `push` / `notificationclick` リスナーを追加。既存タブ focus or `openWindow`
- **UI**: `WebPushToggle` (`/settings`) — `Notification.requestPermission()` → `pushManager.subscribe()` → `push.subscribe` のフロー。unsupported / denied / busy の 4 状態
- **env**: VAPID 関連 3 変数 + `WEB_PUSH_SUBJECT` を `.env.example` に記載、`npx web-push generate-vapid-keys` での鍵生成手順も
- **二重配信抑止**: settings UI に明記。Weekly Digest = email only / Daily reminder = push only の分離で同じ通知は 1 経路のみ

### 受け入れ基準
- [x] VAPID 鍵生成 → `.env.example` に手順記載 (実際の鍵登録は Vercel 側の手動操作)
- [x] 購読情報を DB に保存 → `push_subscriptions`
- [ ] iOS 実機 (iPhone 15 / Safari) で 1 週間の到達率 ≥ 80% → **本番デプロイ後の作者手動検証**
- [x] on/off 切替 → `/settings` の `WebPushToggle`
- [x] メールとの二重配信抑止 → チャネル分離方針を UI に明記

### Test plan
- [x] `pnpm typecheck` ✓
- [x] `pnpm test -- --run` ✓ (295/295、新規 +5: sendPushNotification 3 + webPushPublicKey 2)
- [x] `pnpm build` ✓

closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)