### PR TITLE
feat(batch): 問題事前生成バッチ (夜間 cron、#39)

### DIFF
--- a/src/app/api/cron/daily-reminder/route.ts
+++ b/src/app/api/cron/daily-reminder/route.ts
@@ -5,6 +5,7 @@ import { getDb } from "@/db/client";
 import { pushSubscriptions, users } from "@/db/schema";
 import { appUrl } from "@/lib/env";
 import { sendPushNotification } from "@/lib/push/web-push-client";
+import { verifyCronAuth } from "@/server/cron/auth";
 
 export const dynamic = "force-dynamic";
 
@@ -17,14 +18,10 @@ export const dynamic = "force-dynamic";
  * 本番で CRON_SECRET 未設定は fail-closed で 500 (Weekly Digest と同じ方針)。
  */
 export async function GET(req: Request) {
-  const cronSecret = process.env.CRON_SECRET;
-  if (!cronSecret) {
-    if (process.env.VERCEL_ENV === "production") {
-      return NextResponse.json({ error: "CRON_SECRET not configured" }, { status: 500 });
-    }
-  } else if (req.headers.get("authorization") !== `Bearer ${cronSecret}`) {
-    return NextResponse.json({ error: "unauthorized" }, { status: 401 });
-  }
+  // CRON_SECRET 認可 (src/server/cron/auth.ts に集約、Codex PR#83 Round 5 指摘 #3)。
+  // push 送信は RapidAPI 的なコスト課金対象なので preview も fail-closed 側に倒す。
+  const authFail = verifyCronAuth(req, { failClosedOn: "production-and-preview" });
+  if (authFail) return authFail;
 
   const db = getDb();
   const rows = await db

--- a/src/app/api/cron/pregenerate-questions/route.ts
+++ b/src/app/api/cron/pregenerate-questions/route.ts
@@ -14,9 +14,13 @@ export const maxDuration = 60;
  * Pro プランなら 4 時間ごと (0/4 * * *) に縮退も選択肢 (受け入れ基準の注記)。
  */
 export async function GET(req: Request) {
+  // production / preview で CRON_SECRET 未設定は fail-closed (Codex Round 3 指摘: preview も
+  // public URL なので no-auth だと外部から LLM 予算を消費されうる)。dev / ローカルのみ bypass 許可。
   const cronSecret = process.env.CRON_SECRET;
+  const requiresAuth =
+    process.env.VERCEL_ENV === "production" || process.env.VERCEL_ENV === "preview";
   if (!cronSecret) {
-    if (process.env.VERCEL_ENV === "production") {
+    if (requiresAuth) {
       return NextResponse.json({ error: "CRON_SECRET not configured" }, { status: 500 });
     }
   } else if (req.headers.get("authorization") !== `Bearer ${cronSecret}`) {

--- a/src/app/api/cron/pregenerate-questions/route.ts
+++ b/src/app/api/cron/pregenerate-questions/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from "next/server";
+
+import { runPregenerateBatch } from "@/server/batch/pregenerate";
+
+export const dynamic = "force-dynamic";
+/** LLM 呼び出しで Vercel Functions default 10s を超えるため 60s まで拡張 (Hobby 上限) */
+export const maxDuration = 60;
+
+/**
+ * 問題の事前生成バッチ cron (issue #39, docs/03 §3.3.4)。
+ * 未充足の (concept, difficulty, thinkingStyle) 組合せを補充し、出題時レイテンシを下げる。
+ *
+ * Vercel Cron 側は Hobby プランなら日次 (schedule: 18:00 UTC = 03:00 JST)。
+ * Pro プランなら 4 時間ごと (0/4 * * *) に縮退も選択肢 (受け入れ基準の注記)。
+ */
+export async function GET(req: Request) {
+  const cronSecret = process.env.CRON_SECRET;
+  if (!cronSecret) {
+    if (process.env.VERCEL_ENV === "production") {
+      return NextResponse.json({ error: "CRON_SECRET not configured" }, { status: 500 });
+    }
+  } else if (req.headers.get("authorization") !== `Bearer ${cronSecret}`) {
+    return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  }
+
+  const result = await runPregenerateBatch();
+  return NextResponse.json(result);
+}

--- a/src/app/api/cron/pregenerate-questions/route.ts
+++ b/src/app/api/cron/pregenerate-questions/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 
 import { runPregenerateBatch } from "@/server/batch/pregenerate";
+import { verifyCronAuth } from "@/server/cron/auth";
 
 export const dynamic = "force-dynamic";
 /** LLM 呼び出しで Vercel Functions default 10s を超えるため 60s まで拡張 (Hobby 上限) */
@@ -12,21 +13,13 @@ export const maxDuration = 60;
  *
  * Vercel Cron 側は Hobby プランなら日次 (schedule: 18:00 UTC = 03:00 JST)。
  * Pro プランなら 4 時間ごと (0/4 * * *) に縮退も選択肢 (受け入れ基準の注記)。
+ *
+ * 認可: production + preview で CRON_SECRET 必須 (preview も public URL で LLM 予算保護)。
+ * dev / ローカルのみ bypass 可。
  */
 export async function GET(req: Request) {
-  // production / preview で CRON_SECRET 未設定は fail-closed (Codex Round 3 指摘: preview も
-  // public URL なので no-auth だと外部から LLM 予算を消費されうる)。dev / ローカルのみ bypass 許可。
-  const cronSecret = process.env.CRON_SECRET;
-  const requiresAuth =
-    process.env.VERCEL_ENV === "production" || process.env.VERCEL_ENV === "preview";
-  if (!cronSecret) {
-    if (requiresAuth) {
-      return NextResponse.json({ error: "CRON_SECRET not configured" }, { status: 500 });
-    }
-  } else if (req.headers.get("authorization") !== `Bearer ${cronSecret}`) {
-    return NextResponse.json({ error: "unauthorized" }, { status: 401 });
-  }
-
+  const authFail = verifyCronAuth(req, { failClosedOn: "production-and-preview" });
+  if (authFail) return authFail;
   const result = await runPregenerateBatch();
   return NextResponse.json(result);
 }

--- a/src/app/api/cron/weekly-digest/route.ts
+++ b/src/app/api/cron/weekly-digest/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 
 import { getResend, resendFromEmail } from "@/lib/email/resend-client";
+import { verifyCronAuth } from "@/server/cron/auth";
 import { collectWeeklyDigestTargets, renderDigestHtml } from "@/server/digest/weekly-digest";
 
 export const dynamic = "force-dynamic";
@@ -17,17 +18,10 @@ export const dynamic = "force-dynamic";
  * 戻り値: { sent: number, skipped: number, errors: Array<{userId, error}> }
  */
 export async function GET(req: Request) {
-  // CRON_SECRET 認可。
-  // - production: 必ず設定されていないと 500 (fail-closed、Codex Round 1 指摘 C)
-  // - preview / dev: 未設定ならスキップ (ローカル動作を楽にする)
-  const cronSecret = process.env.CRON_SECRET;
-  if (!cronSecret) {
-    if (process.env.VERCEL_ENV === "production") {
-      return NextResponse.json({ error: "CRON_SECRET not configured" }, { status: 500 });
-    }
-  } else if (req.headers.get("authorization") !== `Bearer ${cronSecret}`) {
-    return NextResponse.json({ error: "unauthorized" }, { status: 401 });
-  }
+  // CRON_SECRET 認可 (src/server/cron/auth.ts に集約、Codex PR#83 Round 5 指摘 #3)。
+  // production のみ fail-closed。メール送信はコスト低なので preview も bypass 許容。
+  const authFail = verifyCronAuth(req, { failClosedOn: "production" });
+  if (authFail) return authFail;
 
   const resend = getResend();
   const from = resendFromEmail();

--- a/src/server/batch/pregenerate.test.ts
+++ b/src/server/batch/pregenerate.test.ts
@@ -1,12 +1,14 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+// mock chain: .from → .where → .groupBy → then (for query #2) or
+//             .from → then (for query #1 concepts)
 const queue: Array<() => unknown> = [];
 vi.mock("@/db/client", () => {
   function makeBuilder(): unknown {
     const b: Record<string, unknown> = {
       from: () => b,
       where: () => b,
-      limit: () => b,
+      groupBy: () => b,
       then: (onFulfilled: (v: unknown) => unknown) => {
         const handler = queue.shift();
         const result = handler ? handler() : [];
@@ -25,30 +27,39 @@ beforeEach(() => {
 });
 
 describe("findDeficitCombos", () => {
-  it("concept 0 件なら空配列", async () => {
+  it("concept 0 件なら空配列 (DB 2 回目 query は呼ばれない)", async () => {
     queue.push(() => []);
     const out = await findDeficitCombos();
     expect(out).toEqual([]);
   });
 
-  it("cache 不足の combo のみ返し、不足量降順 + 決定論順", async () => {
-    // concept 2 個、各 difficulty 1 個 → combo は (2 concepts) × (1 diff) × (3 styles) = 6
+  it("cache 不足の combo のみ返し、不足量降順 + conceptId 昇順", async () => {
+    // query #1: concepts
     queue.push(() => [
       { id: "a", difficultyLevels: ["junior"] },
       { id: "b", difficultyLevels: ["junior"] },
     ]);
-    // 各 combo の count query が順番に呼ばれる (6 combos × 1 query each)
-    // 順番: a/junior/why, a/junior/how, a/junior/trade_off, b/junior/why, b/junior/how, b/junior/trade_off
-    queue.push(() => [{ cnt: PREBATCH_TARGET_PER_COMBO }]); // a/why: OK (返さない)
-    queue.push(() => [{ cnt: 0 }]); // a/how: 不足量 5
-    queue.push(() => [{ cnt: 3 }]); // a/trade_off: 不足量 2
-    queue.push(() => [{ cnt: 1 }]); // b/why: 不足量 4
-    queue.push(() => [{ cnt: PREBATCH_TARGET_PER_COMBO + 10 }]); // b/how: OK
-    queue.push(() => [{ cnt: 0 }]); // b/trade_off: 不足量 5
+    // query #2: GROUP BY での count 集計 (見つかった combo のみ返す、無い combo は counts=0 扱い)
+    queue.push(() => [
+      // a/junior/why は 5 件で充足
+      {
+        conceptId: "a",
+        difficulty: "junior",
+        thinkingStyle: "why",
+        cnt: PREBATCH_TARGET_PER_COMBO,
+      },
+      // a/junior/trade_off は 3 件 → 不足 2
+      { conceptId: "a", difficulty: "junior", thinkingStyle: "trade_off", cnt: 3 },
+      // b/junior/why は 1 件 → 不足 4
+      { conceptId: "b", difficulty: "junior", thinkingStyle: "why", cnt: 1 },
+      // b/junior/how は 15 件で充足超え
+      { conceptId: "b", difficulty: "junior", thinkingStyle: "how", cnt: 15 },
+      // a/junior/how, b/junior/trade_off は count が返っていない = 0 件扱い (不足 5)
+    ]);
 
     const out = await findDeficitCombos();
     // 不足量降順: 5, 5, 4, 2
-    // 同値 (5) は conceptId 昇順 → a/how が先、b/trade_off が次
+    // 同値 (5) は conceptId 昇順 → a/how, b/trade_off
     expect(out.map((c) => `${c.conceptId}|${c.thinkingStyle}`)).toEqual([
       "a|how",
       "b|trade_off",
@@ -59,10 +70,26 @@ describe("findDeficitCombos", () => {
 
   it("全 combo が target 以上なら空配列", async () => {
     queue.push(() => [{ id: "a", difficultyLevels: ["junior"] }]);
-    // 3 styles 全て充足
-    queue.push(() => [{ cnt: PREBATCH_TARGET_PER_COMBO }]);
-    queue.push(() => [{ cnt: PREBATCH_TARGET_PER_COMBO + 1 }]);
-    queue.push(() => [{ cnt: PREBATCH_TARGET_PER_COMBO }]);
+    queue.push(() => [
+      {
+        conceptId: "a",
+        difficulty: "junior",
+        thinkingStyle: "why",
+        cnt: PREBATCH_TARGET_PER_COMBO,
+      },
+      {
+        conceptId: "a",
+        difficulty: "junior",
+        thinkingStyle: "how",
+        cnt: PREBATCH_TARGET_PER_COMBO + 1,
+      },
+      {
+        conceptId: "a",
+        difficulty: "junior",
+        thinkingStyle: "trade_off",
+        cnt: PREBATCH_TARGET_PER_COMBO,
+      },
+    ]);
     const out = await findDeficitCombos();
     expect(out).toEqual([]);
   });

--- a/src/server/batch/pregenerate.test.ts
+++ b/src/server/batch/pregenerate.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const queue: Array<() => unknown> = [];
+vi.mock("@/db/client", () => {
+  function makeBuilder(): unknown {
+    const b: Record<string, unknown> = {
+      from: () => b,
+      where: () => b,
+      limit: () => b,
+      then: (onFulfilled: (v: unknown) => unknown) => {
+        const handler = queue.shift();
+        const result = handler ? handler() : [];
+        return Promise.resolve(result).then(onFulfilled);
+      },
+    };
+    return b;
+  }
+  return { getDb: () => ({ select: () => makeBuilder() }) };
+});
+
+import { findDeficitCombos, PREBATCH_TARGET_PER_COMBO } from "./pregenerate";
+
+beforeEach(() => {
+  queue.length = 0;
+});
+
+describe("findDeficitCombos", () => {
+  it("concept 0 件なら空配列", async () => {
+    queue.push(() => []);
+    const out = await findDeficitCombos();
+    expect(out).toEqual([]);
+  });
+
+  it("cache 不足の combo のみ返し、不足量降順 + 決定論順", async () => {
+    // concept 2 個、各 difficulty 1 個 → combo は (2 concepts) × (1 diff) × (3 styles) = 6
+    queue.push(() => [
+      { id: "a", difficultyLevels: ["junior"] },
+      { id: "b", difficultyLevels: ["junior"] },
+    ]);
+    // 各 combo の count query が順番に呼ばれる (6 combos × 1 query each)
+    // 順番: a/junior/why, a/junior/how, a/junior/trade_off, b/junior/why, b/junior/how, b/junior/trade_off
+    queue.push(() => [{ cnt: PREBATCH_TARGET_PER_COMBO }]); // a/why: OK (返さない)
+    queue.push(() => [{ cnt: 0 }]); // a/how: 不足量 5
+    queue.push(() => [{ cnt: 3 }]); // a/trade_off: 不足量 2
+    queue.push(() => [{ cnt: 1 }]); // b/why: 不足量 4
+    queue.push(() => [{ cnt: PREBATCH_TARGET_PER_COMBO + 10 }]); // b/how: OK
+    queue.push(() => [{ cnt: 0 }]); // b/trade_off: 不足量 5
+
+    const out = await findDeficitCombos();
+    // 不足量降順: 5, 5, 4, 2
+    // 同値 (5) は conceptId 昇順 → a/how が先、b/trade_off が次
+    expect(out.map((c) => `${c.conceptId}|${c.thinkingStyle}`)).toEqual([
+      "a|how",
+      "b|trade_off",
+      "b|why",
+      "a|trade_off",
+    ]);
+  });
+
+  it("全 combo が target 以上なら空配列", async () => {
+    queue.push(() => [{ id: "a", difficultyLevels: ["junior"] }]);
+    // 3 styles 全て充足
+    queue.push(() => [{ cnt: PREBATCH_TARGET_PER_COMBO }]);
+    queue.push(() => [{ cnt: PREBATCH_TARGET_PER_COMBO + 1 }]);
+    queue.push(() => [{ cnt: PREBATCH_TARGET_PER_COMBO }]);
+    const out = await findDeficitCombos();
+    expect(out).toEqual([]);
+  });
+});

--- a/src/server/batch/pregenerate.test.ts
+++ b/src/server/batch/pregenerate.test.ts
@@ -68,6 +68,27 @@ describe("findDeficitCombos", () => {
     ]);
   });
 
+  it("tie-break: 同 conceptId / 同 difficulty なら thinkingStyle.localeCompare で how < trade_off < why", async () => {
+    queue.push(() => [{ id: "a", difficultyLevels: ["junior"] }]);
+    queue.push(() => []); // 全 combo count=0 → deficit=5 で同値
+    const out = await findDeficitCombos();
+    expect(out.map((c) => c.thinkingStyle)).toEqual(["how", "trade_off", "why"]);
+  });
+
+  it("tie-break: 同 conceptId / 同 thinkingStyle なら DIFFICULTY_LEVELS 順 (junior < mid)", async () => {
+    // concept "a" で junior / mid 両方が全 style 不足 → 6 combos 同 deficit=5
+    queue.push(() => [{ id: "a", difficultyLevels: ["mid", "junior"] }]);
+    queue.push(() => []);
+    const out = await findDeficitCombos();
+    const first3 = out.slice(0, 3);
+    const last3 = out.slice(3);
+    // DIFFICULTY_LEVELS 順: junior が mid より先
+    expect(first3.every((c) => c.difficulty === "junior")).toBe(true);
+    expect(last3.every((c) => c.difficulty === "mid")).toBe(true);
+    expect(first3.map((c) => c.thinkingStyle)).toEqual(["how", "trade_off", "why"]);
+    expect(last3.map((c) => c.thinkingStyle)).toEqual(["how", "trade_off", "why"]);
+  });
+
   it("全 combo が target 以上なら空配列", async () => {
     queue.push(() => [{ id: "a", difficultyLevels: ["junior"] }]);
     queue.push(() => [

--- a/src/server/batch/pregenerate.ts
+++ b/src/server/batch/pregenerate.ts
@@ -137,6 +137,8 @@ export async function findDeficitCombos(params?: { now?: Date }): Promise<Combo[
 export async function runPregenerateBatch(args?: {
   maxPerRun?: number;
   deadlineMs?: number;
+  /** 1 call あたりの想定実行時間 (ms)。次 call 開始前の残り時間チェックに使う */
+  expectedCallMs?: number;
   now?: () => number;
 }): Promise<PrebatchResult> {
   const maxPerRun = Math.min(Math.max(args?.maxPerRun ?? PREBATCH_MAX_PER_RUN, 0), 50);
@@ -144,6 +146,9 @@ export async function runPregenerateBatch(args?: {
   const startedAt = now();
   // maxDuration=60s の手前で自主 deadline (findDeficitCombos 等の時間分 5s バッファ)
   const deadlineMs = args?.deadlineMs ?? 55_000;
+  // gpt-5 1 call あたりの想定時間 (Codex Round 5 指摘 #1)。残り時間がこれ未満なら新規 call を
+  // 開始しない。これで deadline 直前に call 開始 → 60s 枠超過 → silent kill を回避。
+  const expectedCallMs = args?.expectedCallMs ?? 12_000;
   const combos = await findDeficitCombos();
   const plan = combos.slice(0, maxPerRun);
   let generated = 0;
@@ -151,7 +156,8 @@ export async function runPregenerateBatch(args?: {
   let skipped = 0;
   const errors: PrebatchResult["errors"] = [];
   for (let i = 0; i < plan.length; i++) {
-    if (now() - startedAt > deadlineMs) {
+    const elapsed = now() - startedAt;
+    if (elapsed + expectedCallMs > deadlineMs) {
       skipped = plan.length - i; // 残りを skipped に計上
       break;
     }

--- a/src/server/batch/pregenerate.ts
+++ b/src/server/batch/pregenerate.ts
@@ -115,7 +115,11 @@ export async function findDeficitCombos(params?: { now?: Date }): Promise<Combo[
       if (b.deficit !== a.deficit) return b.deficit - a.deficit;
       if (a.combo.conceptId !== b.combo.conceptId)
         return a.combo.conceptId.localeCompare(b.combo.conceptId);
-      return a.combo.difficulty.localeCompare(b.combo.difficulty);
+      if (a.combo.difficulty !== b.combo.difficulty)
+        return a.combo.difficulty.localeCompare(b.combo.difficulty);
+      // thinkingStyle tie-break で完全決定論 (Codex Round 3 指摘: 同 conceptId/difficulty 内の
+      // 順序が実装依存にならないようにする)
+      return (a.combo.thinkingStyle ?? "").localeCompare(b.combo.thinkingStyle ?? "");
     })
     .map((x) => x.combo);
 }

--- a/src/server/batch/pregenerate.ts
+++ b/src/server/batch/pregenerate.ts
@@ -1,6 +1,6 @@
 import "server-only";
 
-import { and, eq, sql } from "drizzle-orm";
+import { and, eq, gte, inArray, sql } from "drizzle-orm";
 
 import { getDb } from "@/db/client";
 import {
@@ -14,15 +14,22 @@ import {
 import { generateMcq } from "@/server/generator/mcq";
 
 /** 1 回の cron で生成する最大問題数。LLM コスト上限のガード (docs/03 §3.3.4)。
- *  Vercel Hobby の日次 cron だと 30 回/月 × 20 件 = 600 件/月が上限。
+ *  gpt-5 1 call ≒ 3-10s かかるため、Hobby の maxDuration=60s 枠内に安全に収まる件数に
+ *  絞る (Codex Round 1 指摘 #2)。Pro プランで maxDuration を伸ばしたら 20 以上に上げて OK。
  */
-export const PREBATCH_MAX_PER_RUN = 20;
+export const PREBATCH_MAX_PER_RUN = 8;
 
 /** combo あたり最低保ちたい cache 件数 (これ未満のところを優先的に補充) */
 export const PREBATCH_TARGET_PER_COMBO = 5;
 
 /** 未充足 combo 探索の上限 (過剰スキャンを防ぐ) */
 const PREBATCH_SCAN_LIMIT = 200;
+
+/** キャッシュ窓 (日)。`src/server/generator/cache.ts` の既定値 30 と揃える
+ *  (Codex Round 1 指摘 #3: pregen と runtime の窓が不整合だと、30 日より古い問題で
+ *  deficit=0 と誤判定されて補充されないのに runtime は cache miss で新規生成になる)。
+ */
+export const PREBATCH_CACHE_WINDOW_DAYS = 30;
 
 export type Combo = {
   conceptId: string;
@@ -35,24 +42,27 @@ export type PrebatchResult = {
   planned: number;
   generated: number;
   failed: number;
+  /** 時間切れで未実行のまま終了した件数 */
+  skipped: number;
   errors: Array<{ combo: Combo; message: string }>;
 };
 
 /** 各 combo について、現在のキャッシュ件数が PREBATCH_TARGET_PER_COMBO 未満のものを
- *  優先度順 (不足量が大きい順) に返す。retired/失敗した問題は含めない。
+ *  優先度順 (不足量が大きい順) に返す。retired=true / 30 日より古い問題は除外する。
+ *  count の取得は単一 GROUP BY クエリ (Codex Round 1 指摘 #1: N+1 回避)。
  */
 export async function findDeficitCombos(params?: { now?: Date }): Promise<Combo[]> {
-  void params;
   const db = getDb();
-  // concepts × difficulty (concept.difficultyLevels から展開) × thinkingStyle を
-  // JS 側で作って、各 combo の cache count を SQL で取る方が concept を先に絞れて楽。
+  const now = params?.now ?? new Date();
+  const since = new Date(now.getTime() - PREBATCH_CACHE_WINDOW_DAYS * 24 * 60 * 60 * 1000);
+
   const conceptRows: Pick<Concept, "id" | "difficultyLevels">[] = await db
     .select({ id: concepts.id, difficultyLevels: concepts.difficultyLevels })
     .from(concepts);
+  if (conceptRows.length === 0) return [];
 
-  // MVP: thinkingStyle は why / how / trade_off の 3 個だけ pregen (代表的なもの)。
-  // 6 個全部 × concept 数 × difficulty 数 だと combo が指数的に膨らむため、
-  // まずはよく使う 3 個に絞る。必要になれば env で広げられる。
+  // MVP: thinkingStyle は why / how / trade_off の 3 個だけ pregen。6 個全部 × concept ×
+  // difficulty だと combo が指数的に膨らむため、まずはよく使う 3 個に絞る。
   const STYLES_TO_PREGEN: ThinkingStyle[] = ["why", "how", "trade_off"];
   const combos: Combo[] = [];
   for (const c of conceptRows) {
@@ -66,32 +76,35 @@ export async function findDeficitCombos(params?: { now?: Date }): Promise<Combo[
     }
     if (combos.length >= PREBATCH_SCAN_LIMIT) break;
   }
-
-  // 各 combo の cache count を一括で取る (N+1 を避けるため UNION ALL で)。
-  // MVP で combo 数が 200 以下なら 1 クエリに収まる。
   if (combos.length === 0) return [];
+
+  // 単一 GROUP BY で関連 combo の count を一括取得。concept 範囲を絞る inArray で
+  // 不要な全スキャンを避ける。JS 側で key 化して参照する。
+  const conceptIds = Array.from(new Set(combos.map((c) => c.conceptId)));
+  const rows = await db
+    .select({
+      conceptId: questions.conceptId,
+      difficulty: questions.difficulty,
+      thinkingStyle: questions.thinkingStyle,
+      cnt: sql<number>`count(*)::int`.as("cnt"),
+    })
+    .from(questions)
+    .where(
+      and(
+        eq(questions.type, "mcq"),
+        eq(questions.retired, false),
+        gte(questions.createdAt, since),
+        inArray(questions.conceptId, conceptIds),
+      ),
+    )
+    .groupBy(questions.conceptId, questions.difficulty, questions.thinkingStyle);
+
   const counts = new Map<string, number>();
-  for (const combo of combos) {
-    const rows = await db
-      .select({ cnt: sql<number>`count(*)::int`.as("cnt") })
-      .from(questions)
-      .where(
-        and(
-          eq(questions.conceptId, combo.conceptId),
-          eq(questions.difficulty, combo.difficulty),
-          eq(questions.type, "mcq"),
-          combo.thinkingStyle
-            ? eq(questions.thinkingStyle, combo.thinkingStyle)
-            : sql`${questions.thinkingStyle} IS NULL`,
-          eq(questions.retired, false),
-        ),
-      );
-    const cnt = rows[0]?.cnt ?? 0;
-    const key = `${combo.conceptId}|${combo.difficulty}|${combo.thinkingStyle ?? "null"}`;
-    counts.set(key, cnt);
+  for (const r of rows) {
+    const key = `${r.conceptId}|${r.difficulty}|${r.thinkingStyle ?? "null"}`;
+    counts.set(key, r.cnt ?? 0);
   }
 
-  // 不足量 (TARGET - cnt) の降順で並べる。同値は decidable な順序で安定化
   return combos
     .map((c) => ({
       combo: c,
@@ -109,17 +122,33 @@ export async function findDeficitCombos(params?: { now?: Date }): Promise<Combo[
     .map((x) => x.combo);
 }
 
-/** 1 回の cron で未充足 combo を最大 PREBATCH_MAX_PER_RUN 件だけ補充。
+/** 1 回の cron で未充足 combo を最大 maxPerRun 件だけ補充。
  *  個々の失敗は errors に積むだけで次へ進む (「生成失敗時のリトライ/スキップ」)。
+ *  deadlineMs を超えたら残りを skipped としてカウントし中間結果を返す
+ *  (Vercel Functions の maxDuration 超過で silent kill されるのを防ぐ、Codex Round 1 指摘 #2)。
  */
-export async function runPregenerateBatch(args?: { maxPerRun?: number }): Promise<PrebatchResult> {
+export async function runPregenerateBatch(args?: {
+  maxPerRun?: number;
+  deadlineMs?: number;
+  now?: () => number;
+}): Promise<PrebatchResult> {
   const maxPerRun = Math.min(Math.max(args?.maxPerRun ?? PREBATCH_MAX_PER_RUN, 0), 50);
+  const now = args?.now ?? (() => Date.now());
+  const startedAt = now();
+  // maxDuration=60s の手前で自主 deadline (findDeficitCombos 等の時間分 5s バッファ)
+  const deadlineMs = args?.deadlineMs ?? 55_000;
   const combos = await findDeficitCombos();
   const plan = combos.slice(0, maxPerRun);
   let generated = 0;
   let failed = 0;
+  let skipped = 0;
   const errors: PrebatchResult["errors"] = [];
-  for (const combo of plan) {
+  for (let i = 0; i < plan.length; i++) {
+    if (now() - startedAt > deadlineMs) {
+      skipped = plan.length - i; // 残りを skipped に計上
+      break;
+    }
+    const combo = plan[i]!;
     try {
       await generateMcq(
         {
@@ -127,7 +156,6 @@ export async function runPregenerateBatch(args?: { maxPerRun?: number }): Promis
           difficulty: combo.difficulty,
           thinkingStyle: combo.thinkingStyle,
           forceFresh: true, // cache をバイパスして新規問題を DB に追加
-          // userId を渡さないので misconception 注入もされず、共有 cache 向けの純粋な問題になる
         },
         undefined,
       );
@@ -140,5 +168,5 @@ export async function runPregenerateBatch(args?: { maxPerRun?: number }): Promis
       });
     }
   }
-  return { planned: plan.length, generated, failed, errors };
+  return { planned: plan.length, generated, failed, skipped, errors };
 }

--- a/src/server/batch/pregenerate.ts
+++ b/src/server/batch/pregenerate.ts
@@ -11,6 +11,7 @@ import {
   type DifficultyLevel,
   type ThinkingStyle,
 } from "@/db/schema";
+import { CACHE_WINDOW_DAYS } from "@/server/generator/cache";
 import { generateMcq } from "@/server/generator/mcq";
 
 /** 1 回の cron で生成する最大問題数。LLM コスト上限のガード (docs/03 §3.3.4)。
@@ -25,11 +26,8 @@ export const PREBATCH_TARGET_PER_COMBO = 5;
 /** 未充足 combo 探索の上限 (過剰スキャンを防ぐ) */
 const PREBATCH_SCAN_LIMIT = 200;
 
-/** キャッシュ窓 (日)。`src/server/generator/cache.ts` の既定値 30 と揃える
- *  (Codex Round 1 指摘 #3: pregen と runtime の窓が不整合だと、30 日より古い問題で
- *  deficit=0 と誤判定されて補充されないのに runtime は cache miss で新規生成になる)。
- */
-export const PREBATCH_CACHE_WINDOW_DAYS = 30;
+// キャッシュ窓 (日) は CACHE_WINDOW_DAYS (cache.ts) を一箇所で参照する
+// (Codex Round 2 指摘: 30 の直書きをやめて単一の真実の源に一本化)。
 
 export type Combo = {
   conceptId: string;
@@ -54,7 +52,7 @@ export type PrebatchResult = {
 export async function findDeficitCombos(params?: { now?: Date }): Promise<Combo[]> {
   const db = getDb();
   const now = params?.now ?? new Date();
-  const since = new Date(now.getTime() - PREBATCH_CACHE_WINDOW_DAYS * 24 * 60 * 60 * 1000);
+  const since = new Date(now.getTime() - CACHE_WINDOW_DAYS * 24 * 60 * 60 * 1000);
 
   const conceptRows: Pick<Concept, "id" | "difficultyLevels">[] = await db
     .select({ id: concepts.id, difficultyLevels: concepts.difficultyLevels })
@@ -156,6 +154,10 @@ export async function runPregenerateBatch(args?: {
           difficulty: combo.difficulty,
           thinkingStyle: combo.thinkingStyle,
           forceFresh: true, // cache をバイパスして新規問題を DB に追加
+          // pregen は「誰にも配信されていない inventory」を積む目的。
+          // serveCount=0 / lastServedAt=null で insert し、findCachedQuestion の
+          // 「未使用を優先」順序で最優先で取り出せるようにする (Codex Round 2 指摘)。
+          markAsServed: false,
         },
         undefined,
       );

--- a/src/server/batch/pregenerate.ts
+++ b/src/server/batch/pregenerate.ts
@@ -1,0 +1,144 @@
+import "server-only";
+
+import { and, eq, sql } from "drizzle-orm";
+
+import { getDb } from "@/db/client";
+import {
+  concepts,
+  DIFFICULTY_LEVELS,
+  questions,
+  type Concept,
+  type DifficultyLevel,
+  type ThinkingStyle,
+} from "@/db/schema";
+import { generateMcq } from "@/server/generator/mcq";
+
+/** 1 回の cron で生成する最大問題数。LLM コスト上限のガード (docs/03 §3.3.4)。
+ *  Vercel Hobby の日次 cron だと 30 回/月 × 20 件 = 600 件/月が上限。
+ */
+export const PREBATCH_MAX_PER_RUN = 20;
+
+/** combo あたり最低保ちたい cache 件数 (これ未満のところを優先的に補充) */
+export const PREBATCH_TARGET_PER_COMBO = 5;
+
+/** 未充足 combo 探索の上限 (過剰スキャンを防ぐ) */
+const PREBATCH_SCAN_LIMIT = 200;
+
+export type Combo = {
+  conceptId: string;
+  difficulty: DifficultyLevel;
+  /** null は thinkingStyle 指定なし */
+  thinkingStyle: ThinkingStyle | null;
+};
+
+export type PrebatchResult = {
+  planned: number;
+  generated: number;
+  failed: number;
+  errors: Array<{ combo: Combo; message: string }>;
+};
+
+/** 各 combo について、現在のキャッシュ件数が PREBATCH_TARGET_PER_COMBO 未満のものを
+ *  優先度順 (不足量が大きい順) に返す。retired/失敗した問題は含めない。
+ */
+export async function findDeficitCombos(params?: { now?: Date }): Promise<Combo[]> {
+  void params;
+  const db = getDb();
+  // concepts × difficulty (concept.difficultyLevels から展開) × thinkingStyle を
+  // JS 側で作って、各 combo の cache count を SQL で取る方が concept を先に絞れて楽。
+  const conceptRows: Pick<Concept, "id" | "difficultyLevels">[] = await db
+    .select({ id: concepts.id, difficultyLevels: concepts.difficultyLevels })
+    .from(concepts);
+
+  // MVP: thinkingStyle は why / how / trade_off の 3 個だけ pregen (代表的なもの)。
+  // 6 個全部 × concept 数 × difficulty 数 だと combo が指数的に膨らむため、
+  // まずはよく使う 3 個に絞る。必要になれば env で広げられる。
+  const STYLES_TO_PREGEN: ThinkingStyle[] = ["why", "how", "trade_off"];
+  const combos: Combo[] = [];
+  for (const c of conceptRows) {
+    for (const d of c.difficultyLevels) {
+      if (!(DIFFICULTY_LEVELS as readonly string[]).includes(d)) continue;
+      for (const s of STYLES_TO_PREGEN) {
+        combos.push({ conceptId: c.id, difficulty: d, thinkingStyle: s });
+        if (combos.length >= PREBATCH_SCAN_LIMIT) break;
+      }
+      if (combos.length >= PREBATCH_SCAN_LIMIT) break;
+    }
+    if (combos.length >= PREBATCH_SCAN_LIMIT) break;
+  }
+
+  // 各 combo の cache count を一括で取る (N+1 を避けるため UNION ALL で)。
+  // MVP で combo 数が 200 以下なら 1 クエリに収まる。
+  if (combos.length === 0) return [];
+  const counts = new Map<string, number>();
+  for (const combo of combos) {
+    const rows = await db
+      .select({ cnt: sql<number>`count(*)::int`.as("cnt") })
+      .from(questions)
+      .where(
+        and(
+          eq(questions.conceptId, combo.conceptId),
+          eq(questions.difficulty, combo.difficulty),
+          eq(questions.type, "mcq"),
+          combo.thinkingStyle
+            ? eq(questions.thinkingStyle, combo.thinkingStyle)
+            : sql`${questions.thinkingStyle} IS NULL`,
+          eq(questions.retired, false),
+        ),
+      );
+    const cnt = rows[0]?.cnt ?? 0;
+    const key = `${combo.conceptId}|${combo.difficulty}|${combo.thinkingStyle ?? "null"}`;
+    counts.set(key, cnt);
+  }
+
+  // 不足量 (TARGET - cnt) の降順で並べる。同値は decidable な順序で安定化
+  return combos
+    .map((c) => ({
+      combo: c,
+      deficit:
+        PREBATCH_TARGET_PER_COMBO -
+        (counts.get(`${c.conceptId}|${c.difficulty}|${c.thinkingStyle ?? "null"}`) ?? 0),
+    }))
+    .filter((x) => x.deficit > 0)
+    .sort((a, b) => {
+      if (b.deficit !== a.deficit) return b.deficit - a.deficit;
+      if (a.combo.conceptId !== b.combo.conceptId)
+        return a.combo.conceptId.localeCompare(b.combo.conceptId);
+      return a.combo.difficulty.localeCompare(b.combo.difficulty);
+    })
+    .map((x) => x.combo);
+}
+
+/** 1 回の cron で未充足 combo を最大 PREBATCH_MAX_PER_RUN 件だけ補充。
+ *  個々の失敗は errors に積むだけで次へ進む (「生成失敗時のリトライ/スキップ」)。
+ */
+export async function runPregenerateBatch(args?: { maxPerRun?: number }): Promise<PrebatchResult> {
+  const maxPerRun = Math.min(Math.max(args?.maxPerRun ?? PREBATCH_MAX_PER_RUN, 0), 50);
+  const combos = await findDeficitCombos();
+  const plan = combos.slice(0, maxPerRun);
+  let generated = 0;
+  let failed = 0;
+  const errors: PrebatchResult["errors"] = [];
+  for (const combo of plan) {
+    try {
+      await generateMcq(
+        {
+          conceptId: combo.conceptId,
+          difficulty: combo.difficulty,
+          thinkingStyle: combo.thinkingStyle,
+          forceFresh: true, // cache をバイパスして新規問題を DB に追加
+          // userId を渡さないので misconception 注入もされず、共有 cache 向けの純粋な問題になる
+        },
+        undefined,
+      );
+      generated += 1;
+    } catch (err) {
+      failed += 1;
+      errors.push({
+        combo,
+        message: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+  return { planned: plan.length, generated, failed, errors };
+}

--- a/src/server/batch/pregenerate.ts
+++ b/src/server/batch/pregenerate.ts
@@ -115,10 +115,15 @@ export async function findDeficitCombos(params?: { now?: Date }): Promise<Combo[
       if (b.deficit !== a.deficit) return b.deficit - a.deficit;
       if (a.combo.conceptId !== b.combo.conceptId)
         return a.combo.conceptId.localeCompare(b.combo.conceptId);
-      if (a.combo.difficulty !== b.combo.difficulty)
-        return a.combo.difficulty.localeCompare(b.combo.difficulty);
-      // thinkingStyle tie-break で完全決定論 (Codex Round 3 指摘: 同 conceptId/difficulty 内の
-      // 順序が実装依存にならないようにする)
+      // difficulty は DIFFICULTY_LEVELS の定義順 (beginner→principal) で並べる
+      // (Codex Round 4 指摘: localeCompare だとアルファベット順で rank と乖離)。
+      if (a.combo.difficulty !== b.combo.difficulty) {
+        return (
+          (DIFFICULTY_LEVELS as readonly string[]).indexOf(a.combo.difficulty) -
+          (DIFFICULTY_LEVELS as readonly string[]).indexOf(b.combo.difficulty)
+        );
+      }
+      // thinkingStyle tie-break で完全決定論 (Codex Round 3 指摘)
       return (a.combo.thinkingStyle ?? "").localeCompare(b.combo.thinkingStyle ?? "");
     })
     .map((x) => x.combo);

--- a/src/server/cron/auth.ts
+++ b/src/server/cron/auth.ts
@@ -1,0 +1,31 @@
+import "server-only";
+
+import { NextResponse } from "next/server";
+
+/** cron endpoint の CRON_SECRET 認可共通ヘルパ (Codex PR#83 Round 5 指摘 #3)。
+ *  - 未設定: `failClosedOn` に応じて該当環境では 500 / それ以外は bypass (ローカル dev 用)
+ *  - 設定あり: `Authorization: Bearer ${CRON_SECRET}` 不一致なら 401
+ *
+ *  ok=true のとき null 相当、ng のとき NextResponse を返す。呼び出し側は null チェックで早期 return。
+ */
+export function verifyCronAuth(
+  req: Request,
+  opts: { failClosedOn: "production" | "production-and-preview" },
+): NextResponse | null {
+  const cronSecret = process.env.CRON_SECRET;
+  const vercelEnv = process.env.VERCEL_ENV;
+  const isProd = vercelEnv === "production";
+  const isPreview = vercelEnv === "preview";
+  const requiresAuth =
+    opts.failClosedOn === "production-and-preview" ? isProd || isPreview : isProd;
+  if (!cronSecret) {
+    if (requiresAuth) {
+      return NextResponse.json({ error: "CRON_SECRET not configured" }, { status: 500 });
+    }
+    return null;
+  }
+  if (req.headers.get("authorization") !== `Bearer ${cronSecret}`) {
+    return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  }
+  return null;
+}

--- a/src/server/generator/cache.ts
+++ b/src/server/generator/cache.ts
@@ -9,12 +9,16 @@ import {
   type ThinkingStyle,
 } from "@/db/schema";
 
+/** キャッシュとして有効な問題の生成年齢上限 (日)。pregen / fetchPastSummaries も
+ *  この定数を参照する (Codex Round 2 指摘: 30 を複数箇所ハードコードしていた)。 */
+export const CACHE_WINDOW_DAYS = 30;
+
 export type CacheLookupInput = {
   conceptId: string;
   type: QuestionType;
   thinkingStyle: ThinkingStyle | null;
   difficulty: DifficultyLevel;
-  /** 直近 N 日 (default 30) の生成済みから返す */
+  /** 直近 N 日 (default CACHE_WINDOW_DAYS) の生成済みから返す */
   recentDays?: number;
 };
 
@@ -28,7 +32,7 @@ export async function findCachedQuestion(
   db: Db,
   input: CacheLookupInput,
 ): Promise<Question | null> {
-  const windowDays = input.recentDays ?? 30;
+  const windowDays = input.recentDays ?? CACHE_WINDOW_DAYS;
   const since = new Date(Date.now() - windowDays * 24 * 60 * 60 * 1000);
 
   const predicates = [

--- a/src/server/generator/mcq.ts
+++ b/src/server/generator/mcq.ts
@@ -15,7 +15,7 @@ import { MODEL_MAIN } from "@/lib/openai/models";
 
 import { fetchUnresolvedMisconceptionsForGeneration } from "../grader/extract-misconception";
 
-import { findCachedQuestion } from "./cache";
+import { CACHE_WINDOW_DAYS, findCachedQuestion } from "./cache";
 import { buildMcqPrompt, MCQ_PROMPT_VERSION } from "./prompts";
 import { GeneratedMcqSchema, MCQ_JSON_SCHEMA, type GeneratedMcq } from "./schema";
 
@@ -30,6 +30,14 @@ export type GenerateMcqInput = {
    * 注入する (issue #19, docs/03 §3.4.1)。未指定なら注入しない。
    */
   userId?: string;
+  /**
+   * 生成した問題を「配信済み」としてマークするか (default: true)。
+   * 通常 request path では出題と同時に insert するので true (serveCount=1, lastServedAt=now)。
+   * pregen path (issue #39) では insert だけ先に行いユーザーにはまだ配信していないので
+   * false を渡す。false なら serveCount=0, lastServedAt=null で「untouched inventory」扱いになり
+   * findCachedQuestion の「未使用を優先」ソートで最優先になる (Codex Round 2 指摘)。
+   */
+  markAsServed?: boolean;
 };
 
 export type GenerateMcqResult = {
@@ -39,7 +47,7 @@ export type GenerateMcqResult = {
 
 /** 直近 30 日の出題要約文 (prompt の重複回避ヒント用、retired を除外して新しい順) */
 async function fetchPastSummaries(conceptId: string, max = 5): Promise<string[]> {
-  const since = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+  const since = new Date(Date.now() - CACHE_WINDOW_DAYS * 24 * 60 * 60 * 1000);
   const rows = await getDb()
     .select({ prompt: questions.prompt })
     .from(questions)
@@ -90,7 +98,7 @@ async function countCachedQuestions(params: {
   difficulty: DifficultyLevel;
   thinkingStyle: ThinkingStyle | null;
 }): Promise<number> {
-  const since = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+  const since = new Date(Date.now() - CACHE_WINDOW_DAYS * 24 * 60 * 60 * 1000);
   const db = getDb();
   const predicates = [
     eq(questions.conceptId, params.conceptId),
@@ -206,6 +214,10 @@ export async function generateMcq(
   const generated = await llm({ model: MODEL_MAIN, system, user });
 
   const now = new Date();
+  // markAsServed の default は「request path 経由で直ちに配信される前提」の true。
+  // pregen (issue #39) は false を渡して untouched inventory として残し、findCachedQuestion
+  // の「last_served_at IS NULL DESC」で最優先される状態にする。
+  const markAsServed = input.markAsServed ?? true;
   const [inserted] = await db
     .insert(questions)
     .values({
@@ -221,12 +233,12 @@ export async function generateMcq(
       tags: generated.tags,
       generatedBy: MODEL_MAIN,
       promptVersion: MCQ_PROMPT_VERSION,
-      // 新規問題は出題時点で配信済みとマークする (次回は別問題が未使用として優先される)。
+      // 配信済みなら serveCount=1 / lastServedAt=now、untouched ストックなら 0 / null。
       // 誤概念矯正モード (user-specific な prompt で生成された問題) は共有キャッシュを
       // 汚染しないよう retired=true で保存し、cache 検索対象から除外する
       // (Codex Round 2 P1-b)。
-      serveCount: 1,
-      lastServedAt: now,
+      serveCount: markAsServed ? 1 : 0,
+      lastServedAt: markAsServed ? now : null,
       retired: correctiveMode,
       retiredReason: correctiveMode ? "corrective (user-specific misconception)" : null,
     })

--- a/vercel.json
+++ b/vercel.json
@@ -9,6 +9,10 @@
     {
       "path": "/api/cron/daily-reminder",
       "schedule": "0 23 * * *"
+    },
+    {
+      "path": "/api/cron/pregenerate-questions",
+      "schedule": "0 18 * * *"
     }
   ]
 }


### PR DESCRIPTION
## Summary
issue #39 (Phase 5+) 問題事前生成バッチ。Vercel Cron で未充足の (concept × difficulty × thinkingStyle) combo を夜間に補充し、出題時のレイテンシを下げる。

### 実装
- `src/server/batch/pregenerate.ts` — `findDeficitCombos` (不足量降順 + id/difficulty 昇順の決定論) / `runPregenerateBatch` (generateMcq({forceFresh:true}) を max 20 件、失敗は errors に積んでスキップ)。`PREBATCH_TARGET_PER_COMBO=5` (combo あたり最低 5 件) / `PREBATCH_MAX_PER_RUN=20` で月次コストを Hobby 日次 = 600 件/月に上限化。thinkingStyle は `why/how/trade_off` の 3 つに絞って combo 爆発防止
- `/api/cron/pregenerate-questions` route — CRON_SECRET fail-closed (production 未設定で 500)、`maxDuration=60` で LLM 呼び出しに対応
- `vercel.json`: crons に 18:00 UTC = 03:00 JST を追加

### 受け入れ基準
- [x] Vercel Cron (Hobby プランで日次に縮退、Pro 移行時は `0 */4 * * *` に差し替え可能と明記)
- [x] 1 バッチあたりの最大生成数 + 月間予算の上限 (`PREBATCH_MAX_PER_RUN=20` × 30 runs/month = 600 件/月)
- [x] 生成失敗時のリトライ/スキップ (errors 配列に積んで次の combo へ、次回 cron で再試行相当)

### Test plan
- [x] `pnpm typecheck` ✓
- [x] `pnpm test -- --run` ✓ (298/298、新規 +3: `findDeficitCombos` の 0 concept / 不足量降順 / 全充足空配列)
- [x] `pnpm build` ✓

closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)