### PR TITLE
feat(home): トップページから各機能への導線を追加 (#77)

### DIFF
--- a/src/app/(app)/deep/[domain]/page.tsx
+++ b/src/app/(app)/deep/[domain]/page.tsx
@@ -10,7 +10,13 @@ function isDomainId(v: string): v is DomainId {
   return (DOMAIN_IDS as readonly string[]).includes(v);
 }
 
-export default async function DeepDivePage({ params }: { params: Promise<{ domain: string }> }) {
+export default async function DeepDivePage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ domain: string }>;
+  searchParams?: Promise<{ returnTo?: string | string[] }>;
+}) {
   // auth 判定と /login redirect は (app)/layout.tsx で既に済んでいる。ここでは
   // onboarding 未完了の追加チェックだけを行う (React.cache で DB round-trip は layout と
   // 合算しても 1 回)。
@@ -20,9 +26,11 @@ export default async function DeepDivePage({ params }: { params: Promise<{ domai
   const { domain } = await params;
   if (!isDomainId(domain)) notFound();
 
+  const sp = await searchParams;
+  const rawReturnTo = Array.isArray(sp?.returnTo) ? sp?.returnTo[0] : sp?.returnTo;
   return (
     <main className="flex min-h-screen flex-col items-center justify-center gap-6 p-6">
-      <DeepDiveScreen domainId={domain} />
+      <DeepDiveScreen domainId={domain} returnTo={rawReturnTo} />
     </main>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -12,7 +12,7 @@ export default async function Home() {
     redirect("/onboarding");
   }
   return (
-    <main className="flex min-h-screen flex-col items-center justify-center gap-6 p-8">
+    <main className="flex min-h-screen flex-col items-center gap-6 p-6 sm:p-8">
       <HomeScreen
         initialUser={
           initialUser

--- a/src/features/deep-dive/deep-dive-screen.tsx
+++ b/src/features/deep-dive/deep-dive-screen.tsx
@@ -16,28 +16,13 @@ import {
 import type { DomainId } from "@/db/schema";
 import { DrillScreen } from "@/features/drill/drill-screen";
 import { useDrillStore } from "@/features/drill/drill-state";
+import { DOMAIN_LABELS } from "@/lib/domain-labels";
 import { trpc } from "@/lib/trpc/react";
 
 type Phase =
   | { kind: "idle" }
   | { kind: "running"; sessionId: string }
   | { kind: "error"; message: string };
-
-const DOMAIN_LABELS: Record<DomainId, string> = {
-  programming: "Programming",
-  dsa: "DSA",
-  os: "OS",
-  network: "Network",
-  db: "Database",
-  security: "Security",
-  distributed: "Distributed",
-  design: "Design",
-  devops: "DevOps",
-  tools: "Tools",
-  low_level: "Low-level",
-  ai_ml: "AI / ML",
-  frontend: "Frontend",
-};
 
 /**
  * Deep Dive セッション画面 (issue #28)。

--- a/src/features/deep-dive/deep-dive-screen.tsx
+++ b/src/features/deep-dive/deep-dive-screen.tsx
@@ -35,7 +35,15 @@ type Phase =
  *   - running: DrillScreen を skipInitialStartCard で埋め込み
  *   - 完了後「ホームに戻る」で /insights に遷移 (元の導線 Weakest カードに戻る想定)
  */
-export function DeepDiveScreen({ domainId }: { domainId: DomainId }) {
+/** 完了後の戻り先。Home 発 (default) は `/`、Insights の Weakest カード発は `?returnTo=/insights`。
+ *  外部 URL 混入を避けるため、prop として許可する値は `/` で始まる内部 path のみ。 */
+function normalizeReturnTo(raw: string | undefined): string {
+  if (!raw) return "/";
+  return raw.startsWith("/") && !raw.startsWith("//") ? raw : "/";
+}
+
+export function DeepDiveScreen({ domainId, returnTo }: { domainId: DomainId; returnTo?: string }) {
+  const safeReturnTo = normalizeReturnTo(returnTo);
   const router = useRouter();
   const [phase, setPhase] = useState<Phase>({ kind: "idle" });
   const startSession = trpc.session.start.useMutation();
@@ -62,8 +70,9 @@ export function DeepDiveScreen({ domainId }: { domainId: DomainId }) {
     return (
       <DrillScreen
         onReset={() => {
-          // 完了後は Insights (元の導線 Weakest カードの画面) に戻す
-          router.push("/insights");
+          // 完了後の戻り先は呼び出し側が決める (default は Home の `/`)。
+          // Insights の Weakest カード発は `?returnTo=/insights` を付けて従来挙動を維持。
+          router.push(safeReturnTo);
         }}
         skipInitialStartCard
       />

--- a/src/features/home/home-screen.tsx
+++ b/src/features/home/home-screen.tsx
@@ -14,8 +14,9 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
-import { TIER_1_DOMAIN_IDS, type Tier1DomainId } from "@/db/schema";
+import { TIER_1_DOMAIN_IDS } from "@/db/schema";
 import { OfflineDrainer } from "@/features/offline/offline-drainer";
+import { DOMAIN_LABELS } from "@/lib/domain-labels";
 import { trpc } from "@/lib/trpc/react";
 
 export type InitialHomeUser = {
@@ -24,19 +25,6 @@ export type InitialHomeUser = {
   displayName: string | null;
   dailyGoal: number;
 } | null;
-
-/** Deep Dive 一覧で表示する Tier 1 6 ドメインのラベル。
- *  DOMAIN_LABELS (deep-dive-screen.tsx) と重複しないよう、Tier 1 のみをここに絞る。
- *  Tier 2+ は onboarding でまだ選べず、ホームから直接導線する必要もないため除外。
- */
-const TIER_1_LABELS: Record<Tier1DomainId, string> = {
-  programming: "Programming",
-  dsa: "DSA",
-  network: "Network",
-  db: "Database",
-  tools: "Tools",
-  frontend: "Frontend",
-};
 
 function NavCard({
   href,
@@ -151,7 +139,7 @@ export function HomeScreen({ initialUser }: { initialUser: InitialHomeUser }) {
 
         <section className="space-y-2">
           <h2 className="text-lg font-semibold">学習を始める</h2>
-          <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+          <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
             <NavCard href="/drill" title="Daily Drill" description="今日の目標まで 1 問ずつ" />
             <NavCard href="/review" title="Mistake Review" description="間違えた問題を再挑戦" />
             <NavCard href="/custom" title="Custom Session" description="自然文で狙い撃ち出題" />
@@ -182,7 +170,7 @@ export function HomeScreen({ initialUser }: { initialUser: InitialHomeUser }) {
               <NavCard
                 key={d}
                 href={`/deep/${d}`}
-                title={TIER_1_LABELS[d]}
+                title={DOMAIN_LABELS[d]}
                 description="集中出題"
               />
             ))}

--- a/src/features/home/home-screen.tsx
+++ b/src/features/home/home-screen.tsx
@@ -72,10 +72,11 @@ export function HomeScreen({ initialUser }: { initialUser: InitialHomeUser }) {
     }
   }
 
-  // tRPC / DB 障害と「ログアウト済み」を UI 上でも区別する
+  // tRPC / DB 障害と「ログアウト済み」を UI 上でも区別する。`my-auto` は flex-col の
+  // 親 (page.tsx の main) で縦方向に中央寄せする (Codex PR#85 Round 3 指摘 #1)。
   if (me.isError) {
     return (
-      <Card className="w-full max-w-md">
+      <Card className="my-auto w-full max-w-md">
         <CardHeader>
           <CardTitle>読み込みに失敗しました</CardTitle>
           <CardDescription>tRPC / DB に到達できませんでした。</CardDescription>
@@ -95,7 +96,7 @@ export function HomeScreen({ initialUser }: { initialUser: InitialHomeUser }) {
 
   if (!me.data || !me.data.authenticated) {
     return (
-      <Card className="w-full max-w-md">
+      <Card className="my-auto w-full max-w-md">
         <CardHeader>
           <CardTitle className="flex items-center gap-2">
             <Sparkles className="h-5 w-5" /> Tanren

--- a/src/features/home/home-screen.tsx
+++ b/src/features/home/home-screen.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { LogOut, RefreshCw, Sparkles } from "lucide-react";
+import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 
@@ -13,6 +14,7 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import { TIER_1_DOMAIN_IDS, type Tier1DomainId } from "@/db/schema";
 import { OfflineDrainer } from "@/features/offline/offline-drainer";
 import { trpc } from "@/lib/trpc/react";
 
@@ -22,6 +24,43 @@ export type InitialHomeUser = {
   displayName: string | null;
   dailyGoal: number;
 } | null;
+
+/** Deep Dive 一覧で表示する Tier 1 6 ドメインのラベル。
+ *  DOMAIN_LABELS (deep-dive-screen.tsx) と重複しないよう、Tier 1 のみをここに絞る。
+ *  Tier 2+ は onboarding でまだ選べず、ホームから直接導線する必要もないため除外。
+ */
+const TIER_1_LABELS: Record<Tier1DomainId, string> = {
+  programming: "Programming",
+  dsa: "DSA",
+  network: "Network",
+  db: "Database",
+  tools: "Tools",
+  frontend: "Frontend",
+};
+
+function NavCard({
+  href,
+  title,
+  description,
+}: {
+  href: string;
+  title: string;
+  description: string;
+}) {
+  return (
+    <Link
+      href={href}
+      className="focus-visible:ring-ring rounded-md focus:outline-none focus-visible:ring-2"
+    >
+      <Card className="hover:bg-accent/50 h-full transition-colors">
+        <CardHeader className="p-4">
+          <CardTitle className="text-base">{title}</CardTitle>
+          <CardDescription className="text-xs">{description}</CardDescription>
+        </CardHeader>
+      </Card>
+    </Link>
+  );
+}
 
 export function HomeScreen({ initialUser }: { initialUser: InitialHomeUser }) {
   const router = useRouter();
@@ -91,30 +130,65 @@ export function HomeScreen({ initialUser }: { initialUser: InitialHomeUser }) {
   return (
     <>
       {/* OfflineDrainer を authenticated エントリ画面で mount する。root layout に置くと
-          /login など公開ルートでも auth 解決の責務が発生するため (Codex Round 4 指摘 #3)、
-          既に user を知っている HomeScreen 内に閉じる。follow-up で enqueue caller を
-          drill-screen に配線する際に drainer の置き場所も見直す予定。 */}
+          /login など公開ルートでも auth 解決の責務が発生するため (Codex PR #84 Round 4)、
+          既に user を知っている HomeScreen 内に閉じる。 */}
       <OfflineDrainer userId={user.id} />
-      <Card className="w-full max-w-md">
-        <CardHeader>
-          <CardTitle>ようこそ、{user.displayName ?? user.email}</CardTitle>
-          <CardDescription>{user.email}</CardDescription>
-        </CardHeader>
-        <CardContent className="space-y-2 text-sm">
-          <div>
-            1日の目標: <span className="font-medium">{user.dailyGoal} 問</span>
+      <div className="w-full max-w-4xl space-y-6">
+        <header className="flex items-start justify-between gap-2">
+          <div className="min-w-0">
+            <h1 className="truncate text-2xl font-semibold">
+              ようこそ、{user.displayName ?? user.email}
+            </h1>
+            <p className="text-muted-foreground text-sm">
+              1日の目標: <span className="font-medium">{user.dailyGoal} 問</span>
+            </p>
           </div>
-          <div className="text-muted-foreground">
-            Phase 0 bootstrap。Drill / Insights は別 issue で接続予定。
-          </div>
-        </CardContent>
-        <CardFooter>
-          <Button variant="outline" onClick={handleLogout} disabled={loggingOut}>
+          <Button variant="outline" size="sm" onClick={handleLogout} disabled={loggingOut}>
             <LogOut className="mr-1 h-4 w-4" />
             {loggingOut ? "ログアウト中…" : "ログアウト"}
           </Button>
-        </CardFooter>
-      </Card>
+        </header>
+
+        <section className="space-y-2">
+          <h2 className="text-lg font-semibold">学習を始める</h2>
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+            <NavCard href="/drill" title="Daily Drill" description="今日の目標まで 1 問ずつ" />
+            <NavCard href="/review" title="Mistake Review" description="間違えた問題を再挑戦" />
+            <NavCard href="/custom" title="Custom Session" description="自然文で狙い撃ち出題" />
+          </div>
+        </section>
+
+        <section className="space-y-2">
+          <h2 className="text-lg font-semibold">Insights</h2>
+          <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
+            <NavCard href="/insights" title="Dashboard" description="概要と最新サマリ" />
+            <NavCard href="/insights/history" title="History" description="過去セッション一覧" />
+            <NavCard href="/insights/search" title="Search" description="全文検索" />
+            <NavCard href="/insights/map" title="Mastery Map" description="習熟度を可視化" />
+            <NavCard href="/insights/trends" title="Trends" description="推移を追う" />
+            <NavCard
+              href="/insights/misconceptions"
+              title="Misconceptions"
+              description="誤概念を整理"
+            />
+          </div>
+        </section>
+
+        <section className="space-y-2">
+          <h2 className="text-lg font-semibold">Deep Dive</h2>
+          <p className="text-muted-foreground text-xs">1 ドメインに集中して 10-15 問</p>
+          <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
+            {TIER_1_DOMAIN_IDS.map((d) => (
+              <NavCard
+                key={d}
+                href={`/deep/${d}`}
+                title={TIER_1_LABELS[d]}
+                description="集中出題"
+              />
+            ))}
+          </div>
+        </section>
+      </div>
     </>
   );
 }

--- a/src/features/insights/overview-screen.tsx
+++ b/src/features/insights/overview-screen.tsx
@@ -42,7 +42,9 @@ function ItemRow({
   // /custom?conceptId=... に直接 conceptId を渡し、parser を迂回して customSpec.concepts を
   // 決定論的に固定する (Round 3 指摘 #1: 自然言語 prefill では別 concept に解釈されうる)。
   const customHref = `/custom?conceptId=${encodeURIComponent(item.conceptId)}`;
-  const deepHref = `/deep/${encodeURIComponent(item.domainId)}`;
+  // Insights 発の Deep Dive は完了後 /insights に戻して Weakest カードの更新を見せたい。
+  // Home 発 (/ default) とは別挙動なので `?returnTo=/insights` を明示付与。
+  const deepHref = `/deep/${encodeURIComponent(item.domainId)}?returnTo=%2Finsights`;
   return (
     <li className="border-border rounded-md border p-2 text-sm">
       <div className="flex items-baseline justify-between gap-2">

--- a/src/features/onboarding/onboarding-screen.tsx
+++ b/src/features/onboarding/onboarding-screen.tsx
@@ -13,10 +13,11 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
-import { cn } from "@/lib/cn";
-import { TIER_1_DOMAIN_IDS, type DomainId, type Tier1DomainId } from "@/db/schema";
+import { TIER_1_DOMAIN_IDS, type Tier1DomainId } from "@/db/schema";
 import { DrillScreen } from "@/features/drill/drill-screen";
 import { useDrillStore } from "@/features/drill/drill-state";
+import { cn } from "@/lib/cn";
+import { DOMAIN_LABELS } from "@/lib/domain-labels";
 import { trpc } from "@/lib/trpc/react";
 
 type Step =
@@ -42,22 +43,6 @@ const WELCOME_SLIDES: Array<{ icon: typeof Brain; title: string; body: string }>
     body: "次の数問で出発点を測ります。3〜5 分で終わります。",
   },
 ];
-
-const TIER_1_LABELS: Record<DomainId, string> = {
-  programming: "Programming",
-  dsa: "DSA",
-  os: "OS",
-  network: "Network",
-  db: "Database",
-  security: "Security",
-  distributed: "Distributed",
-  design: "Design",
-  devops: "DevOps",
-  tools: "Tools",
-  low_level: "Low-level",
-  ai_ml: "AI / ML",
-  frontend: "Frontend",
-};
 
 type SelfLevel = "beginner" | "junior" | "mid" | "senior";
 
@@ -208,7 +193,7 @@ export function OnboardingScreen() {
                         : "border-border hover:border-muted-foreground",
                     )}
                   >
-                    {TIER_1_LABELS[d]}
+                    {DOMAIN_LABELS[d]}
                   </button>
                 );
               })}

--- a/src/lib/domain-labels.ts
+++ b/src/lib/domain-labels.ts
@@ -1,0 +1,20 @@
+import type { DomainId } from "@/db/schema";
+
+/** UI 上で 13 ドメインを表示するときの英語ラベル。docs/02-learning-system.md §2.1.1 の
+ *  ドメイン名に合わせる。Home / Deep Dive / Onboarding から同じ import で参照する
+ *  (Codex PR#85 Round 1 指摘 #2: 以前は 2 ファイルに似たような Record が散らばっていた)。 */
+export const DOMAIN_LABELS: Record<DomainId, string> = {
+  programming: "Programming",
+  dsa: "DSA",
+  os: "OS",
+  network: "Network",
+  db: "Database",
+  security: "Security",
+  distributed: "Distributed",
+  design: "Design",
+  devops: "DevOps",
+  tools: "Tools",
+  low_level: "Low-level",
+  ai_ml: "AI / ML",
+  frontend: "Frontend",
+};


### PR DESCRIPTION
## Summary
issue #77 対応。HomeScreen の Phase 0 プレースホルダを削除し、実装済みの各機能 (`#17`〜`#39`) への導線を追加。

### 実装
- `src/features/home/home-screen.tsx` を Phase 0 bootstrap 文言から機能ナビゲーション UI に置き換え。
- 3 セクションの NavCard grid:
  - **学習を始める**: `/drill`, `/review`, `/custom`
  - **Insights**: `/insights` (Dashboard), `/insights/history`, `/insights/search`, `/insights/map`, `/insights/trends`, `/insights/misconceptions`
  - **Deep Dive**: Tier 1 6 ドメイン (`programming` / `dsa` / `network` / `db` / `tools` / `frontend`) を `/deep/[domain]` リンクとして並べる (Tier 2+ は onboarding 未解放のため除外、CLAUDE.md §3 MVP スコープ遵守)
- モバイル `grid-cols-2` / タブレット以上 `sm:grid-cols-3` のレスポンシブ。
- 未ログイン・エラー時の UI は従来通り (Passkey ログイン誘導 / 再試行カード)。
- `onboardingCompletedAt` 未完了時の `/onboarding` redirect は `src/app/page.tsx` 側で既存実装、維持。

### 受け入れ基準
- [x] Phase 0 bootstrap プレースホルダ文言を削除
- [x] Daily Drill 導線
- [x] Mistake Review 導線
- [x] Custom Session 導線
- [x] Insights Dashboard 導線 (+ history / search / map / trends / misconceptions)
- [x] Deep Dive 導線 (Tier 1 6 ドメイン)
- [x] モバイル崩れ無し (grid-cols-2 / sm:grid-cols-3)
- [x] onboarding 未完了 redirect は維持

### Test plan
- [x] \`pnpm typecheck\` ✓
- [x] \`pnpm test -- --run\` ✓ (300/300)
- [x] \`pnpm build\` ✓

closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)